### PR TITLE
refactor: simplify Oz workflow token handling

### DIFF
--- a/.github/scripts/create_implementation_from_issue.py
+++ b/.github/scripts/create_implementation_from_issue.py
@@ -14,6 +14,7 @@ from oz_workflows.helpers import (
     coauthor_prompt_lines,
     conventional_commit_prefix,
     org_member_comments_text,
+    record_run_session_link,
     resolve_coauthor_line,
     resolve_spec_context_for_issue,
     triggering_comment_prompt_text,
@@ -143,7 +144,7 @@ def main() -> None:
             skill_name=IMPLEMENT_SPECS_SKILL,
             title=f"Implement issue #{issue_number}",
             config=config,
-            on_poll=lambda current_run: _on_poll(progress, current_run),
+            on_poll=lambda current_run: record_run_session_link(progress, current_run),
         )
 
         if not branch_updated_since(
@@ -192,12 +193,6 @@ def main() -> None:
             f"I created or updated a draft implementation PR for this issue: {pr.html_url}\n\n"
             f"{next_steps_section}"
         )
-
-
-def _on_poll(progress: WorkflowProgressComment, run: object) -> None:
-    session_link = getattr(run, "session_link", None) or ""
-    progress.record_session_link(session_link)
-
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/create_spec_from_issue.py
+++ b/.github/scripts/create_spec_from_issue.py
@@ -13,6 +13,7 @@ from oz_workflows.helpers import (
     build_pr_body,
     coauthor_prompt_lines,
     org_member_comments_text,
+    record_run_session_link,
     resolve_coauthor_line,
     triggering_comment_prompt_text,
     WorkflowProgressComment,
@@ -92,7 +93,7 @@ def main() -> None:
             skill_name=SPEC_DRIVEN_IMPLEMENTATION_SKILL,
             title=f"Create specs for issue #{issue_number}",
             config=config,
-            on_poll=lambda current_run: _on_poll(progress, current_run),
+            on_poll=lambda current_run: record_run_session_link(progress, current_run),
         )
 
         if not branch_updated_since(
@@ -138,12 +139,6 @@ def main() -> None:
             f"{spec_preview_section}\n\n"
             f"{next_steps_section}"
         )
-
-
-def _on_poll(progress: WorkflowProgressComment, run: object) -> None:
-    session_link = getattr(run, "session_link", None) or ""
-    progress.record_session_link(session_link)
-
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/oz_workflows/actions.py
+++ b/.github/scripts/oz_workflows/actions.py
@@ -5,18 +5,21 @@ import uuid
 
 
 def _append_multiline(path: str, name: str, value: str) -> None:
+    """Append a multiline output or environment entry using a unique delimiter."""
     delimiter = f"oz_{uuid.uuid4()}"
     with open(path, "a", encoding="utf-8") as handle:
         handle.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
 
 
 def set_output(name: str, value: str) -> None:
+    """Publish a GitHub Actions step output when the workflow provides a sink."""
     output_path = os.environ.get("GITHUB_OUTPUT")
     if output_path:
         _append_multiline(output_path, name, value)
 
 
 def append_summary(text: str) -> None:
+    """Append text to the GitHub Actions step summary, preserving line endings."""
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary_path:
         return
@@ -28,12 +31,15 @@ def append_summary(text: str) -> None:
 
 
 def notice(message: str) -> None:
+    """Emit a GitHub Actions notice annotation."""
     print(f"::notice::{message}")
 
 
 def warning(message: str) -> None:
+    """Emit a GitHub Actions warning annotation."""
     print(f"::warning::{message}")
 
 
 def error(message: str) -> None:
+    """Emit a GitHub Actions error annotation."""
     print(f"::error::{message}")

--- a/.github/scripts/oz_workflows/env.py
+++ b/.github/scripts/oz_workflows/env.py
@@ -7,6 +7,7 @@ from typing import Any
 
 
 def require_env(name: str) -> str:
+    """Return a required environment variable after trimming surrounding whitespace."""
     value = os.environ.get(name, "").strip()
     if not value:
         raise RuntimeError(f"Missing required environment variable: {name}")
@@ -14,35 +15,36 @@ def require_env(name: str) -> str:
 
 
 def optional_env(name: str) -> str:
+    """Return an optional environment variable as a trimmed string."""
     return os.environ.get(name, "").strip()
 
 
 def repo_slug() -> str:
+    """Return the current GitHub repository slug."""
     return require_env("GITHUB_REPOSITORY")
 
 
 def repo_parts() -> tuple[str, str]:
+    """Split the current repository slug into owner and repository name."""
     owner, repo = repo_slug().split("/", 1)
     return owner, repo
 
 
 def workspace() -> Path:
+    """Return the workflow workspace directory."""
     return Path(os.environ.get("GITHUB_WORKSPACE") or os.getcwd())
 
 
 def load_event() -> dict[str, Any]:
+    """Load the GitHub Actions event payload JSON."""
     event_path = require_env("GITHUB_EVENT_PATH")
     with open(event_path, "r", encoding="utf-8") as handle:
         return json.load(handle)
 
 
-def read_text_if_exists(path: Path) -> str:
-    if not path.exists():
-        return ""
-    return path.read_text(encoding="utf-8")
-
 
 def parse_mcp_servers(raw_value: str, cwd: Path) -> dict[str, Any] | None:
+    """Parse inline MCP JSON or a JSON file path into a server config object."""
     raw = raw_value.strip()
     if not raw:
         return None
@@ -50,11 +52,6 @@ def parse_mcp_servers(raw_value: str, cwd: Path) -> dict[str, Any] | None:
         candidate_path = Path(raw)
         if not candidate_path.is_absolute():
             candidate_path = cwd / candidate_path
-        try:
-            if candidate_path.is_file():
-                raw = candidate_path.read_text(encoding="utf-8")
-        except OSError:
-            pass
         raw = candidate_path.read_text(encoding="utf-8")
 
     parsed = json.loads(raw)

--- a/.github/scripts/oz_workflows/helpers.py
+++ b/.github/scripts/oz_workflows/helpers.py
@@ -45,6 +45,32 @@ def _label_name(label: Any) -> str:
     return str(_field(label, "name", "") or "")
 
 
+def format_issue_comments_for_prompt(
+    comments: list[Any],
+    *,
+    metadata_prefix: str,
+    exclude_comment_id: int | None = None,
+) -> str:
+    """Format human-visible issue comments for prompt context."""
+    selected = [
+        comment
+        for comment in comments
+        if int(_field(comment, "id") or 0) != exclude_comment_id
+        and metadata_prefix not in str(_field(comment, "body") or "")
+    ]
+    if not selected:
+        return "- None"
+    formatted = []
+    for comment in selected:
+        user = _login(_field(comment, "user")) or "unknown"
+        association = _field(comment, "author_association") or "NONE"
+        body = str(_field(comment, "body") or "").strip() or "(no body)"
+        formatted.append(
+            f"- @{user} [{association}] ({_timestamp_text(_field(comment, 'created_at'))}): {body}"
+        )
+    return "\n".join(formatted)
+
+
 def _list_issue_comments(
     github: Repository | Any,
     owner: str,
@@ -394,6 +420,12 @@ class WorkflowProgressComment:
         if existing:
             self.comment_id = int(_field(existing, "id"))
         return existing
+
+
+def record_run_session_link(progress: WorkflowProgressComment, run: object) -> None:
+    """Record the current Oz session link on a progress comment when available."""
+    session_link = getattr(run, "session_link", None) or ""
+    progress.record_session_link(session_link)
 
 
 # Maps issue label names to conventional commit type prefixes.

--- a/.github/scripts/oz_workflows/oz_client.py
+++ b/.github/scripts/oz_workflows/oz_client.py
@@ -16,10 +16,12 @@ DEFAULT_OZ_ORIGIN_TOKEN_ENV_NAME = "STAGING_ORIGIN_TOKEN"
 
 
 def oz_api_base_url() -> str:
+    """Return the configured Oz API base URL."""
     return optional_env("WARP_API_BASE_URL") or DEFAULT_OZ_API_BASE_URL
 
 
 def oz_origin_token() -> str:
+    """Return the origin token required for Oz API requests."""
     origin_token_env_name = (
         optional_env("WARP_ORIGIN_TOKEN_ENV_NAME") or DEFAULT_OZ_ORIGIN_TOKEN_ENV_NAME
     )
@@ -27,6 +29,7 @@ def oz_origin_token() -> str:
 
 
 def build_oz_client() -> OzAPI:
+    """Build an authenticated Oz SDK client for GitHub Actions workflows."""
     return OzAPI(
         api_key=require_env("WARP_API_KEY"),
         base_url=oz_api_base_url(),
@@ -41,24 +44,11 @@ def build_agent_config(
     *,
     config_name: str,
     workspace: Path,
-    environment_env_name: str = "WARP_ENVIRONMENT_ID",
-    environment_env_names: list[str] | None = None,
 ) -> dict[str, Any]:
-    candidate_env_names = list(environment_env_names or [])
-    if environment_env_name and environment_env_name not in candidate_env_names:
-        candidate_env_names.append(environment_env_name)
-    if "WARP_ENVIRONMENT_ID" not in candidate_env_names:
-        candidate_env_names.append("WARP_ENVIRONMENT_ID")
-    environment_id = ""
-    for env_name in candidate_env_names:
-        value = optional_env(env_name)
-        if value:
-            environment_id = value
-            break
+    """Build the agent configuration payload sent to the Oz API."""
+    environment_id = optional_env("WARP_ENVIRONMENT_ID")
     if not environment_id:
-        raise RuntimeError(
-            f"Missing Oz environment configuration. Set one of: {', '.join(candidate_env_names)}"
-        )
+        raise RuntimeError("Missing Oz environment configuration. Set WARP_ENVIRONMENT_ID")
 
     config: dict[str, Any] = {
         "environment_id": environment_id,
@@ -81,6 +71,7 @@ def build_agent_config(
 
 
 def skill_spec(skill_name: str) -> str:
+    """Resolve a repository-local skill name into a fully qualified skill spec."""
     if ":" in skill_name:
         return skill_name
     skill_path = skill_name
@@ -99,6 +90,7 @@ def run_agent(
     poll_interval_seconds: int = 10,
     timeout_seconds: int = 60 * 60,
 ) -> Any:
+    """Run an Oz agent and poll until it reaches a terminal state."""
     client = build_oz_client()
     request: dict[str, Any] = {
         "prompt": prompt,

--- a/.github/scripts/resolve_review_context.py
+++ b/.github/scripts/resolve_review_context.py
@@ -14,7 +14,6 @@ SLASH_COMMAND_PATTERN = re.compile(
 
 def main() -> None:
     event = load_event()
-    event_name = event.get("event_name") or event.get("action")
     github_event_name = optional_env("GITHUB_EVENT_NAME")
 
     should_review = False

--- a/.github/scripts/respond_to_pr_comment.py
+++ b/.github/scripts/respond_to_pr_comment.py
@@ -13,6 +13,7 @@ from oz_workflows.helpers import (
     build_next_steps_section,
     coauthor_prompt_lines,
     org_member_comments_text,
+    record_run_session_link,
     resolve_coauthor_line,
     resolve_spec_context_for_pr,
     review_thread_comments_text,
@@ -81,7 +82,8 @@ def _handle_issue_comment(
     pr.get_issue_comment(trigger_comment_id).create_reaction("eyes")
     issue_comments = list(pr.get_issue_comments())
     issue_comments_context = org_member_comments_text(
-        issue_comments, exclude_comment_id=trigger_comment_id,
+        issue_comments,
+        exclude_comment_id=trigger_comment_id,
     )
     review_comments = list(pr.get_review_comments())
     review_context = all_review_comments_text(review_comments)
@@ -208,7 +210,7 @@ def _run_implementation(
         skill_name="implement-issue",
         title=f"Respond to PR comment #{pr_number}",
         config=config,
-        on_poll=lambda current_run: _on_poll(progress, current_run),
+        on_poll=lambda current_run: record_run_session_link(progress, current_run),
     )
 
     next_steps_section = build_next_steps_section(
@@ -231,12 +233,6 @@ def _run_implementation(
     progress.complete(
         f"I pushed changes to this PR based on the comment.\n\n{next_steps_section}"
     )
-
-
-def _on_poll(progress: WorkflowProgressComment, run: object) -> None:
-    session_link = getattr(run, "session_link", None) or ""
-    progress.record_session_link(session_link)
-
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/respond_to_triaged_issue_comment.py
+++ b/.github/scripts/respond_to_triaged_issue_comment.py
@@ -9,9 +9,8 @@ from github import Auth, Github
 from oz_workflows.env import load_event, repo_parts, repo_slug, require_env, workspace
 from oz_workflows.helpers import (
     WorkflowProgressComment,
-    _field,
-    _login,
-    _timestamp_text,
+    format_issue_comments_for_prompt,
+    record_run_session_link,
     triggering_comment_prompt_text,
 )
 from oz_workflows.oz_client import build_agent_config, run_agent
@@ -28,24 +27,16 @@ def format_visible_issue_comments(
     *,
     exclude_comment_id: int | None = None,
 ) -> str:
-    selected = [
-        comment
-        for comment in comments
-        if int(_field(comment, "id") or 0) != exclude_comment_id
-        and OZ_AGENT_METADATA_PREFIX not in str(_field(comment, "body") or "")
-    ]
-    if not selected:
-        return "- None"
-    formatted = []
-    for comment in selected:
-        user = _login(_field(comment, "user")) or "unknown"
-        association = _field(comment, "author_association") or "NONE"
-        body = str(_field(comment, "body") or "").strip() or "(no body)"
-        formatted.append(f"- @{user} [{association}] ({_timestamp_text(_field(comment, 'created_at'))}): {body}")
-    return "\n".join(formatted)
+    """Format visible issue comments while filtering Oz-managed metadata comments."""
+    return format_issue_comments_for_prompt(
+        comments,
+        metadata_prefix=OZ_AGENT_METADATA_PREFIX,
+        exclude_comment_id=exclude_comment_id,
+    )
 
 
 def extract_analysis_comment(result: dict[str, Any]) -> str:
+    """Return the normalized inline analysis comment from a transport payload."""
     return str(result.get("analysis_comment") or "").strip()
 
 
@@ -143,7 +134,7 @@ def main() -> None:
             skill_name="triage-issue",
             title=f"Respond to triaged issue comment #{issue_number}",
             config=config,
-            on_poll=lambda current_run: _on_poll(progress, current_run),
+            on_poll=lambda current_run: record_run_session_link(progress, current_run),
         )
         payload, transport_comment_id = poll_for_transport_payload(
             github,
@@ -165,12 +156,6 @@ def main() -> None:
                 "but I don’t have additional analysis to add yet."
             )
         progress.complete(analysis_comment)
-
-
-def _on_poll(progress: WorkflowProgressComment, run: object) -> None:
-    session_link = getattr(run, "session_link", None) or ""
-    progress.record_session_link(session_link)
-
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -6,7 +6,12 @@ from textwrap import dedent
 from github import Auth, Github
 
 from oz_workflows.env import optional_env, repo_parts, repo_slug, require_env, workspace
-from oz_workflows.helpers import is_spec_only_pr, resolve_spec_context_for_pr, WorkflowProgressComment
+from oz_workflows.helpers import (
+    is_spec_only_pr,
+    record_run_session_link,
+    resolve_spec_context_for_pr,
+    WorkflowProgressComment,
+)
 from oz_workflows.oz_client import build_agent_config, run_agent
 from oz_workflows.transport import new_transport_token, poll_for_transport_payload
 
@@ -110,7 +115,7 @@ def main() -> None:
             skill_name=skill_name,
             title=f"PR review #{pr_number}",
             config=config,
-            on_poll=lambda current_run: _on_poll(progress, current_run),
+            on_poll=lambda current_run: record_run_session_link(progress, current_run),
         )
         payload, transport_comment_id = poll_for_transport_payload(
             github,
@@ -149,12 +154,6 @@ def main() -> None:
         else:
             pr.create_review(body=summary or "Automated review by Oz", event="COMMENT")
         progress.complete("I completed the review and posted feedback on this pull request.")
-
-
-def _on_poll(progress: WorkflowProgressComment, run: object) -> None:
-    session_link = getattr(run, "session_link", None) or ""
-    progress.record_session_link(session_link)
-
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/tests/test_oz_client.py
+++ b/.github/scripts/tests/test_oz_client.py
@@ -68,36 +68,21 @@ class SkillSpecTest(unittest.TestCase):
 
 
 class BuildAgentConfigTest(unittest.TestCase):
-    @patch.dict(os.environ, {"WARP_ENVIRONMENT_ID": "legacy-env"}, clear=False)
-    def test_falls_back_to_legacy_environment_variable(self) -> None:
+    @patch.dict(os.environ, {"WARP_ENVIRONMENT_ID": "default-env"}, clear=False)
+    def test_uses_warp_environment_id(self) -> None:
         config = build_agent_config(
             config_name="review-pull-request",
             workspace=Path("/tmp"),
-            environment_env_names=[
-                "WARP_AGENT_REVIEW_ENVIRONMENT_ID",
-                "WARP_AGENT_ENVIRONMENT_ID",
-            ],
         )
-        self.assertEqual(config["environment_id"], "legacy-env")
+        self.assertEqual(config["environment_id"], "default-env")
 
-    @patch.dict(
-        os.environ,
-        {
-            "WARP_ENVIRONMENT_ID": "legacy-env",
-            "WARP_AGENT_ENVIRONMENT_ID": "agent-env",
-        },
-        clear=False,
-    )
-    def test_prefers_explicit_agent_environment_variable(self) -> None:
-        config = build_agent_config(
-            config_name="review-pull-request",
-            workspace=Path("/tmp"),
-            environment_env_names=[
-                "WARP_AGENT_REVIEW_ENVIRONMENT_ID",
-                "WARP_AGENT_ENVIRONMENT_ID",
-            ],
-        )
-        self.assertEqual(config["environment_id"], "agent-env")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_requires_warp_environment_id(self) -> None:
+        with self.assertRaises(RuntimeError):
+            build_agent_config(
+                config_name="review-pull-request",
+                workspace=Path("/tmp"),
+            )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -12,7 +12,13 @@ from github.Repository import Repository
 from oz_workflows.actions import append_summary, warning
 from oz_workflows.env import load_event, optional_env, repo_parts, repo_slug, require_env, workspace
 from oz_workflows.helpers import (
+    _field,
+    _label_name,
+    _login,
+    _timestamp_text,
     build_comment_body,
+    format_issue_comments_for_prompt,
+    record_run_session_link,
     triggering_comment_prompt_text,
     WorkflowProgressComment,
 )
@@ -37,31 +43,8 @@ OZ_AGENT_METADATA_PREFIX = "<!-- oz-agent-metadata:"
 TRIAGE_DISCLAIMER = "*This is an automated analysis by Oz and may be incorrect. A maintainer will verify the details.*"
 
 
-def _field(item: Any, name: str, default: Any = None) -> Any:
-    if isinstance(item, dict):
-        return item.get(name, default)
-    return getattr(item, name, default)
-
-
-def _login(item: Any) -> str:
-    if isinstance(item, dict):
-        return str(item.get("login") or "")
-    return str(getattr(item, "login", "") or "")
-
-
-def _timestamp_text(value: Any) -> str:
-    if isinstance(value, datetime):
-        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-    return str(value or "")
-
-
-def _label_name(label: Any) -> str:
-    if isinstance(label, str):
-        return label
-    return str(_field(label, "name", "") or "")
-
-
 def triage_heuristics_prompt(owner: str, repo: str) -> str:
+    """Return repository-specific triage guidance for the agent prompt."""
     if owner == "warpdotdev" and repo == "Warp":
         return dedent(
             """
@@ -148,6 +131,7 @@ def main() -> None:
 
 
 def resolve_issue_number_override(event_name: str, event: dict[str, Any]) -> str:
+    """Resolve an explicitly requested issue number from the triggering event."""
     if event_name in {"issue_comment", "issues"}:
         issue_number = (event.get("issue") or {}).get("number")
         return str(issue_number or "").strip()
@@ -162,6 +146,7 @@ def resolve_issues_to_triage(
     issue_number_override: str,
     lookback_minutes: int,
 ) -> list[Any]:
+    """Return the issues this workflow run should triage."""
     if issue_number_override:
         issue = github.get_issue(int(issue_number_override))
         return [] if issue.pull_request else [issue]
@@ -189,6 +174,7 @@ def process_issue(
     template_context: dict[str, Any],
     recent_open_issues: list[Any] | None,
 ) -> None:
+    """Run the end-to-end triage flow for a single GitHub issue."""
     issue_number = int(issue.number)
     progress = WorkflowProgressComment(
         github,
@@ -291,9 +277,9 @@ def process_issue(
         skill_name="triage-issue",
         title=f"Triage issue #{issue_number}",
         config=agent_config,
-        on_poll=lambda current_run: _on_poll(progress, current_run),
+        on_poll=lambda current_run: record_run_session_link(progress, current_run),
     )
-    _on_poll(progress, run)
+    record_run_session_link(progress, run)
     payload, transport_comment_id = poll_for_transport_payload(
         github,
         owner,
@@ -351,6 +337,7 @@ def apply_triage_result(
     configured_labels: dict[str, Any],
     repo_labels: dict[str, Any],
 ) -> None:
+    """Apply the structured triage result back onto the GitHub issue."""
     issue_number = int(_field(issue, "number"))
     result_labels = extract_requested_labels(result)
     follow_up_questions = extract_follow_up_questions(result)
@@ -374,13 +361,6 @@ def apply_triage_result(
             )
             managed_labels.append(label_name)
             continue
-        if issue_number <= 0:
-            continue
-        if current_issue_number is not None and issue_number == current_issue_number:
-            continue
-        if issue_number in seen_issue_numbers:
-            continue
-        seen_issue_numbers.add(issue_number)
         if label_name in repo_labels:
             managed_labels.append(label_name)
             continue
@@ -417,6 +397,7 @@ def ensure_label_exists(
     label_name: str,
     label_spec: Any,
 ) -> None:
+    """Create a configured label when the repository does not already have it."""
     if label_name in repo_labels:
         return
     if not isinstance(label_spec, dict):
@@ -433,6 +414,7 @@ def ensure_label_exists(
 
 
 def extract_requested_labels(result: dict[str, Any]) -> list[str]:
+    """Normalize the requested label list from a triage result payload."""
     raw_labels = result.get("labels")
     if not isinstance(raw_labels, list):
         return []
@@ -440,6 +422,7 @@ def extract_requested_labels(result: dict[str, Any]) -> list[str]:
 
 
 def extract_follow_up_questions(result: dict[str, Any]) -> list[str]:
+    """Normalize follow-up questions from a triage result payload."""
     raw_questions = result.get("follow_up_questions")
     if not isinstance(raw_questions, list):
         return []
@@ -487,36 +470,16 @@ def sync_follow_up_comment(
     *,
     questions: list[str],
 ) -> None:
-    issue_number = int(_field(issue, "number"))
-    metadata = follow_up_comment_metadata(issue_number)
-    comments = list(issue.get_comments()) if hasattr(issue, "get_comments") else github.list_issue_comments(owner, repo, issue_number)
-    existing = next(
-        (
-            comment
-            for comment in comments
-            if metadata in str(_field(comment, "body") or "")
-        ),
-        None,
-    )
     if not questions:
         return
-    comment_body = build_follow_up_comment(issue, questions)
-    if existing is None:
-        if hasattr(issue, "create_comment"):
-            issue.create_comment(comment_body)
-        else:
-            github.create_comment(owner, repo, issue_number, comment_body)
-        return
-    if str(_field(existing, "body") or "") != comment_body:
-        if hasattr(existing, "edit"):
-            existing.edit(comment_body)
-        else:
-            github.update_comment(owner, repo, int(_field(existing, "id")), comment_body)
-
-
-def _on_poll(progress: WorkflowProgressComment, run: object) -> None:
-    session_link = getattr(run, "session_link", None) or ""
-    progress.record_session_link(session_link)
+    _sync_managed_issue_comment(
+        github,
+        owner,
+        repo,
+        issue,
+        metadata=follow_up_comment_metadata(int(_field(issue, "number"))),
+        comment_body=build_follow_up_comment(issue, questions),
+    )
 
 
 def extract_duplicate_of(
@@ -595,31 +558,16 @@ def sync_duplicate_comment(
     *,
     duplicates: list[dict[str, Any]],
 ) -> None:
-    issue_number = int(_field(issue, "number"))
-    metadata = duplicate_comment_metadata(issue_number)
-    comments = list(issue.get_comments()) if hasattr(issue, "get_comments") else github.list_issue_comments(owner, repo, issue_number)
-    existing = next(
-        (
-            comment
-            for comment in comments
-            if metadata in str(_field(comment, "body") or "")
-        ),
-        None,
-    )
     if not duplicates:
         return
-    comment_body = build_duplicate_comment(issue, duplicates)
-    if existing is None:
-        if hasattr(issue, "create_comment"):
-            issue.create_comment(comment_body)
-        else:
-            github.create_comment(owner, repo, issue_number, comment_body)
-        return
-    if str(_field(existing, "body") or "") != comment_body:
-        if hasattr(existing, "edit"):
-            existing.edit(comment_body)
-        else:
-            github.update_comment(owner, repo, int(_field(existing, "id")), comment_body)
+    _sync_managed_issue_comment(
+        github,
+        owner,
+        repo,
+        issue,
+        metadata=duplicate_comment_metadata(int(_field(issue, "number"))),
+        comment_body=build_duplicate_comment(issue, duplicates),
+    )
 
 
 def load_recent_issues_for_dedupe(github: Repository) -> list[Any] | None:
@@ -660,21 +608,48 @@ def format_issue_comments(
     *,
     exclude_comment_id: int | None = None,
 ) -> str:
-    selected = [
-        comment
-        for comment in comments
-        if int(_field(comment, "id") or 0) != exclude_comment_id
-        and OZ_AGENT_METADATA_PREFIX not in str(_field(comment, "body") or "")
-    ]
-    if not selected:
-        return "- None"
-    formatted = []
-    for comment in selected:
-        user = _login(_field(comment, "user")) or "unknown"
-        association = _field(comment, "author_association") or "NONE"
-        body = str(_field(comment, "body") or "").strip() or "(no body)"
-        formatted.append(f"- @{user} [{association}] ({_timestamp_text(_field(comment, 'created_at'))}): {body}")
-    return "\n".join(formatted)
+    """Format non-managed issue comments for the triage prompt."""
+    return format_issue_comments_for_prompt(
+        comments,
+        metadata_prefix=OZ_AGENT_METADATA_PREFIX,
+        exclude_comment_id=exclude_comment_id,
+    )
+
+
+def _sync_managed_issue_comment(
+    github: Repository,
+    owner: str,
+    repo: str,
+    issue: Any,
+    *,
+    metadata: str,
+    comment_body: str,
+) -> None:
+    issue_number = int(_field(issue, "number"))
+    comments = (
+        list(issue.get_comments())
+        if hasattr(issue, "get_comments")
+        else github.list_issue_comments(owner, repo, issue_number)
+    )
+    existing = next(
+        (
+            comment
+            for comment in comments
+            if metadata in str(_field(comment, "body") or "")
+        ),
+        None,
+    )
+    if existing is None:
+        if hasattr(issue, "create_comment"):
+            issue.create_comment(comment_body)
+        else:
+            github.create_comment(owner, repo, issue_number, comment_body)
+        return
+    if str(_field(existing, "body") or "") != comment_body:
+        if hasattr(existing, "edit"):
+            existing.edit(comment_body)
+        else:
+            github.update_comment(owner, repo, int(_field(existing, "id")), comment_body)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/update_pr_review.py
+++ b/.github/scripts/update_pr_review.py
@@ -31,10 +31,6 @@ def main() -> None:
     config = build_agent_config(
         config_name="update-pr-review",
         workspace=workspace(),
-        environment_env_names=[
-            "WARP_AGENT_REVIEW_ENVIRONMENT_ID",
-            "WARP_AGENT_ENVIRONMENT_ID",
-        ],
     )
     run_agent(
         prompt=prompt,

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -9,7 +9,24 @@ concurrency:
   cancel-in-progress: false
 jobs:
   create_implementation:
-    if: (github.event_name == 'issues' && github.event.action == 'assigned' && github.event.assignee.login == 'oz-agent' && contains(github.event.issue.labels.*.name, 'ready-to-implement')) || (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'ready-to-implement' && contains(github.event.issue.assignees.*.login, 'oz-agent')) || (github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'ready-to-implement') && contains(github.event.comment.body, '@oz-agent') && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER'))
+    if: >-
+      (
+        github.event_name == 'issues' &&
+        github.event.action == 'assigned' &&
+        github.event.assignee.login == 'oz-agent' &&
+        contains(github.event.issue.labels.*.name, 'ready-to-implement')
+      ) || (
+        github.event_name == 'issues' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'ready-to-implement' &&
+        contains(github.event.issue.assignees.*.login, 'oz-agent')
+      ) || (
+        github.event_name == 'issue_comment' &&
+        !github.event.issue.pull_request &&
+        contains(github.event.issue.labels.*.name, 'ready-to-implement') &&
+        contains(github.event.comment.body, '@oz-agent') &&
+        contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association)
+      )
     name: Create implementation diff
     runs-on: ubuntu-slim
     permissions:
@@ -35,14 +52,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Resolve staging origin token
+        id: staging_origin_token
         run: |
-          STAGING_ORIGIN_TOKEN="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          echo "::add-mask::$STAGING_ORIGIN_TOKEN"
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
           {
-            echo 'STAGING_ORIGIN_TOKEN<<EOF'
-            printf '%s\n' "$STAGING_ORIGIN_TOKEN"
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -59,4 +77,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python .github/scripts/create_implementation_from_issue.py

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -9,7 +9,24 @@ concurrency:
   cancel-in-progress: false
 jobs:
   create_spec:
-    if: (github.event_name == 'issues' && github.event.action == 'assigned' && github.event.assignee.login == 'oz-agent' && contains(github.event.issue.labels.*.name, 'ready-to-spec')) || (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'ready-to-spec' && contains(github.event.issue.assignees.*.login, 'oz-agent')) || (github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'ready-to-spec') && contains(github.event.comment.body, '@oz-agent') && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER'))
+    if: >-
+      (
+        github.event_name == 'issues' &&
+        github.event.action == 'assigned' &&
+        github.event.assignee.login == 'oz-agent' &&
+        contains(github.event.issue.labels.*.name, 'ready-to-spec')
+      ) || (
+        github.event_name == 'issues' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'ready-to-spec' &&
+        contains(github.event.issue.assignees.*.login, 'oz-agent')
+      ) || (
+        github.event_name == 'issue_comment' &&
+        !github.event.issue.pull_request &&
+        contains(github.event.issue.labels.*.name, 'ready-to-spec') &&
+        contains(github.event.comment.body, '@oz-agent') &&
+        contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association)
+      )
     name: Create spec diff
     runs-on: ubuntu-slim
     permissions:
@@ -35,14 +52,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Resolve staging origin token
+        id: staging_origin_token
         run: |
-          STAGING_ORIGIN_TOKEN="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          echo "::add-mask::$STAGING_ORIGIN_TOKEN"
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
           {
-            echo 'STAGING_ORIGIN_TOKEN<<EOF'
-            printf '%s\n' "$STAGING_ORIGIN_TOKEN"
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -59,4 +77,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python .github/scripts/create_spec_from_issue.py

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -49,14 +49,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Resolve staging origin token
+        id: staging_origin_token
         run: |
-          STAGING_ORIGIN_TOKEN="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          echo "::add-mask::$STAGING_ORIGIN_TOKEN"
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
           {
-            echo 'STAGING_ORIGIN_TOKEN<<EOF'
-            printf '%s\n' "$STAGING_ORIGIN_TOKEN"
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -76,4 +77,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python .github/scripts/enforce_pr_issue_state.py

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -11,7 +11,7 @@ jobs:
   respond:
     if: >-
       contains(github.event.comment.body, '@oz-agent') &&
-      (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') &&
+      contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association) &&
       github.event.comment.user.login != 'github-actions[bot]' &&
       (github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request))
     name: Respond to PR comment
@@ -39,14 +39,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Resolve staging origin token
+        id: staging_origin_token
         run: |
-          STAGING_ORIGIN_TOKEN="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          echo "::add-mask::$STAGING_ORIGIN_TOKEN"
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
           {
-            echo 'STAGING_ORIGIN_TOKEN<<EOF'
-            printf '%s\n' "$STAGING_ORIGIN_TOKEN"
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -63,4 +64,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python .github/scripts/respond_to_pr_comment.py

--- a/.github/workflows/respond-to-triaged-issue-comment.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment.yml
@@ -7,7 +7,13 @@ concurrency:
   cancel-in-progress: false
 jobs:
   respond_inline:
-    if: github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '@oz-agent') && contains(github.event.issue.labels.*.name, 'triaged') && !contains(github.event.issue.labels.*.name, 'ready-to-spec') && !contains(github.event.issue.labels.*.name, 'ready-to-implement')
+    if: >-
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@oz-agent') &&
+      contains(github.event.issue.labels.*.name, 'triaged') &&
+      !contains(github.event.issue.labels.*.name, 'ready-to-spec') &&
+      !contains(github.event.issue.labels.*.name, 'ready-to-implement')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -31,14 +37,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Resolve staging origin token
+        id: staging_origin_token
         run: |
-          STAGING_ORIGIN_TOKEN="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          echo "::add-mask::$STAGING_ORIGIN_TOKEN"
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
           {
-            echo 'STAGING_ORIGIN_TOKEN<<EOF'
-            printf '%s\n' "$STAGING_ORIGIN_TOKEN"
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -55,4 +62,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python .github/scripts/respond_to_triaged_issue_comment.py

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -37,8 +37,6 @@ jobs:
     runs-on: ubuntu-slim
     env:
       WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-      WARP_AGENT_ENVIRONMENT_ID: ${{ vars.WARP_AGENT_ENVIRONMENT_ID || vars.WARP_ENVIRONMENT_ID || '' }}
-      WARP_AGENT_REVIEW_ENVIRONMENT_ID: ${{ vars.WARP_AGENT_REVIEW_ENVIRONMENT_ID || '' }}
     permissions:
       contents: read
       id-token: write
@@ -60,14 +58,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Resolve staging origin token
+        id: staging_origin_token
         run: |
-          STAGING_ORIGIN_TOKEN="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          echo "::add-mask::$STAGING_ORIGIN_TOKEN"
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
           {
-            echo 'STAGING_ORIGIN_TOKEN<<EOF'
-            printf '%s\n' "$STAGING_ORIGIN_TOKEN"
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -88,4 +87,5 @@ jobs:
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python .github/scripts/review_pr.py

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -68,14 +68,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Resolve staging origin token
+        id: staging_origin_token
         run: |
-          STAGING_ORIGIN_TOKEN="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          echo "::add-mask::$STAGING_ORIGIN_TOKEN"
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
           {
-            echo 'STAGING_ORIGIN_TOKEN<<EOF'
-            printf '%s\n' "$STAGING_ORIGIN_TOKEN"
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -94,4 +95,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python .github/scripts/triage_new_issues.py

--- a/.github/workflows/update-pr-review.yml
+++ b/.github/workflows/update-pr-review.yml
@@ -32,14 +32,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Resolve staging origin token
+        id: staging_origin_token
         run: |
-          STAGING_ORIGIN_TOKEN="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          echo "::add-mask::$STAGING_ORIGIN_TOKEN"
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
           {
-            echo 'STAGING_ORIGIN_TOKEN<<EOF'
-            printf '%s\n' "$STAGING_ORIGIN_TOKEN"
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -56,6 +57,6 @@ jobs:
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
-          WARP_AGENT_ENVIRONMENT_ID: ${{ vars.WARP_AGENT_ENVIRONMENT_ID || '' }}
-          WARP_AGENT_REVIEW_ENVIRONMENT_ID: ${{ vars.WARP_AGENT_REVIEW_ENVIRONMENT_ID || '' }}
+          WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python .github/scripts/update_pr_review.py


### PR DESCRIPTION
## Summary
- simplify the Python workflow helpers by removing unused code and consolidating repeated comment/session-link logic
- remove auxiliary Oz environment variable fallbacks and clean up workflow conditionals
- route staging origin token handling through step outputs and reduce unnecessary token exposure in the resolver step

## Validation
- python3 -m compileall .github/scripts
- env PYTHONPATH=/Users/captainsafia/repos/oz-for-oss/.github/scripts python3 -m unittest discover -s /Users/captainsafia/repos/oz-for-oss/.github/scripts/tests

Conversation: https://staging.warp.dev/conversation/e037b054-b9d0-4fee-b753-3d247100456f

Co-Authored-By: Oz <oz-agent@warp.dev>
