### PR TITLE
chore: reduce ignored profile warning noise

### DIFF
--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -56,7 +56,6 @@ jobs:
           PYTHONPATH: src
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
-          WARP_AGENT_PROFILE: ${{ vars.WARP_AGENT_PROFILE || '' }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -56,7 +56,6 @@ jobs:
           PYTHONPATH: src
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
-          WARP_AGENT_PROFILE: ${{ vars.WARP_AGENT_PROFILE || '' }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -73,7 +73,6 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           REQUESTER: ${{ inputs.requester }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
-          WARP_AGENT_PROFILE: ${{ vars.WARP_AGENT_PROFILE || '' }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -60,7 +60,6 @@ jobs:
           PYTHONPATH: src
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
-          WARP_AGENT_PROFILE: ${{ vars.WARP_AGENT_PROFILE || '' }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -86,7 +86,6 @@ jobs:
           REVIEW_FOCUS: ${{ inputs.focus }}
           COMMENT_ID: ${{ inputs.comment_id }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
-          WARP_AGENT_PROFILE: ${{ vars.WARP_AGENT_PROFILE || '' }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
         run: python src/review_pr.py

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -84,7 +84,6 @@ jobs:
           LOOKBACK_MINUTES: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.lookback_minutes || '60' }}
           TRIAGE_ISSUE_NUMBER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.issue_number || '' }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
-          WARP_AGENT_PROFILE: ${{ vars.WARP_AGENT_PROFILE || '' }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}

--- a/.github/workflows/update-pr-review.yml
+++ b/.github/workflows/update-pr-review.yml
@@ -54,7 +54,6 @@ jobs:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           LOOKBACK_DAYS: ${{ inputs.lookback_days || '7' }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
-          WARP_AGENT_PROFILE: ${{ vars.WARP_AGENT_PROFILE || '' }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_AGENT_ENVIRONMENT_ID: ${{ vars.WARP_AGENT_ENVIRONMENT_ID || '' }}

--- a/src/oz_workflows/helpers.py
+++ b/src/oz_workflows/helpers.py
@@ -111,6 +111,7 @@ def resolve_oz_assigner_login(
     )
     return (matching_events[0].get("actor") or {}).get("login") or ""
 
+
 def resolve_progress_requester_login(
     github: GitHubClient,
     owner: str,
@@ -189,7 +190,6 @@ class WorkflowProgressComment:
                 self.github.delete_comment(self.owner, self.repo, int(existing["id"]))
             except Exception:
                 pass
-            self.comment_id = None
             self.comment_id = None
 
     def _append_sections(self, sections: list[str]) -> None:
@@ -370,7 +370,6 @@ def _summarize_commits(commits: list[dict[str, Any]]) -> str:
         lines.append(f"- {first_line}")
     if len(lines) > max_lines:
         lines = lines[:max_lines] + [f"- … and {len(lines) - max_lines} more commits"]
-    return "\n".join(lines)
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary
- stop passing `WARP_AGENT_PROFILE` from the affected GitHub Actions workflows because the current Oz Python SDK ignores it
- remove dead duplicate lines from `src/oz_workflows/helpers.py`

## Validation
- `env PYTHONPATH=/Users/captainsafia/repos/oz-for-oss-worktrees/cleanup-warning-fix/src python -m unittest discover -s /Users/captainsafia/repos/oz-for-oss-worktrees/cleanup-warning-fix/src/tests`
- `git --no-pager diff --check`

Co-Authored-By: Oz <oz-agent@warp.dev>
