### PR TITLE
refactor: make oz workflows reusable across repos

### DIFF
--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -471,6 +471,21 @@ def sync_follow_up_comment(
     questions: list[str],
 ) -> None:
     if not questions:
+        issue_number = int(_field(issue, "number"))
+        metadata = follow_up_comment_metadata(issue_number)
+        comments = (
+            list(issue.get_comments())
+            if hasattr(issue, "get_comments")
+            else github.list_issue_comments(owner, repo, issue_number)
+        )
+        existing = next(
+            (
+                comment
+                for comment in comments
+                if metadata in str(_field(comment, "body") or "")
+            ),
+            None,
+        )
         if existing is not None:
             if hasattr(existing, "delete"):
                 existing.delete()

--- a/.github/workflows/comment-on-unready-assigned-issue.yml
+++ b/.github/workflows/comment-on-unready-assigned-issue.yml
@@ -1,14 +1,25 @@
 name: Comment on Unready Assigned Issue
 on:
   workflow_call:
+    inputs:
+      _skip_event_filter:
+        description: Bypass event-based job conditions (set automatically for workflow_call)
+        required: false
+        default: 'true'
+        type: string
+    secrets:
+      OZ_MGMT_GHA_APP_ID:
+        required: true
+      OZ_MGMT_GHA_PRIVATE_KEY:
+        required: true
   issues:
     types: [assigned]
 concurrency:
-  group: comment-on-unready-assigned-issue-${{ github.event.issue.number }}
+  group: comment-on-unready-assigned-issue-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 jobs:
   comment_when_unready:
-    if: github.event_name == 'workflow_call' || (github.event.assignee.login == 'oz-agent' && !contains(github.event.issue.labels.*.name, 'ready-to-spec') && !contains(github.event.issue.labels.*.name, 'ready-to-implement'))
+    if: inputs._skip_event_filter == 'true' || (github.event.assignee.login == 'oz-agent' && !contains(github.event.issue.labels.*.name, 'ready-to-spec') && !contains(github.event.issue.labels.*.name, 'ready-to-implement'))
     runs-on: ubuntu-slim
     permissions:
       issues: write

--- a/.github/workflows/comment-on-unready-assigned-issue.yml
+++ b/.github/workflows/comment-on-unready-assigned-issue.yml
@@ -1,5 +1,6 @@
 name: Comment on Unready Assigned Issue
 on:
+  workflow_call:
   issues:
     types: [assigned]
 concurrency:
@@ -7,10 +8,14 @@ concurrency:
   cancel-in-progress: false
 jobs:
   comment_when_unready:
-    if: github.event.assignee.login == 'oz-agent' && !contains(github.event.issue.labels.*.name, 'ready-to-spec') && !contains(github.event.issue.labels.*.name, 'ready-to-implement')
+    if: github.event_name == 'workflow_call' || (github.event.assignee.login == 'oz-agent' && !contains(github.event.issue.labels.*.name, 'ready-to-spec') && !contains(github.event.issue.labels.*.name, 'ready-to-implement'))
     runs-on: ubuntu-slim
     permissions:
       issues: write
+    env:
+      WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
+      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token
         id: app_token
@@ -20,6 +25,13 @@ jobs:
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Checkout workflow code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
+          ref: ${{ env.WORKFLOW_CODE_REF }}
+          path: ${{ env.WORKFLOW_CODE_PATH }}
+          token: ${{ steps.app_token.outputs.token }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -27,9 +39,9 @@ jobs:
       - name: Install Python workflow dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r .github/scripts/requirements.txt
+          python -m pip install -r "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/requirements.txt"
       - name: Run unready-assignment workflow
         env:
-          PYTHONPATH: .github/scripts
+          PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
-        run: python .github/scripts/comment_on_unready_assigned_issue.py
+        run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/comment_on_unready_assigned_issue.py"

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -1,5 +1,6 @@
 name: Create Implementation from Issue
 on:
+  workflow_call:
   issues:
     types: [assigned, labeled]
   issue_comment:
@@ -10,7 +11,7 @@ concurrency:
 jobs:
   create_implementation:
     if: >-
-      (
+      github.event_name == 'workflow_call' || (
         github.event_name == 'issues' &&
         github.event.action == 'assigned' &&
         github.event.assignee.login == 'oz-agent' &&
@@ -34,6 +35,10 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    env:
+      WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
+      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token
         id: app_token
@@ -45,6 +50,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Checkout workflow code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
+          ref: ${{ env.WORKFLOW_CODE_REF }}
+          path: ${{ env.WORKFLOW_CODE_PATH }}
+          token: ${{ steps.app_token.outputs.token }}
       - name: Authenticate to Google Cloud for staging secret access
         uses: google-github-actions/auth@v2
         with:
@@ -68,14 +80,14 @@ jobs:
       - name: Install Python workflow dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r .github/scripts/requirements.txt
+          python -m pip install -r "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/requirements.txt"
       - name: Run create-implementation workflow
         env:
-          PYTHONPATH: .github/scripts
+          PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
           STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
-        run: python .github/scripts/create_implementation_from_issue.py
+        run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/create_implementation_from_issue.py"

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -1,17 +1,30 @@
 name: Create Implementation from Issue
 on:
   workflow_call:
+    inputs:
+      _skip_event_filter:
+        description: Bypass event-based job conditions (set automatically for workflow_call)
+        required: false
+        default: 'true'
+        type: string
+    secrets:
+      OZ_MGMT_GHA_APP_ID:
+        required: true
+      OZ_MGMT_GHA_PRIVATE_KEY:
+        required: true
+      WARP_API_KEY:
+        required: true
   issues:
     types: [assigned, labeled]
   issue_comment:
     types: [created]
 concurrency:
-  group: create-implementation-issue-${{ github.event.issue.number }}
+  group: create-implementation-issue-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 jobs:
   create_implementation:
     if: >-
-      github.event_name == 'workflow_call' || (
+      inputs._skip_event_filter == 'true' || (
         github.event_name == 'issues' &&
         github.event.action == 'assigned' &&
         github.event.assignee.login == 'oz-agent' &&

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -1,17 +1,30 @@
 name: Create Spec from Issue
 on:
   workflow_call:
+    inputs:
+      _skip_event_filter:
+        description: Bypass event-based job conditions (set automatically for workflow_call)
+        required: false
+        default: 'true'
+        type: string
+    secrets:
+      OZ_MGMT_GHA_APP_ID:
+        required: true
+      OZ_MGMT_GHA_PRIVATE_KEY:
+        required: true
+      WARP_API_KEY:
+        required: true
   issues:
     types: [assigned, labeled]
   issue_comment:
     types: [created]
 concurrency:
-  group: create-spec-issue-${{ github.event.issue.number }}
+  group: create-spec-issue-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 jobs:
   create_spec:
     if: >-
-      github.event_name == 'workflow_call' || (
+      inputs._skip_event_filter == 'true' || (
         github.event_name == 'issues' &&
         github.event.action == 'assigned' &&
         github.event.assignee.login == 'oz-agent' &&

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -1,5 +1,6 @@
 name: Create Spec from Issue
 on:
+  workflow_call:
   issues:
     types: [assigned, labeled]
   issue_comment:
@@ -10,7 +11,7 @@ concurrency:
 jobs:
   create_spec:
     if: >-
-      (
+      github.event_name == 'workflow_call' || (
         github.event_name == 'issues' &&
         github.event.action == 'assigned' &&
         github.event.assignee.login == 'oz-agent' &&
@@ -34,6 +35,10 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    env:
+      WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
+      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token
         id: app_token
@@ -45,6 +50,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Checkout workflow code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
+          ref: ${{ env.WORKFLOW_CODE_REF }}
+          path: ${{ env.WORKFLOW_CODE_PATH }}
+          token: ${{ steps.app_token.outputs.token }}
       - name: Authenticate to Google Cloud for staging secret access
         uses: google-github-actions/auth@v2
         with:
@@ -68,14 +80,14 @@ jobs:
       - name: Install Python workflow dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r .github/scripts/requirements.txt
+          python -m pip install -r "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/requirements.txt"
       - name: Run create-spec workflow
         env:
-          PYTHONPATH: .github/scripts
+          PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
           STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
-        run: python .github/scripts/create_spec_from_issue.py
+        run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/create_spec_from_issue.py"

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -26,6 +26,10 @@ jobs:
   enforce_issue_state:
     name: Enforce PR issue state
     runs-on: ubuntu-slim
+    env:
+      WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
+      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: read
       id-token: write
@@ -42,6 +46,13 @@ jobs:
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Checkout workflow code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
+          ref: ${{ env.WORKFLOW_CODE_REF }}
+          path: ${{ env.WORKFLOW_CODE_PATH }}
+          token: ${{ steps.app_token.outputs.token }}
       - name: Authenticate to Google Cloud for staging secret access
         uses: google-github-actions/auth@v2
         with:
@@ -65,11 +76,11 @@ jobs:
       - name: Install Python workflow dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r .github/scripts/requirements.txt
+          python -m pip install -r "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/requirements.txt"
       - name: Run PR issue-state enforcement
         id: run_enforcement
         env:
-          PYTHONPATH: .github/scripts
+          PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           REQUESTER: ${{ inputs.requester }}
@@ -78,4 +89,4 @@ jobs:
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
           STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
-        run: python .github/scripts/enforce_pr_issue_state.py
+        run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/enforce_pr_issue_state.py"

--- a/.github/workflows/respond-to-triaged-issue-comment.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment.yml
@@ -1,5 +1,6 @@
 name: Respond to Triaged Issue Comment
 on:
+  workflow_call:
   issue_comment:
     types: [created]
 concurrency:
@@ -8,17 +9,23 @@ concurrency:
 jobs:
   respond_inline:
     if: >-
-      github.event_name == 'issue_comment' &&
-      !github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@oz-agent') &&
-      contains(github.event.issue.labels.*.name, 'triaged') &&
-      !contains(github.event.issue.labels.*.name, 'ready-to-spec') &&
-      !contains(github.event.issue.labels.*.name, 'ready-to-implement')
+      github.event_name == 'workflow_call' || (
+        github.event_name == 'issue_comment' &&
+        !github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@oz-agent') &&
+        contains(github.event.issue.labels.*.name, 'triaged') &&
+        !contains(github.event.issue.labels.*.name, 'ready-to-spec') &&
+        !contains(github.event.issue.labels.*.name, 'ready-to-implement')
+      )
     runs-on: ubuntu-slim
     permissions:
       contents: read
       id-token: write
       issues: write
+    env:
+      WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
+      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token
         id: app_token
@@ -30,6 +37,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Checkout workflow code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
+          ref: ${{ env.WORKFLOW_CODE_REF }}
+          path: ${{ env.WORKFLOW_CODE_PATH }}
+          token: ${{ steps.app_token.outputs.token }}
       - name: Authenticate to Google Cloud for staging secret access
         uses: google-github-actions/auth@v2
         with:
@@ -53,14 +67,14 @@ jobs:
       - name: Install Python workflow dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r .github/scripts/requirements.txt
+          python -m pip install -r "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/requirements.txt"
       - name: Run inline issue response workflow
         env:
-          PYTHONPATH: .github/scripts
+          PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
           STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
-        run: python .github/scripts/respond_to_triaged_issue_comment.py
+        run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/respond_to_triaged_issue_comment.py"

--- a/.github/workflows/respond-to-triaged-issue-comment.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment.yml
@@ -1,6 +1,19 @@
 name: Respond to Triaged Issue Comment
 on:
   workflow_call:
+    inputs:
+      _skip_event_filter:
+        description: Bypass event-based job conditions (set automatically for workflow_call)
+        required: false
+        default: 'true'
+        type: string
+    secrets:
+      OZ_MGMT_GHA_APP_ID:
+        required: true
+      OZ_MGMT_GHA_PRIVATE_KEY:
+        required: true
+      WARP_API_KEY:
+        required: true
   issue_comment:
     types: [created]
 concurrency:
@@ -9,7 +22,7 @@ concurrency:
 jobs:
   respond_inline:
     if: >-
-      github.event_name == 'workflow_call' || (
+      inputs._skip_event_filter == 'true' || (
         github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
         contains(github.event.comment.body, '@oz-agent') &&

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -37,6 +37,9 @@ jobs:
     runs-on: ubuntu-slim
     env:
       WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
+      WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
+      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: read
       id-token: write
@@ -51,6 +54,13 @@ jobs:
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Checkout workflow code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
+          ref: ${{ env.WORKFLOW_CODE_REF }}
+          path: ${{ env.WORKFLOW_CODE_PATH }}
+          token: ${{ steps.app_token.outputs.token }}
       - name: Authenticate to Google Cloud for staging secret access
         uses: google-github-actions/auth@v2
         with:
@@ -74,10 +84,10 @@ jobs:
       - name: Install Python workflow dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r .github/scripts/requirements.txt
+          python -m pip install -r "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/requirements.txt"
       - name: Run PR review workflow
         env:
-          PYTHONPATH: .github/scripts
+          PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           TRIGGER_SOURCE: ${{ inputs.trigger_source }}
@@ -88,4 +98,4 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
-        run: python .github/scripts/review_pr.py
+        run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/review_pr.py"

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -2,6 +2,11 @@ name: Triage New Issues
 on:
   workflow_call:
     inputs:
+      _skip_event_filter:
+        description: Bypass event-based job conditions (set automatically for workflow_call)
+        required: false
+        default: 'true'
+        type: string
       issue_number:
         description: Optional issue number to triage immediately
         required: false
@@ -12,6 +17,13 @@ on:
         required: false
         default: '60'
         type: string
+    secrets:
+      OZ_MGMT_GHA_APP_ID:
+        required: true
+      OZ_MGMT_GHA_PRIVATE_KEY:
+        required: true
+      WARP_API_KEY:
+        required: true
   issues:
     types: [opened]
   schedule:
@@ -36,7 +48,7 @@ concurrency:
 jobs:
   triage_issues:
     if: |
-      github.event_name == 'workflow_call' || (
+      inputs._skip_event_filter == 'true' || (
         github.event_name != 'issue_comment' &&
         !contains(github.event.issue.labels.*.name, 'triaged')
       ) || (

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -1,5 +1,17 @@
 name: Triage New Issues
 on:
+  workflow_call:
+    inputs:
+      issue_number:
+        description: Optional issue number to triage immediately
+        required: false
+        default: ''
+        type: string
+      lookback_minutes:
+        description: Minutes of issue history to scan when no issue number is provided
+        required: false
+        default: '60'
+        type: string
   issues:
     types: [opened]
   schedule:
@@ -24,7 +36,7 @@ concurrency:
 jobs:
   triage_issues:
     if: |
-      (
+      github.event_name == 'workflow_call' || (
         github.event_name != 'issue_comment' &&
         !contains(github.event.issue.labels.*.name, 'triaged')
       ) || (
@@ -50,6 +62,10 @@ jobs:
       contents: read
       id-token: write
       issues: write
+    env:
+      WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
+      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token
         id: app_token
@@ -61,6 +77,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Checkout workflow code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
+          ref: ${{ env.WORKFLOW_CODE_REF }}
+          path: ${{ env.WORKFLOW_CODE_PATH }}
+          token: ${{ steps.app_token.outputs.token }}
       - name: Authenticate to Google Cloud for staging secret access
         uses: google-github-actions/auth@v2
         with:
@@ -84,16 +107,16 @@ jobs:
       - name: Install Python workflow dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r .github/scripts/requirements.txt
+          python -m pip install -r "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/requirements.txt"
       - name: Run issue triage workflow
         env:
-          PYTHONPATH: .github/scripts
+          PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          LOOKBACK_MINUTES: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.lookback_minutes || '60' }}
-          TRIAGE_ISSUE_NUMBER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.issue_number || '' }}
+          LOOKBACK_MINUTES: ${{ inputs.lookback_minutes || github.event.inputs.lookback_minutes || '60' }}
+          TRIAGE_ISSUE_NUMBER: ${{ inputs.issue_number || github.event.inputs.issue_number || '' }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
           STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
-        run: python .github/scripts/triage_new_issues.py
+        run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/triage_new_issues.py"

--- a/.github/workflows/update-pr-review.yml
+++ b/.github/workflows/update-pr-review.yml
@@ -7,6 +7,13 @@ on:
         required: false
         default: '7'
         type: string
+    secrets:
+      OZ_MGMT_GHA_APP_ID:
+        required: true
+      OZ_MGMT_GHA_PRIVATE_KEY:
+        required: true
+      WARP_API_KEY:
+        required: true
   schedule:
     - cron: '0 9 * * 1'  # Every Monday at 09:00 UTC
   workflow_dispatch:

--- a/.github/workflows/update-pr-review.yml
+++ b/.github/workflows/update-pr-review.yml
@@ -1,5 +1,12 @@
 name: Update PR Review Skill
 on:
+  workflow_call:
+    inputs:
+      lookback_days:
+        description: Number of days to look back for PR feedback
+        required: false
+        default: '7'
+        type: string
   schedule:
     - cron: '0 9 * * 1'  # Every Monday at 09:00 UTC
   workflow_dispatch:
@@ -16,6 +23,10 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    env:
+      WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
+      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token
         id: app_token
@@ -25,6 +36,13 @@ jobs:
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Checkout workflow code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
+          ref: ${{ env.WORKFLOW_CODE_REF }}
+          path: ${{ env.WORKFLOW_CODE_PATH }}
+          token: ${{ steps.app_token.outputs.token }}
       - name: Authenticate to Google Cloud for staging secret access
         uses: google-github-actions/auth@v2
         with:
@@ -48,10 +66,10 @@ jobs:
       - name: Install Python workflow dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r .github/scripts/requirements.txt
+          python -m pip install -r "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/requirements.txt"
       - name: Run update PR review workflow
         env:
-          PYTHONPATH: .github/scripts
+          PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           LOOKBACK_DAYS: ${{ inputs.lookback_days || '7' }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
@@ -59,4 +77,4 @@ jobs:
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
           STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
-        run: python .github/scripts/update_pr_review.py
+        run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/update_pr_review.py"


### PR DESCRIPTION
## Summary
- convert the shared Oz GitHub Actions workflows into reusable workflows that can be called from other repositories
- keep the shared Python/scripts sourced from `oz-for-oss`, using `github.sha` for local runs and `main` for external callers
- remove the need for per-caller workflow-code configuration in the shared workflows

## Context
- Conversation: https://staging.warp.dev/conversation/7188157a-664e-493c-9f4f-02f10df35853

Co-Authored-By: Oz <oz-agent@warp.dev>