### PR TITLE
fix: harden transport parsing

### DIFF
--- a/src/oz_workflows/transport.py
+++ b/src/oz_workflows/transport.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 import re
 import time
@@ -21,9 +22,14 @@ def parse_transport_comment(body: str) -> dict[str, Any] | None:
     match = TRANSPORT_PATTERN.search(body)
     if not match:
         return None
-    payload = json.loads(match.group("payload"))
-    encoded = payload.get("payload", "")
-    decoded = base64.b64decode(encoded).decode("utf-8")
+    try:
+        payload = json.loads(match.group("payload"))
+        if not isinstance(payload, dict):
+            return None
+        encoded = payload.get("payload", "")
+        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except (TypeError, ValueError, json.JSONDecodeError, binascii.Error, UnicodeDecodeError):
+        return None
     payload["decoded_payload"] = decoded
     return payload
 

--- a/src/tests/test_transport.py
+++ b/src/tests/test_transport.py
@@ -3,27 +3,95 @@ from __future__ import annotations
 import base64
 import json
 import unittest
+from oz_workflows.transport import parse_transport_comment, poll_for_transport_payload
 
-from oz_workflows.transport import parse_transport_comment
+
+def transport_comment(payload: str) -> str:
+    return f"<!-- oz-workflow-transport {payload} -->"
+
+
+def encoded_payload(payload: dict[str, str]) -> str:
+    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
 
 
 class ParseTransportCommentTest(unittest.TestCase):
     def test_decodes_payload(self) -> None:
-        encoded = base64.b64encode(json.dumps({"hello": "world"}).encode("utf-8")).decode("utf-8")
-        body = (
-            '<!-- oz-workflow-transport '
-            + json.dumps(
+        body = transport_comment(
+            json.dumps(
                 {
                     "token": "abc",
                     "kind": "review-json",
                     "encoding": "base64",
-                    "payload": encoded,
+                    "payload": encoded_payload({"hello": "world"}),
                 }
             )
-            + " -->"
         )
         parsed = parse_transport_comment(body)
         self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["decoded_payload"], '{"hello": "world"}')
+    def test_returns_none_for_malformed_json(self) -> None:
+        body = transport_comment('{"token": "abc", "kind": }')
+        self.assertIsNone(parse_transport_comment(body))
+
+    def test_returns_none_for_invalid_base64_payload(self) -> None:
+        body = transport_comment(
+            json.dumps(
+                {
+                    "token": "abc",
+                    "kind": "review-json",
+                    "encoding": "base64",
+                    "payload": "%%%not-base64%%%",
+                }
+            )
+        )
+        self.assertIsNone(parse_transport_comment(body))
+
+
+class PollForTransportPayloadTest(unittest.TestCase):
+    def test_skips_malformed_transport_comments(self) -> None:
+        valid_comment = transport_comment(
+            json.dumps(
+                {
+                    "token": "abc",
+                    "kind": "review-json",
+                    "encoding": "base64",
+                    "payload": encoded_payload({"hello": "world"}),
+                }
+            )
+        )
+        malformed_comment = transport_comment(
+            json.dumps(
+                {
+                    "token": "abc",
+                    "kind": "review-json",
+                    "encoding": "base64",
+                    "payload": "%%%not-base64%%%",
+                }
+            )
+        )
+
+        class FakeGitHubClient:
+            def list_issue_comments(self, owner: str, repo: str, issue_number: int) -> list[dict[str, object]]:
+                self.request = (owner, repo, issue_number)
+                return [
+                    {"id": 1, "body": valid_comment},
+                    {"id": 2, "body": malformed_comment},
+                ]
+
+        github = FakeGitHubClient()
+        parsed, comment_id = poll_for_transport_payload(
+            github,
+            "warpdotdev",
+            "oz-for-oss",
+            42,
+            token="abc",
+            kind="review-json",
+            timeout_seconds=0,
+            poll_interval_seconds=0,
+        )
+
+        self.assertEqual(github.request, ("warpdotdev", "oz-for-oss", 42))
+        self.assertEqual(comment_id, 1)
         self.assertEqual(parsed["decoded_payload"], '{"hello": "world"}')
 
 


### PR DESCRIPTION
## Summary
- Harden transport comment parsing so malformed JSON, non-object payloads, invalid base64, or invalid UTF-8 content fail closed and are ignored.
- Keep polling resilient by treating malformed transport comments as absent instead of propagating parser exceptions.
- Add focused parser and poller regression tests for success and malformed payload handling.

## Failure mode
Polling could crash when a transport comment matched the marker but contained malformed JSON or an invalid base64 payload, because parsing raised before the loop could continue scanning comments.

## Fail-closed behavior
Malformed transport comments now return `None` from the parser, so polling skips them and continues searching for a matching valid payload.

## Validation
- `source /Users/captainsafia/repos/oz-for-oss/.venv/bin/activate.fish; env PYTHONPATH=/Users/captainsafia/repos/oz-for-oss-worktrees/transport-hardening-fix/src python -m unittest discover -s /Users/captainsafia/repos/oz-for-oss-worktrees/transport-hardening-fix/src/tests -p 'test_transport.py'`

## Artifacts
- Conversation: https://staging.warp.dev/conversation/e7fcf0ac-5e7f-443f-96c2-134dbca94ca6

Co-Authored-By: Oz <oz-agent@warp.dev>
