### PR TITLE
feat: prefer consuming repo skill overrides with fallback

### DIFF
--- a/.github/scripts/create_implementation_from_issue.py
+++ b/.github/scripts/create_implementation_from_issue.py
@@ -20,11 +20,11 @@ from oz_workflows.helpers import (
     triggering_comment_prompt_text,
     WorkflowProgressComment,
 )
-from oz_workflows.oz_client import build_agent_config, run_agent
+from oz_workflows.oz_client import build_agent_config, run_agent, skill_file_path
 
 IMPLEMENT_SPECS_SKILL = "implement-specs"
-IMPLEMENT_SPECS_SKILL_PATH = ".agents/skills/implement-specs/SKILL.md"
-SPEC_DRIVEN_IMPLEMENTATION_SKILL_PATH = ".agents/skills/spec-driven-implementation/SKILL.md"
+SPEC_DRIVEN_IMPLEMENTATION_SKILL = "spec-driven-implementation"
+IMPLEMENT_ISSUE_SKILL = "implement-issue"
 
 
 def main() -> None:
@@ -99,6 +99,11 @@ def main() -> None:
 
         coauthor_line = resolve_coauthor_line(client, event)
         coauthor_directives = coauthor_prompt_lines(coauthor_line)
+        implement_specs_skill_path = skill_file_path(IMPLEMENT_SPECS_SKILL)
+        spec_driven_implementation_skill_path = skill_file_path(
+            SPEC_DRIVEN_IMPLEMENTATION_SKILL
+        )
+        implement_issue_skill_path = skill_file_path(IMPLEMENT_ISSUE_SKILL)
 
         prompt = dedent(
             f"""
@@ -120,8 +125,8 @@ def main() -> None:
             {spec_context_text}
 
             Cloud Workflow Requirements:
-            - Use the local shared skills `{IMPLEMENT_SPECS_SKILL_PATH}` and `{SPEC_DRIVEN_IMPLEMENTATION_SKILL_PATH}` as the base workflow for this run.
-            - Read `.agents/skills/implement-issue/SKILL.md` and apply its Oz-specific wrapper instructions for `spec_context.md`, `issue_comments.txt`, and `implementation_summary.md`.
+            - Use the shared implementation skills `{implement_specs_skill_path}` and `{spec_driven_implementation_skill_path}` as the base workflow for this run. Prefer the consuming repository's versions when present; otherwise use the checked-in oz-for-oss copies.
+            - Read the Oz wrapper skill `{implement_issue_skill_path}` and apply its instructions for `spec_context.md`, `issue_comments.txt`, and `implementation_summary.md`.
             - You are running in a cloud environment, so the caller cannot read your local diff.
             - Work on branch `{target_branch}`.
             - If that branch already exists, fetch it and continue from it. Otherwise create it from `{default_branch}`.

--- a/.github/scripts/create_spec_from_issue.py
+++ b/.github/scripts/create_spec_from_issue.py
@@ -18,12 +18,13 @@ from oz_workflows.helpers import (
     triggering_comment_prompt_text,
     WorkflowProgressComment,
 )
-from oz_workflows.oz_client import build_agent_config, run_agent
+from oz_workflows.oz_client import build_agent_config, run_agent, skill_file_path
 
 SPEC_DRIVEN_IMPLEMENTATION_SKILL = "spec-driven-implementation"
-SPEC_DRIVEN_IMPLEMENTATION_SKILL_PATH = ".agents/skills/spec-driven-implementation/SKILL.md"
-WRITE_PRODUCT_SPEC_SKILL_PATH = ".agents/skills/write-product-spec/SKILL.md"
-WRITE_TECH_SPEC_SKILL_PATH = ".agents/skills/write-tech-spec/SKILL.md"
+WRITE_PRODUCT_SPEC_SKILL = "write-product-spec"
+WRITE_TECH_SPEC_SKILL = "write-tech-spec"
+CREATE_PRODUCT_SPEC_SKILL = "create-product-spec"
+CREATE_TECH_SPEC_SKILL = "create-tech-spec"
 
 
 def main() -> None:
@@ -53,6 +54,13 @@ def main() -> None:
         progress.start("Oz is starting work on product and tech specs for this issue.")
         coauthor_line = resolve_coauthor_line(client, event)
         coauthor_directives = coauthor_prompt_lines(coauthor_line)
+        spec_driven_implementation_skill_path = skill_file_path(
+            SPEC_DRIVEN_IMPLEMENTATION_SKILL
+        )
+        write_product_spec_skill_path = skill_file_path(WRITE_PRODUCT_SPEC_SKILL)
+        write_tech_spec_skill_path = skill_file_path(WRITE_TECH_SPEC_SKILL)
+        create_product_spec_skill_path = skill_file_path(CREATE_PRODUCT_SPEC_SKILL)
+        create_tech_spec_skill_path = skill_file_path(CREATE_TECH_SPEC_SKILL)
 
         prompt = dedent(
             f"""
@@ -73,9 +81,9 @@ def main() -> None:
             Cloud Workflow Requirements:
             - You are running in a cloud environment, so the caller cannot read your local diff.
             - Start from the repository default branch `{default_branch}`.
-            - Use the local shared skill `{SPEC_DRIVEN_IMPLEMENTATION_SKILL_PATH}` as the base spec-first workflow for this run.
-            - First, read the local shared skill `{WRITE_PRODUCT_SPEC_SKILL_PATH}`, then read `.agents/skills/create-product-spec/SKILL.md` for the Oz-specific wrapper instructions, and create a product spec at `specs/issue-{issue_number}/product.md`.
-            - Then, read the local shared skill `{WRITE_TECH_SPEC_SKILL_PATH}`, then read `.agents/skills/create-tech-spec/SKILL.md` for the Oz-specific wrapper instructions, and create a tech spec at `specs/issue-{issue_number}/tech.md`.
+            - Use the shared spec-first skill `{spec_driven_implementation_skill_path}` as the base workflow for this run. Prefer the consuming repository's version when present; otherwise use the checked-in oz-for-oss copy.
+            - First, read the shared product-spec skill `{write_product_spec_skill_path}`, then read the Oz wrapper skill `{create_product_spec_skill_path}`, and create a product spec at `specs/issue-{issue_number}/product.md`.
+            - Then, read the shared tech-spec skill `{write_tech_spec_skill_path}`, then read the Oz wrapper skill `{create_tech_spec_skill_path}`, and create a tech spec at `specs/issue-{issue_number}/tech.md`.
             - If you produce spec changes, commit only the spec changes to branch `{branch_name}` and push that branch to origin.
             - Do not open or update the pull request yourself.
             - If there is no worthwhile spec diff, do not push the branch.

--- a/.github/scripts/oz_workflows/oz_client.py
+++ b/.github/scripts/oz_workflows/oz_client.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 from oz_agent_sdk import OzAPI
 
 from .actions import notice, warning
-from .env import optional_env, parse_mcp_servers, repo_slug, require_env
+from .env import optional_env, parse_mcp_servers, repo_slug, require_env, workspace
 
 
 TERMINAL_STATES = {"SUCCEEDED", "FAILED", "ERROR", "CANCELLED"}
@@ -70,14 +70,70 @@ def build_agent_config(
     return config
 
 
+def _normalize_skill_path(skill_name: str) -> str:
+    """Normalize a short skill name into a repository-relative skill path."""
+    if skill_name.endswith("SKILL.md"):
+        return skill_name
+    return f".agents/skills/{skill_name}/SKILL.md"
+
+
+def _workflow_code_root() -> Path:
+    """Return the checked-out workflow code root when available."""
+    configured_path = optional_env("WORKFLOW_CODE_PATH")
+    if configured_path:
+        root = Path(configured_path)
+        if not root.is_absolute():
+            root = workspace() / root
+        return root
+    return Path(__file__).resolve().parents[3]
+
+
+def _resolve_skill_location(skill_name: str) -> tuple[str, str, Path]:
+    """Resolve a skill to the repo slug, relative path, and on-disk file location."""
+    if ":" in skill_name:
+        repo, skill_path = skill_name.split(":", 1)
+        return repo, skill_path, Path(skill_path)
+
+    skill_path = _normalize_skill_path(skill_name)
+    consumer_repo_slug = repo_slug()
+    consumer_repo_root = workspace()
+    workflow_repo_root = _workflow_code_root()
+    workflow_repo_slug = optional_env("WORKFLOW_CODE_REPOSITORY") or consumer_repo_slug
+
+    candidates = [(consumer_repo_slug, consumer_repo_root)]
+    if (workflow_repo_slug, workflow_repo_root) != (consumer_repo_slug, consumer_repo_root):
+        candidates.append((workflow_repo_slug, workflow_repo_root))
+
+    for candidate_repo_slug, candidate_root in candidates:
+        candidate_path = candidate_root / skill_path
+        if candidate_path.is_file():
+            return candidate_repo_slug, skill_path, candidate_path
+
+    checked_locations = ", ".join(
+        str(candidate_root / skill_path) for _candidate_repo_slug, candidate_root in candidates
+    )
+    raise RuntimeError(
+        f"Unable to resolve skill {skill_name!r}. Checked: {checked_locations}"
+    )
+
+
+def skill_file_path(skill_name: str) -> str:
+    """Resolve a skill to the workspace-relative file path that the agent should read."""
+    _repo_slug, skill_path, resolved_path = _resolve_skill_location(skill_name)
+    if ":" in skill_name:
+        return skill_path
+    try:
+        return resolved_path.relative_to(workspace()).as_posix()
+    except ValueError:
+        return resolved_path.as_posix()
+
+
 def skill_spec(skill_name: str) -> str:
-    """Resolve a repository-local skill name into a fully qualified skill spec."""
+    """Resolve a skill name into a fully qualified spec, preferring consumer repo overrides."""
+    resolved_repo_slug, skill_path, _resolved_path = _resolve_skill_location(skill_name)
     if ":" in skill_name:
         return skill_name
-    skill_path = skill_name
-    if not skill_path.endswith("SKILL.md"):
-        skill_path = f".agents/skills/{skill_name}/SKILL.md"
-    return f"{repo_slug()}:{skill_path}"
+    return f"{resolved_repo_slug}:{skill_path}"
 
 
 def run_agent(

--- a/.github/scripts/tests/test_oz_client.py
+++ b/.github/scripts/tests/test_oz_client.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
 from pathlib import Path
 
-from oz_workflows.oz_client import build_agent_config, build_oz_client, skill_spec
+from oz_workflows.oz_client import (
+    build_agent_config,
+    build_oz_client,
+    skill_file_path,
+    skill_spec,
+)
 
 
 class BuildOzClientTest(unittest.TestCase):
@@ -48,19 +54,78 @@ class BuildOzClientTest(unittest.TestCase):
 
 
 class SkillSpecTest(unittest.TestCase):
-    @patch.dict(os.environ, {"GITHUB_REPOSITORY": "warpdotdev/oz-oss-testbed"}, clear=False)
-    def test_resolves_short_skill_name_to_full_skill_path(self) -> None:
-        self.assertEqual(
-            skill_spec("implement-issue"),
-            "warpdotdev/oz-oss-testbed:.agents/skills/implement-issue/SKILL.md",
-        )
+    def test_prefers_consuming_repo_skill_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            skill_path = repo_root / ".agents/skills/implement-issue/SKILL.md"
+            skill_path.parent.mkdir(parents=True)
+            skill_path.write_text("# implement issue\n", encoding="utf-8")
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_REPOSITORY": "warpdotdev/consumer-repo",
+                    "GITHUB_WORKSPACE": str(repo_root),
+                    "WORKFLOW_CODE_REPOSITORY": "warpdotdev/oz-for-oss",
+                    "WORKFLOW_CODE_PATH": "__oz_shared",
+                },
+                clear=False,
+            ):
+                self.assertEqual(
+                    skill_spec("implement-issue"),
+                    "warpdotdev/consumer-repo:.agents/skills/implement-issue/SKILL.md",
+                )
+                self.assertEqual(
+                    skill_file_path("implement-issue"),
+                    ".agents/skills/implement-issue/SKILL.md",
+                )
 
-    @patch.dict(os.environ, {"GITHUB_REPOSITORY": "warpdotdev/oz-oss-testbed"}, clear=False)
+    def test_falls_back_to_workflow_repo_skill_when_consumer_repo_lacks_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            skill_path = repo_root / "__oz_shared/.agents/skills/implement-issue/SKILL.md"
+            skill_path.parent.mkdir(parents=True)
+            skill_path.write_text("# implement issue\n", encoding="utf-8")
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_REPOSITORY": "warpdotdev/consumer-repo",
+                    "GITHUB_WORKSPACE": str(repo_root),
+                    "WORKFLOW_CODE_REPOSITORY": "warpdotdev/oz-for-oss",
+                    "WORKFLOW_CODE_PATH": "__oz_shared",
+                },
+                clear=False,
+            ):
+                self.assertEqual(
+                    skill_spec("implement-issue"),
+                    "warpdotdev/oz-for-oss:.agents/skills/implement-issue/SKILL.md",
+                )
+                self.assertEqual(
+                    skill_file_path("implement-issue"),
+                    "__oz_shared/.agents/skills/implement-issue/SKILL.md",
+                )
+
     def test_preserves_relative_skill_file_path(self) -> None:
-        self.assertEqual(
-            skill_spec(".agents/skills/review-pr/SKILL.md"),
-            "warpdotdev/oz-oss-testbed:.agents/skills/review-pr/SKILL.md",
-        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo_root = Path(tempdir)
+            skill_path = repo_root / ".agents/skills/review-pr/SKILL.md"
+            skill_path.parent.mkdir(parents=True)
+            skill_path.write_text("# review pr\n", encoding="utf-8")
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_REPOSITORY": "warpdotdev/oz-oss-testbed",
+                    "GITHUB_WORKSPACE": str(repo_root),
+                },
+                clear=False,
+            ):
+                self.assertEqual(
+                    skill_spec(".agents/skills/review-pr/SKILL.md"),
+                    "warpdotdev/oz-oss-testbed:.agents/skills/review-pr/SKILL.md",
+                )
+                self.assertEqual(
+                    skill_file_path(".agents/skills/review-pr/SKILL.md"),
+                    ".agents/skills/review-pr/SKILL.md",
+                )
 
     def test_preserves_already_qualified_skill_spec(self) -> None:
         qualified = "warpdotdev/oz-oss-testbed:.agents/skills/create-tech-spec/SKILL.md"


### PR DESCRIPTION
## Summary
- prefer skills defined in the consuming repository when available
- fall back to the checked-in oz-for-oss skill copies when they are not
- add tests covering both resolution paths

## Validation
- python3 -m py_compile .github/scripts/oz_workflows/oz_client.py .github/scripts/create_spec_from_issue.py .github/scripts/create_implementation_from_issue.py .github/scripts/tests/test_oz_client.py
- env PYTHONPATH=/Users/captainsafia/repos/oz-for-oss/.github/scripts python3 -m unittest discover -s /Users/captainsafia/repos/oz-for-oss/.github/scripts/tests -p 'test_oz_client.py'

## Artifacts
- Conversation: https://staging.warp.dev/conversation/7c017f86-38c2-424a-af70-43bee45c39e4

Co-Authored-By: Oz <oz-agent@warp.dev>
