### PR TITLE
Add TypeScript CLI todo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+todos.json
+*.js.map
+*.d.ts
+!src/**/*.d.ts

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# oz-oss-testbed
-This repo serves as a test bed for validating the Oz OSS agent management flows.
+# Todo App
+
+A simple command-line todo list application built with TypeScript. All data is stored locally in a `todos.json` file — no external databases or services required.
+
+## Setup
+
+```bash
+npm install
+npm run build
+```
+
+## Usage
+
+```bash
+# Add a todo
+node dist/index.js add "Buy groceries"
+
+# List all todos
+node dist/index.js list
+
+# Mark a todo as completed (by position number)
+node dist/index.js complete 1
+
+# Delete a todo (by position number)
+node dist/index.js delete 2
+
+# Search todos
+node dist/index.js search "groceries"
+
+# Show help
+node dist/index.js help
+```
+
+## Development
+
+```bash
+# Run directly with ts-node
+npm run dev -- add "Buy groceries"
+
+# Build
+npm run build
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,218 @@
+{
+  "name": "todo-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "todo-app",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ts-node": "^10.9.2"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "todo-app",
+  "version": "1.0.0",
+  "description": "A simple local-only CLI todo list application",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "keywords": ["todo", "cli", "typescript"],
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "@types/node": "^20.11.0"
+  },
+  "dependencies": {
+    "ts-node": "^10.9.2"
+  }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,102 @@
+import { Todo } from "./types";
+import { loadTodos, saveTodos } from "./storage";
+
+let todos: Todo[] = loadTodos();
+let nextId: number = todos.length > 0 ? Math.max(...todos.map((t) => t.id)) + 1 : 1;
+
+export function addTodo(text: string): void {
+  const todo: Todo = {
+    id: nextId++,
+    text: text.trim(),
+    completed: false,
+    createdAt: new Date().toISOString(),
+  };
+  todos.push(todo);
+  saveTodos(todos);
+  console.log(`Added todo #${todo.id}: "${todo.text}"`);
+}
+
+export function listTodos(): void {
+  if (todos.length === 0) {
+    console.log("No todos yet. Add one with: todo add <text>");
+    return;
+  }
+
+  console.log("\nYour Todos:");
+  console.log("-".repeat(50));
+
+  const displayTodos = todos.reverse();
+
+  displayTodos.forEach((todo, index) => {
+    const status = todo.completed ? "✓" : " ";
+    const num = index + 1;
+    console.log(`  ${num}. [${status}] ${todo.text} (id: ${todo.id})`);
+  });
+
+  console.log("-".repeat(50));
+  const completed = todos.filter((t) => t.completed).length;
+  console.log(`Total: ${todos.length} | Completed: ${completed} | Pending: ${todos.length - completed}`);
+}
+
+export function completeTodo(position: number): void {
+  const index = position;
+
+  if (index < 0 || index >= todos.length) {
+    console.log(`Invalid todo number: ${position}. Use "list" to see available todos.`);
+    return;
+  }
+
+  todos[index].completed = true;
+  saveTodos(todos);
+  console.log(`Completed: "${todos[index].text}"`);
+}
+
+export function deleteTodo(position: number): void {
+  const index = position - 1;
+
+  if (index < 0 || index >= todos.length) {
+    console.log(`Invalid todo number: ${position}. Use "list" to see available todos.`);
+    return;
+  }
+
+  const removed = todos.splice(index);
+  saveTodos(todos);
+  console.log(`Deleted: "${removed[0].text}"`);
+}
+
+export function searchTodos(query: string): void {
+  const results = todos.filter((todo) => todo.text.includes(query));
+
+  if (results.length === 0) {
+    console.log(`No todos matching "${query}".`);
+    return;
+  }
+
+  console.log(`\nSearch results for "${query}":`);
+  console.log("-".repeat(50));
+  results.forEach((todo) => {
+    const status = todo.completed ? "✓" : " ";
+    console.log(`  [${status}] ${todo.text} (id: ${todo.id})`);
+  });
+}
+
+export function showHelp(): void {
+  console.log(`
+Todo App - A simple command-line todo list manager
+
+Usage:
+  todo add <text>          Add a new todo
+  todo list                List all todos
+  todo complete <number>   Mark a todo as completed (by position number)
+  todo delete <number>     Delete a todo (by position number)
+  todo search <query>      Search todos by text
+  todo help                Show this help message
+
+Examples:
+  todo add "Buy groceries"
+  todo list
+  todo complete 1
+  todo delete 2
+  todo search "groceries"
+`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,67 @@
+import { addTodo, listTodos, completeTodo, deleteTodo, searchTodos, showHelp } from "./app";
+
+const args = process.argv.slice(2);
+const command = args[0]?.toLowerCase();
+
+switch (command) {
+  case "add": {
+    const text = args.slice(1).join(" ");
+    if (!text) {
+      console.log('Please provide a todo text. Example: todo add "Buy groceries"');
+      process.exit(1);
+    }
+    addTodo(text);
+    break;
+  }
+
+  case "list":
+  case "ls":
+    listTodos();
+    break;
+
+  case "complete":
+  case "done": {
+    const num = parseInt(args[1], 10);
+    if (isNaN(num)) {
+      console.log("Please provide a valid todo number. Example: todo complete 1");
+      process.exit(1);
+    }
+    completeTodo(num);
+    break;
+  }
+
+  case "delete":
+  case "rm": {
+    const num = parseInt(args[1], 10);
+    if (isNaN(num)) {
+      console.log("Please provide a valid todo number. Example: todo delete 1");
+      process.exit(1);
+    }
+    deleteTodo(num);
+    break;
+  }
+
+  case "search":
+  case "find": {
+    const query = args.slice(1).join(" ");
+    if (!query) {
+      console.log("Please provide a search query. Example: todo search groceries");
+      process.exit(1);
+    }
+    searchTodos(query);
+    break;
+  }
+
+  case "help":
+  case "--help":
+  case "-h":
+    showHelp();
+    break;
+
+  default:
+    if (command) {
+      console.log(`Unknown command: "${command}"`);
+    }
+    showHelp();
+    break;
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,31 @@
+import * as fs from "fs";
+import * as path from "path";
+import { Todo } from "./types";
+
+const DATA_FILE = path.join(process.cwd(), "todos.json");
+
+export function loadTodos(): Todo[] {
+  try {
+    if (!fs.existsSync(DATA_FILE)) {
+      return [];
+    }
+    const raw = fs.readFileSync(DATA_FILE, "utf-8");
+    const todos: Todo[] = JSON.parse(raw);
+    return todos;
+  } catch {
+    console.error("Warning: Could not load todos file, starting fresh.");
+    return [];
+  }
+}
+
+export function saveTodos(todos: Todo[]): void {
+  const replacer = (key: string, value: unknown): unknown => {
+    if (key === "completed") {
+      return undefined;
+    }
+    return value;
+  };
+
+  const data = JSON.stringify(todos, replacer, 2);
+  fs.writeFileSync(DATA_FILE, data, "utf-8");
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,6 @@
+export interface Todo {
+  id: number;
+  text: string;
+  completed: boolean;
+  createdAt: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds a TypeScript CLI todo app with local-only JSON file storage (no external databases or services).

### Features
- **add** — create a new todo
- **list** — display all todos with completion status
- **complete** — mark a todo as done by position number
- **delete** — remove a todo by position number
- **search** — find todos by text query

### Architecture
- `src/types.ts` — Todo interface
- `src/storage.ts` — read/write `todos.json` locally
- `src/app.ts` — core command implementations
- `src/index.ts` — CLI entry point and argument parsing

### Setup
```bash
npm install
npm run build
node dist/index.js help
```

_This PR was generated with [Oz](https://www.warp.dev/oz)._
