### PR TITLE
chore: parameterize Oz client configuration

### DIFF
--- a/src/oz_workflows/oz_client.py
+++ b/src/oz_workflows/oz_client.py
@@ -11,14 +11,27 @@ from .env import optional_env, parse_mcp_servers, repo_slug, require_env
 
 
 TERMINAL_STATES = {"SUCCEEDED", "FAILED", "ERROR", "CANCELLED"}
+DEFAULT_OZ_API_BASE_URL = "https://staging.warp.dev/api/v1"
+DEFAULT_OZ_ORIGIN_TOKEN_ENV_NAME = "STAGING_ORIGIN_TOKEN"
+
+
+def oz_api_base_url() -> str:
+    return optional_env("WARP_API_BASE_URL") or DEFAULT_OZ_API_BASE_URL
+
+
+def oz_origin_token() -> str:
+    origin_token_env_name = (
+        optional_env("WARP_ORIGIN_TOKEN_ENV_NAME") or DEFAULT_OZ_ORIGIN_TOKEN_ENV_NAME
+    )
+    return require_env(origin_token_env_name)
 
 
 def build_oz_client() -> OzAPI:
     return OzAPI(
         api_key=require_env("WARP_API_KEY"),
-        base_url="https://staging.warp.dev/api/v1",
+        base_url=oz_api_base_url(),
         default_headers={
-            "X-Warp-Origin-Token": require_env("STAGING_ORIGIN_TOKEN"),
+            "X-Warp-Origin-Token": oz_origin_token(),
             "x-oz-api-source": "GITHUB_ACTION",
         },
     )

--- a/src/tests/test_oz_client.py
+++ b/src/tests/test_oz_client.py
@@ -13,15 +13,38 @@ class BuildOzClientTest(unittest.TestCase):
     @patch.dict(
         os.environ,
         {"WARP_API_KEY": "fake-key", "STAGING_ORIGIN_TOKEN": "fake-token"},
-        clear=False,
+        clear=True,
     )
     @patch("oz_workflows.oz_client.OzAPI")
-    def test_default_headers_include_api_source(self, mock_oz_api: unittest.mock.MagicMock) -> None:
+    def test_default_headers_include_api_source(
+        self, mock_oz_api: unittest.mock.MagicMock
+    ) -> None:
         build_oz_client()
         _args, kwargs = mock_oz_api.call_args
         headers = kwargs["default_headers"]
+        self.assertEqual(kwargs["base_url"], "https://staging.warp.dev/api/v1")
         self.assertEqual(headers["x-oz-api-source"], "GITHUB_ACTION")
         self.assertEqual(headers["X-Warp-Origin-Token"], "fake-token")
+
+    @patch.dict(
+        os.environ,
+        {
+            "WARP_API_KEY": "fake-key",
+            "WARP_API_BASE_URL": "https://app.warp.dev/api/v1",
+            "WARP_ORIGIN_TOKEN_ENV_NAME": "PROD_ORIGIN_TOKEN",
+            "PROD_ORIGIN_TOKEN": "prod-token",
+        },
+        clear=True,
+    )
+    @patch("oz_workflows.oz_client.OzAPI")
+    def test_uses_configured_base_url_and_origin_token_env_name(
+        self, mock_oz_api: unittest.mock.MagicMock
+    ) -> None:
+        build_oz_client()
+        _args, kwargs = mock_oz_api.call_args
+        headers = kwargs["default_headers"]
+        self.assertEqual(kwargs["base_url"], "https://app.warp.dev/api/v1")
+        self.assertEqual(headers["X-Warp-Origin-Token"], "prod-token")
 
 
 class SkillSpecTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `build_oz_client()` previously hard-coded the staging Oz API base URL and always looked up `STAGING_ORIGIN_TOKEN`, which made non-staging rollout a code change.
- Added `WARP_API_BASE_URL` and `WARP_ORIGIN_TOKEN_ENV_NAME` as configuration knobs while preserving `https://staging.warp.dev/api/v1` and `STAGING_ORIGIN_TOKEN` as the defaults.
- Added focused tests covering both the default staging behavior and the override path for a different base URL and origin-token env lookup.

## Validation
- `env PYTHONPATH=/Users/captainsafia/repos/oz-for-oss-worktrees/oz-client-config-fix/src /Users/captainsafia/repos/oz-for-oss-worktrees/oz-client-config-fix/.venv/bin/python -m unittest discover -s /Users/captainsafia/repos/oz-for-oss-worktrees/oz-client-config-fix/src/tests -p 'test_oz_client.py'`

Co-Authored-By: Oz <oz-agent@warp.dev>
