### PR TITLE
fix: declare direct httpx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,4 @@ The `config.json` file contains **only** label definitions. Stakeholder ownershi
 - Production logic in this repository lives in the Python automation and workflow definitions, not in a shipping application binary or CLI.
 - Shared workflow and hub-action helpers should live in `src/oz_workflows/` so they can be reused by multiple workflow entrypoints.
 - Workflow dependency installation is driven by `src/requirements.txt`.
+- Any third-party module imported directly from `src/` or `src/oz_workflows/` should also be declared directly in `src/requirements.txt`, even if it is currently available transitively through another dependency.

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,1 +1,2 @@
+httpx
 git+https://github.com/warpdotdev/oz-sdk-python@main

--- a/src/tests/test_requirements.py
+++ b/src/tests/test_requirements.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import ast
+import re
+import unittest
+from pathlib import Path
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+SRC_DIR = TESTS_DIR.parent
+REQUIREMENTS_PATH = SRC_DIR / "requirements.txt"
+GITHUB_API_PATH = SRC_DIR / "oz_workflows" / "github_api.py"
+
+
+def imported_top_level_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module.split(".")[0])
+    return modules
+
+
+def declared_requirements(path: Path) -> set[str]:
+    requirements: set[str] = set()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith("git+"):
+            continue
+        normalized = re.split(r"[<>=!~]", line.split("[", 1)[0], maxsplit=1)[0]
+        requirements.add(normalized.strip().lower().replace("_", "-"))
+    return requirements
+
+
+class DirectDependencyDeclarationTest(unittest.TestCase):
+    def test_github_api_direct_imports_are_declared(self) -> None:
+        imports = imported_top_level_modules(GITHUB_API_PATH)
+        if "httpx" not in imports:
+            self.skipTest("github_api.py no longer imports httpx directly")
+
+        requirements = declared_requirements(REQUIREMENTS_PATH)
+        self.assertIn("httpx", requirements)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- declare `httpx` directly in `src/requirements.txt` because `src/oz_workflows/github_api.py` imports it directly
- document that direct third-party imports from `src/` and `src/oz_workflows/` belong in `src/requirements.txt`
- add a focused regression test covering the `github_api.py` to `requirements.txt` dependency path

## Validation

- create a clean virtualenv and run `python -m pip install -r src/requirements.txt`
- run `env PYTHONPATH=src python -c "import oz_workflows.github_api"`
- run `env PYTHONPATH=src python -m unittest discover -s src/tests -p 'test_requirements.py'`

Co-Authored-By: Oz <oz-agent@warp.dev>