### PR TITLE
chore: rename GHA_APP_ID / GHA_PRIVATE_KEY secrets to OZ_MGMT_ prefix

### DIFF
--- a/.github/workflows/comment-on-unready-assigned-issue.yml
+++ b/.github/workflows/comment-on-unready-assigned-issue.yml
@@ -16,8 +16,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GHA_APP_ID }}
-          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -22,8 +22,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GHA_APP_ID }}
-          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -22,8 +22,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GHA_APP_ID }}
-          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -12,9 +12,9 @@ on:
         default: ""
         type: string
     secrets:
-      GHA_APP_ID:
+      OZ_MGMT_GHA_APP_ID:
         required: true
-      GHA_PRIVATE_KEY:
+      OZ_MGMT_GHA_PRIVATE_KEY:
         required: true
       WARP_API_KEY:
         required: true
@@ -38,8 +38,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GHA_APP_ID }}
-          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Authenticate to Google Cloud for staging secret access

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -26,8 +26,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GHA_APP_ID }}
-          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -26,9 +26,9 @@ on:
         default: ""
         type: string
     secrets:
-      GHA_APP_ID:
+      OZ_MGMT_GHA_APP_ID:
         required: true
-      GHA_PRIVATE_KEY:
+      OZ_MGMT_GHA_PRIVATE_KEY:
         required: true
       WARP_API_KEY:
         required: true
@@ -49,8 +49,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GHA_APP_ID }}
-          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Authenticate to Google Cloud for staging secret access

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -48,8 +48,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GHA_APP_ID }}
-          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-pr-review.yml
+++ b/.github/workflows/update-pr-review.yml
@@ -21,8 +21,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GHA_APP_ID }}
-          private-key: ${{ secrets.GHA_PRIVATE_KEY }}
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Authenticate to Google Cloud for staging secret access


### PR DESCRIPTION
## Summary

Rename the `GHA_APP_ID` and `GHA_PRIVATE_KEY` GitHub Actions secrets to use the `OZ_MGMT_` prefix (`OZ_MGMT_GHA_APP_ID` / `OZ_MGMT_GHA_PRIVATE_KEY`) across all workflow files.

## Changes

Updated 8 workflow files under `.github/workflows/`:
- **`enforce-pr-issue-state.yml`** — secret declarations + usage
- **`review-pull-request.yml`** — secret declarations + usage
- **`create-implementation-from-issue.yml`** — usage
- **`create-spec-from-issue.yml`** — usage
- **`triage-new-issues.yml`** — usage
- **`update-pr-review.yml`** — usage
- **`respond-to-pr-comment.yml`** — usage
- **`comment-on-unready-assigned-issue.yml`** — usage

## Note

The corresponding repository secrets must also be renamed in the GitHub repository settings to match the new names.

---

_Conversation: https://staging.warp.dev/conversation/9275f907-f3a6-4bf5-aef5-66aeb13dfd5a_
_Run: https://oz.staging.warp.dev/runs/019d4fe5-746f-725a-b08e-099771586694_
_This PR was generated with [Oz](https://warp.dev/oz)._
