### PR TITLE
fix: pin Oz git identity for cloud commits

### DIFF
--- a/.github/scripts/oz_workflows/helpers.py
+++ b/.github/scripts/oz_workflows/helpers.py
@@ -426,6 +426,8 @@ def conventional_commit_prefix(labels: list[Any], *, default: str = "feat") -> s
 # Accounts created on or after this date use the ``ID+login`` noreply format.
 # See https://docs.github.com/en/account-and-profile/reference/email-addresses-reference#your-noreply-email-address
 _NOREPLY_ID_CUTOFF = datetime(2017, 7, 18, tzinfo=timezone.utc)
+_OZ_COMMIT_AUTHOR_NAME = "Oz"
+_OZ_COMMIT_AUTHOR_EMAIL = "oz-agent@warp.dev"
 
 
 def _noreply_email(login: str, user_id: int | None, created_at: datetime | str | None) -> str:
@@ -471,13 +473,22 @@ def resolve_coauthor_line(
 
 
 def coauthor_prompt_lines(coauthor_line: str) -> str:
-    """Return prompt directive lines for co-authorship."""
+    """Return prompt directive lines for commit attribution."""
+    lines = [
+        f"- Before creating any commit, configure the local git author and committer as `{_OZ_COMMIT_AUTHOR_NAME} <{_OZ_COMMIT_AUTHOR_EMAIL}>`.",
+        f"- Run `git config user.name \"{_OZ_COMMIT_AUTHOR_NAME}\"` and `git config user.email \"{_OZ_COMMIT_AUTHOR_EMAIL}\"` before committing.",
+        "- Do not derive the git author or committer from the triggering issue, PR, comment, sender, or authenticated GitHub user.",
+    ]
     if coauthor_line:
-        return (
-            f"- Include the following co-author attribution at the end of every commit message: {coauthor_line}\n"
-            f"            - Do not attempt to resolve the co-author identity yourself (e.g. via GET /user). Use exactly the line provided above."
+        lines.extend(
+            [
+                f"- Include the following co-author attribution at the end of every commit message: {coauthor_line}",
+                "- Do not attempt to resolve the co-author identity yourself (e.g. via GET /user). Use exactly the line provided above.",
+            ]
         )
-    return "- Do not include any Co-Authored-By lines in commit messages."
+        return "\n".join(lines)
+    lines.append("- Do not include any Co-Authored-By lines in commit messages.")
+    return "\n".join(lines)
 
 
 def build_spec_preview_section(owner: str, repo: str, branch_name: str, issue_number: int) -> str:

--- a/.github/scripts/oz_workflows/helpers.py
+++ b/.github/scripts/oz_workflows/helpers.py
@@ -486,8 +486,8 @@ def coauthor_prompt_lines(coauthor_line: str) -> str:
                 "- Do not attempt to resolve the co-author identity yourself (e.g. via GET /user). Use exactly the line provided above.",
             ]
         )
-        return "\n".join(lines)
-    lines.append("- Do not include any Co-Authored-By lines in commit messages.")
+    else:
+        lines.append("- Do not include any Co-Authored-By lines in commit messages.")
     return "\n".join(lines)
 
 

--- a/.github/scripts/tests/test_helpers.py
+++ b/.github/scripts/tests/test_helpers.py
@@ -424,11 +424,16 @@ class ResolveCoauthorLineTest(unittest.TestCase):
 class CoauthorPromptLinesTest(unittest.TestCase):
     def test_returns_include_directive_when_line_provided(self) -> None:
         result = coauthor_prompt_lines("Co-Authored-By: Alice <alice@users.noreply.github.com>")
+        self.assertIn("configure the local git author and committer as `Oz <oz-agent@warp.dev>`", result)
+        self.assertIn('git config user.name "Oz"', result)
+        self.assertIn("Do not derive the git author or committer", result)
         self.assertIn("Co-Authored-By: Alice <alice@users.noreply.github.com>", result)
         self.assertIn("Do not attempt to resolve the co-author identity yourself", result)
 
     def test_returns_omit_directive_when_empty(self) -> None:
         result = coauthor_prompt_lines("")
+        self.assertIn("configure the local git author and committer as `Oz <oz-agent@warp.dev>`", result)
+        self.assertIn('git config user.email "oz-agent@warp.dev"', result)
         self.assertIn("Do not include any Co-Authored-By lines", result)
 
 


### PR DESCRIPTION
## Summary
- set explicit Oz git author and committer instructions for commit-producing cloud workflows
- keep triggering users as explicit co-author trailers instead of relying on ambient GitHub identity resolution
- add test coverage for the new attribution directives

## Testing
- PYTHONPATH=.github/scripts python3 .github/scripts/tests/test_helpers.py

Conversation: https://staging.warp.dev/conversation/7602e6e8-a342-4b6a-b1f2-d07385481ebd

Co-Authored-By: Oz <oz-agent@warp.dev>
