### PR TITLE
Ignore bot-authored triage issue comments

### DIFF
--- a/.github/scripts/tests/test_triage.py
+++ b/.github/scripts/tests/test_triage.py
@@ -196,6 +196,23 @@ class ResolveIssueNumberOverrideTest(unittest.TestCase):
             "84",
         )
 
+class TriageWorkflowGuardsTest(unittest.TestCase):
+    def _normalized_workflow_text(self, filename: str) -> str:
+        workflow_path = Path(__file__).resolve().parents[2] / "workflows" / filename
+        return " ".join(workflow_path.read_text(encoding="utf-8").split())
+
+    def test_reusable_workflow_ignores_bot_issue_comment_events(self) -> None:
+        self.assertIn(
+            "if: >- github.event_name != 'issue_comment' || github.event.comment.user.type != 'Bot'",
+            self._normalized_workflow_text("triage-new-issues.yml"),
+        )
+
+    def test_local_workflow_ignores_bot_issue_comment_events(self) -> None:
+        self.assertIn(
+            "github.event_name == 'issue_comment' && !github.event.issue.pull_request && github.event.comment.user.type != 'Bot' && (",
+            self._normalized_workflow_text("triage-new-issues-local.yml"),
+        )
+
 
 class FormatIssueCommentsTest(unittest.TestCase):
     def test_can_exclude_triggering_comment(self) -> None:

--- a/.github/workflows/triage-new-issues-local.yml
+++ b/.github/workflows/triage-new-issues-local.yml
@@ -33,6 +33,7 @@ jobs:
       ) || (
         github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
+        github.event.comment.user.type != 'Bot' &&
         (
           (
             contains(github.event.comment.body, '@oz-agent') &&

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -21,6 +21,8 @@ on:
         required: true
 jobs:
   triage_issues:
+    if: >-
+      github.event_name != 'issue_comment' || github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- ignore bot-authored \`issue_comment\` events in the shared triage reusable workflow
- add the same guard in the local triage wrapper so this repo does not invoke triage for bot comments
- add regression coverage that asserts both workflow files keep the bot-comment guard

## Validation
- env PYTHONPATH=/tmp/oz-for-oss-triage-fix.t3QcEa/.github/scripts python3 -m unittest discover -s /tmp/oz-for-oss-triage-fix.t3QcEa/.github/scripts/tests -p 'test_triage.py'
- ruby -e "require 'yaml'; YAML.load_file('/tmp/oz-for-oss-triage-fix.t3QcEa/.github/workflows/triage-new-issues.yml'); YAML.load_file('/tmp/oz-for-oss-triage-fix.t3QcEa/.github/workflows/triage-new-issues-local.yml')"

Co-Authored-By: Oz <oz-agent@warp.dev>
