### PR TITLE
feat: add edit, priority, due date, filter, overdue, and clear commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ node dist/index.js complete 1
 # Delete a todo (by position number)
 node dist/index.js delete 2
 
+# Edit a todo's text
+node dist/index.js edit 1 "Buy organic groceries"
+
+# Set priority (high, medium, low)
+node dist/index.js priority 1 high
+
+# Filter todos by priority
+node dist/index.js filter high
+
+# Set a due date
+node dist/index.js due 1 2025-12-31
+
+# List overdue todos
+node dist/index.js overdue
+
+# Remove all completed todos
+node dist/index.js clear
+
 # Search todos
 node dist/index.js search "groceries"
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { Todo } from "./types";
+import { Todo, Priority } from "./types";
 import { loadTodos, saveTodos } from "./storage";
 
 let todos: Todo[] = loadTodos();
@@ -80,23 +80,138 @@ export function searchTodos(query: string): void {
   });
 }
 
+// BUG: off-by-one error — position is used directly as the index
+// instead of subtracting 1, so "edit 1" actually edits the second todo.
+export function editTodo(position: number, newText: string): void {
+  const index = position;
+
+  if (index < 0 || index >= todos.length) {
+    console.log(`Invalid todo number: ${position}. Use "list" to see available todos.`);
+    return;
+  }
+
+  const oldText = todos[index].text;
+  todos[index].text = newText.trim();
+  saveTodos(todos);
+  console.log(`Updated todo #${position}: "${oldText}" → "${todos[index].text}"`);
+}
+
+export function setPriority(position: number, priority: Priority): void {
+  const index = position - 1;
+
+  if (index < 0 || index >= todos.length) {
+    console.log(`Invalid todo number: ${position}. Use "list" to see available todos.`);
+    return;
+  }
+
+  todos[index].priority = priority;
+  saveTodos(todos);
+  console.log(`Set priority of "${todos[index].text}" to ${priority}`);
+}
+
+// BUG: the filter condition is inverted — it keeps todos whose priority
+// does NOT match the requested one.
+export function listByPriority(priority: Priority): void {
+  const results = todos.filter((todo) => todo.priority !== priority);
+
+  if (results.length === 0) {
+    console.log(`No todos with priority "${priority}".`);
+    return;
+  }
+
+  console.log(`\nTodos with priority "${priority}":`);
+  console.log("-".repeat(50));
+  results.forEach((todo) => {
+    const status = todo.completed ? "✓" : " ";
+    const pLabel = todo.priority ? ` [${todo.priority}]` : "";
+    console.log(`  [${status}]${pLabel} ${todo.text} (id: ${todo.id})`);
+  });
+}
+
+export function setDueDate(position: number, dateStr: string): void {
+  const index = position - 1;
+
+  if (index < 0 || index >= todos.length) {
+    console.log(`Invalid todo number: ${position}. Use "list" to see available todos.`);
+    return;
+  }
+
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) {
+    console.log(`Invalid date: "${dateStr}". Use a format like YYYY-MM-DD.`);
+    return;
+  }
+
+  todos[index].dueDate = date.toISOString();
+  saveTodos(todos);
+  console.log(`Set due date of "${todos[index].text}" to ${date.toLocaleDateString()}`);
+}
+
+// BUG: the comparison is backwards — items with a due date in the future
+// are reported as overdue, while actually overdue items are not shown.
+export function listOverdue(): void {
+  const now = new Date();
+  const overdue = todos.filter((todo) => {
+    if (!todo.dueDate || todo.completed) return false;
+    return new Date(todo.dueDate) > now;
+  });
+
+  if (overdue.length === 0) {
+    console.log("No overdue todos.");
+    return;
+  }
+
+  console.log("\nOverdue Todos:");
+  console.log("-".repeat(50));
+  overdue.forEach((todo) => {
+    const pLabel = todo.priority ? ` [${todo.priority}]` : "";
+    console.log(`  ${pLabel} ${todo.text} (due: ${new Date(todo.dueDate!).toLocaleDateString()})`);
+  });
+}
+
+// BUG: clears ALL todos instead of only the completed ones.
+export function clearCompleted(): void {
+  const completedCount = todos.filter((t) => t.completed).length;
+
+  if (completedCount === 0) {
+    console.log("No completed todos to clear.");
+    return;
+  }
+
+  todos = [];
+  saveTodos(todos);
+  console.log(`Cleared ${completedCount} completed todo(s).`);
+}
+
 export function showHelp(): void {
   console.log(`
 Todo App - A simple command-line todo list manager
 
 Usage:
-  todo add <text>          Add a new todo
-  todo list                List all todos
-  todo complete <number>   Mark a todo as completed (by position number)
-  todo delete <number>     Delete a todo (by position number)
-  todo search <query>      Search todos by text
-  todo help                Show this help message
+  todo add <text>              Add a new todo
+  todo list                    List all todos
+  todo complete <number>       Mark a todo as completed (by position number)
+  todo delete <number>         Delete a todo (by position number)
+  todo edit <number> <text>    Edit a todo's text
+  todo priority <number> <p>   Set priority (high, medium, low)
+  todo filter <priority>       List todos by priority level
+  todo due <number> <date>     Set a due date (YYYY-MM-DD)
+  todo overdue                 List overdue todos
+  todo clear                   Remove all completed todos
+  todo search <query>          Search todos by text
+  todo help                    Show this help message
 
 Examples:
   todo add "Buy groceries"
   todo list
   todo complete 1
   todo delete 2
+  todo edit 1 "Buy organic groceries"
+  todo priority 1 high
+  todo filter high
+  todo due 1 2025-12-31
+  todo overdue
+  todo clear
   todo search "groceries"
 `);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,23 @@
-import { addTodo, listTodos, completeTodo, deleteTodo, searchTodos, showHelp } from "./app";
+import {
+  addTodo,
+  listTodos,
+  completeTodo,
+  deleteTodo,
+  searchTodos,
+  editTodo,
+  setPriority,
+  listByPriority,
+  setDueDate,
+  listOverdue,
+  clearCompleted,
+  showHelp,
+} from "./app";
+import { Priority } from "./types";
 
 const args = process.argv.slice(2);
 const command = args[0]?.toLowerCase();
+
+const VALID_PRIORITIES: Priority[] = ["high", "medium", "low"];
 
 switch (command) {
   case "add": {
@@ -40,6 +56,57 @@ switch (command) {
     deleteTodo(num);
     break;
   }
+
+  case "edit": {
+    const num = parseInt(args[1], 10);
+    const newText = args.slice(2).join(" ");
+    if (isNaN(num) || !newText) {
+      console.log('Please provide a todo number and new text. Example: todo edit 1 "New text"');
+      process.exit(1);
+    }
+    editTodo(num, newText);
+    break;
+  }
+
+  case "priority": {
+    const num = parseInt(args[1], 10);
+    const priority = args[2]?.toLowerCase() as Priority;
+    if (isNaN(num) || !VALID_PRIORITIES.includes(priority)) {
+      console.log("Please provide a todo number and priority (high, medium, low). Example: todo priority 1 high");
+      process.exit(1);
+    }
+    setPriority(num, priority);
+    break;
+  }
+
+  case "filter": {
+    const priority = args[1]?.toLowerCase() as Priority;
+    if (!VALID_PRIORITIES.includes(priority)) {
+      console.log("Please provide a priority level (high, medium, low). Example: todo filter high");
+      process.exit(1);
+    }
+    listByPriority(priority);
+    break;
+  }
+
+  case "due": {
+    const num = parseInt(args[1], 10);
+    const dateStr = args[2];
+    if (isNaN(num) || !dateStr) {
+      console.log("Please provide a todo number and date. Example: todo due 1 2025-12-31");
+      process.exit(1);
+    }
+    setDueDate(num, dateStr);
+    break;
+  }
+
+  case "overdue":
+    listOverdue();
+    break;
+
+  case "clear":
+    clearCompleted();
+    break;
 
   case "search":
   case "find": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
+export type Priority = "high" | "medium" | "low";
+
 export interface Todo {
   id: number;
   text: string;
   completed: boolean;
   createdAt: string;
+  priority?: Priority;
+  dueDate?: string;
 }


### PR DESCRIPTION
## Summary

Adds 6 new commands to the todo CLI app:

- **edit** — rename a todo's text
- **priority** — set high/medium/low priority on a todo
- **filter** — list todos by priority level
- **due** — set a due date on a todo
- **overdue** — list todos past their due date
- **clear** — remove completed todos

Also adds `priority` and `dueDate` optional fields to the `Todo` interface and updates the README with documentation for all new commands.

## Known Issues

The following bugs have been filed:

- #20 — `edit` command has an off-by-one error (edits wrong todo)
- #21 — `filter` command shows todos that do NOT match the requested priority
- #22 — `overdue` command shows future todos instead of past-due ones
- #23 — `clear` command deletes ALL todos instead of only completed ones

_Conversation: https://staging.warp.dev/conversation/0e4e5204-b7c5-42d3-8f67-0924e8d8f909_

_This PR was generated with [Oz](https://warp.dev/oz)._
