### PR TITLE
fix: address Python audit findings

### DIFF
--- a/.github/scripts/oz_workflows/env.py
+++ b/.github/scripts/oz_workflows/env.py
@@ -46,12 +46,15 @@ def parse_mcp_servers(raw_value: str, cwd: Path) -> dict[str, Any] | None:
     raw = raw_value.strip()
     if not raw:
         return None
-
-    candidate_path = Path(raw)
-    if not candidate_path.is_absolute():
-        candidate_path = cwd / candidate_path
-
-    if candidate_path.exists():
+    if not raw.startswith(("{", "[")):
+        candidate_path = Path(raw)
+        if not candidate_path.is_absolute():
+            candidate_path = cwd / candidate_path
+        try:
+            if candidate_path.is_file():
+                raw = candidate_path.read_text(encoding="utf-8")
+        except OSError:
+            pass
         raw = candidate_path.read_text(encoding="utf-8")
 
     parsed = json.loads(raw)

--- a/.github/scripts/tests/test_env.py
+++ b/.github/scripts/tests/test_env.py
@@ -12,6 +12,11 @@ class ParseMcpServersTest(unittest.TestCase):
     def test_parses_inline_json(self) -> None:
         parsed = parse_mcp_servers('{"github":{"warp_id":"123"}}', Path.cwd())
         self.assertEqual(parsed, {"github": {"warp_id": "123"}})
+    def test_parses_large_inline_json_without_treating_it_as_path(self) -> None:
+        long_key = "github" * 80
+        raw = f'{{"{long_key}":{{"warp_id":"123"}}}}'
+        parsed = parse_mcp_servers(raw, Path.cwd())
+        self.assertEqual(parsed, {long_key: {"warp_id": "123"}})
 
     def test_parses_json_file_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/.github/scripts/tests/test_triage.py
+++ b/.github/scripts/tests/test_triage.py
@@ -490,6 +490,32 @@ class ExtractDuplicateOfTest(unittest.TestCase):
         self.assertEqual(len(duplicates), 1)
         self.assertEqual(duplicates[0]["issue_number"], 5)
 
+    def test_skips_invalid_duplicate_issue_numbers(self) -> None:
+        result = {
+            "duplicate_of": [
+                {"issue_number": "abc", "title": "Bad"},
+                {"issue_number": 0, "title": "Also bad"},
+                {"issue_number": 7, "title": "Valid"},
+            ]
+        }
+        self.assertEqual(
+            extract_duplicate_of(result),
+            [{"issue_number": 7, "title": "Valid", "similarity_reason": ""}],
+        )
+
+    def test_skips_self_references_and_duplicate_entries(self) -> None:
+        result = {
+            "duplicate_of": [
+                {"issue_number": 42, "title": "Self"},
+                {"issue_number": 10, "title": "First"},
+                {"issue_number": "10", "title": "Duplicate"},
+            ]
+        }
+        self.assertEqual(
+            extract_duplicate_of(result, current_issue_number=42),
+            [{"issue_number": 10, "title": "First", "similarity_reason": ""}],
+        )
+
 
 class BuildDuplicateCommentTest(unittest.TestCase):
     def test_builds_comment_with_duplicate_links(self) -> None:

--- a/.github/scripts/tests/test_triage.py
+++ b/.github/scripts/tests/test_triage.py
@@ -10,7 +10,9 @@ from triage_new_issues import (
     build_follow_up_comment,
     extract_duplicate_of,
     extract_follow_up_questions,
+    format_recent_issues_for_dedupe,
     format_issue_comments,
+    load_recent_issues_for_dedupe,
     resolve_issue_number_override,
     sync_duplicate_comment,
     sync_follow_up_comment,
@@ -238,6 +240,44 @@ class FormatIssueCommentsTest(unittest.TestCase):
             ]
         )
         self.assertEqual(rendered, "- @alice [NONE] (2026-03-24T00:00:00Z): Visible reporter comment")
+
+
+class LoadRecentIssuesForDedupeTest(unittest.TestCase):
+    def test_returns_prefetched_issue_batch(self) -> None:
+        github = FakeRecentIssuesGitHubClient(
+            [
+                {"number": 1, "title": "One"},
+                {"number": 2, "title": "Two"},
+            ]
+        )
+        issues = load_recent_issues_for_dedupe(github)
+        self.assertEqual([issue["number"] for issue in issues or []], [1, 2])
+        self.assertEqual(github.calls, 1)
+
+    def test_returns_none_when_fetch_fails(self) -> None:
+        github = FakeRecentIssuesGitHubClient([], should_fail=True)
+        self.assertIsNone(load_recent_issues_for_dedupe(github))
+
+
+class FormatRecentIssuesForDedupeTest(unittest.TestCase):
+    def test_formats_prefetched_issues_and_excludes_current_issue(self) -> None:
+        rendered = format_recent_issues_for_dedupe(
+            [
+                {"number": 10, "title": "Current", "body": "skip me"},
+                {"number": 11, "title": "Neighbor", "body": "has details"},
+                {"number": 12, "title": "Pull request", "body": "skip", "pull_request": {"url": "https://example.test/pr/12"}},
+            ],
+            current_issue_number=10,
+        )
+        self.assertIn("#11: Neighbor", rendered)
+        self.assertNotIn("#10: Current", rendered)
+        self.assertNotIn("#12: Pull request", rendered)
+
+    def test_reports_fetch_failure(self) -> None:
+        self.assertEqual(
+            format_recent_issues_for_dedupe(None, current_issue_number=10),
+            "Unable to fetch recent issues for duplicate detection.",
+        )
 
 
 class ExtractFollowUpQuestionsTest(unittest.TestCase):
@@ -525,6 +565,19 @@ class FakeTriageGitHubClient:
     def delete_comment(self, owner: str, repo: str, comment_id: int) -> None:
         self.deleted_comment_ids.append(comment_id)
         self.comments = [comment for comment in self.comments if int(comment["id"]) != comment_id]
+
+
+class FakeRecentIssuesGitHubClient:
+    def __init__(self, issues: list[dict[str, object]], *, should_fail: bool = False) -> None:
+        self.issues = issues
+        self.should_fail = should_fail
+        self.calls = 0
+
+    def get_issues(self, **_: object) -> list[dict[str, object]]:
+        self.calls += 1
+        if self.should_fail:
+            raise RuntimeError("boom")
+        return list(self.issues)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_triage.py
+++ b/.github/scripts/tests/test_triage.py
@@ -529,7 +529,8 @@ class BuildDuplicateCommentTest(unittest.TestCase):
         self.assertIn("#10", body)
         self.assertIn("#20", body)
         self.assertIn("Original bug", body)
-        self.assertIn("closed in 2 business days", body)
+        self.assertIn("Why it looks similar: Same error message", body)
+        self.assertIn("close it as a duplicate after review", body)
         self.assertIn("oz-agent-metadata", body)
 
 

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -569,7 +569,7 @@ def build_duplicate_comment(issue: Any, duplicates: list[dict[str, Any]]) -> str
     if reporter_login:
         lines.append(f"@{reporter_login}")
         lines.append("")
-    lines.append("This issue appears to be a duplicate of the following existing issues:")
+    lines.append("This issue appears likely to overlap with the following existing issues:")
     lines.append("")
     for dup in duplicates:
         num = dup["issue_number"]
@@ -578,13 +578,14 @@ def build_duplicate_comment(issue: Any, duplicates: list[dict[str, Any]]) -> str
         line = f"- #{num}"
         if title:
             line += f" — {title}"
-        if reason:
-            line += f" ({reason})"
         lines.append(line)
+        if reason:
+            lines.append(f"  Why it looks similar: {reason}")
     lines.append("")
     lines.append(
-        "If this is not a duplicate, please comment with additional context explaining "
-        "how this issue differs. Otherwise, this issue will be closed in 2 business days."
+        "If this report is meaningfully different, please comment with the additional context "
+        "or distinguishing behavior so a maintainer can review it. Otherwise, a maintainer may "
+        "close it as a duplicate after review."
     )
     lines.append("")
     lines.append(TRIAGE_DISCLAIMER)

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -115,6 +115,8 @@ def main() -> None:
             return
         queue_text = ", ".join(f"#{_field(issue, 'number')}" for issue in issues)
         append_summary(f"Triage queue: {queue_text}\n")
+        template_context = discover_issue_templates(workspace())
+        recent_open_issues = load_recent_issues_for_dedupe(github)
 
         agent_config = build_agent_config(
             config_name=WORKFLOW_NAME,
@@ -137,6 +139,8 @@ def main() -> None:
                     triggering_comment_id=triggering_comment_id,
                     triggering_comment_text=triggering_comment_text,
                     stakeholders_text=stakeholders_text,
+                    template_context=template_context,
+                    recent_open_issues=recent_open_issues,
                 )
             except Exception as exc:
                 warning(f"Issue triage failed for #{issue_number}: {exc}")
@@ -182,9 +186,10 @@ def process_issue(
     triggering_comment_id: int | None,
     triggering_comment_text: str,
     stakeholders_text: str,
+    template_context: dict[str, Any],
+    recent_open_issues: list[Any] | None,
 ) -> None:
     issue_number = int(issue.number)
-    template_context = discover_issue_templates(workspace())
     progress = WorkflowProgressComment(
         github,
         owner,
@@ -198,7 +203,7 @@ def process_issue(
     comments_text = format_issue_comments(comments, exclude_comment_id=triggering_comment_id)
     current_body = str(issue.body or "").strip()
     original_report = extract_original_issue_report(current_body)
-    recent_issues_text = format_recent_issues_for_dedupe(github, issue_number)
+    recent_issues_text = format_recent_issues_for_dedupe(recent_open_issues, issue_number)
     transport_token = new_transport_token()
     prompt = dedent(
         f"""
@@ -606,15 +611,21 @@ def sync_duplicate_comment(
             github.update_comment(owner, repo, int(_field(existing, "id")), comment_body)
 
 
-def format_recent_issues_for_dedupe(github: Repository, current_issue_number: int) -> str:
-    """Fetch recent open issues and format them for the dedupe prompt context."""
+def load_recent_issues_for_dedupe(github: Repository) -> list[Any] | None:
+    """Fetch recent open issues once so batch triage can reuse duplicate-detection context."""
     try:
         paginated = github.get_issues(state="open", sort="created", direction="desc")
-        first_batch = list(islice(paginated, 51))
+        return list(islice(paginated, 51))
     except Exception:
+        return None
+
+
+def format_recent_issues_for_dedupe(recent_open_issues: list[Any] | None, current_issue_number: int) -> str:
+    """Format recent open issues for the dedupe prompt context."""
+    if recent_open_issues is None:
         return "Unable to fetch recent issues for duplicate detection."
     candidates = [
-        issue for issue in first_batch
+        issue for issue in recent_open_issues
         if not _field(issue, "pull_request")
         and int(_field(issue, "number", 0)) != current_issue_number
     ][:50]

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -329,7 +329,7 @@ def process_issue(
         owner,
         repo,
         issue,
-        duplicates=extract_duplicate_of(result),
+        duplicates=extract_duplicate_of(result, current_issue_number=issue_number),
     )
 
     labels_text = ", ".join(extract_requested_labels(result)) or "no labels"
@@ -374,6 +374,13 @@ def apply_triage_result(
             )
             managed_labels.append(label_name)
             continue
+        if issue_number <= 0:
+            continue
+        if current_issue_number is not None and issue_number == current_issue_number:
+            continue
+        if issue_number in seen_issue_numbers:
+            continue
+        seen_issue_numbers.add(issue_number)
         if label_name in repo_labels:
             managed_labels.append(label_name)
             continue
@@ -517,19 +524,32 @@ def _on_poll(progress: WorkflowProgressComment, run: object) -> None:
     progress.record_session_link(session_link)
 
 
-def extract_duplicate_of(result: dict[str, Any]) -> list[dict[str, Any]]:
+def extract_duplicate_of(
+    result: dict[str, Any],
+    *,
+    current_issue_number: int | None = None,
+) -> list[dict[str, Any]]:
     raw = result.get("duplicate_of")
     if not isinstance(raw, list):
         return []
     duplicates: list[dict[str, Any]] = []
+    seen_issue_numbers: set[int] = set()
     for entry in raw:
         if not isinstance(entry, dict):
             continue
-        issue_number = entry.get("issue_number")
-        if issue_number is None:
+        try:
+            issue_number = int(entry.get("issue_number"))
+        except (TypeError, ValueError):
             continue
+        if issue_number <= 0:
+            continue
+        if current_issue_number is not None and issue_number == current_issue_number:
+            continue
+        if issue_number in seen_issue_numbers:
+            continue
+        seen_issue_numbers.add(issue_number)
         duplicates.append({
-            "issue_number": int(issue_number),
+            "issue_number": issue_number,
             "title": str(entry.get("title") or "").strip(),
             "similarity_reason": str(entry.get("similarity_reason") or "").strip(),
         })


### PR DESCRIPTION
## Summary
- harden `WARP_AGENT_MCP` parsing so inline JSON is not misread as a filesystem path
- reuse duplicate-detection context during batch triage to avoid repeated GitHub issue fetches
- ignore malformed, self-referential, and duplicate `duplicate_of` entries instead of crashing triage
- clarify duplicate follow-up comments so the messaging matches the workflow behavior and is easier to scan

## Validation
- `env PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests`

## Artifacts
- Conversation: https://staging.warp.dev/conversation/9762df35-1525-459f-a050-6d739e81e7c4
- Plan: https://staging.warp.dev/drive/notebook/YxJcrDiOhgJiAyoU697BRp

Co-Authored-By: Oz <oz-agent@warp.dev>
