### PR TITLE
fix: replace stale progress session links

### DIFF
--- a/.github/scripts/oz_workflows/helpers.py
+++ b/.github/scripts/oz_workflows/helpers.py
@@ -202,18 +202,37 @@ def build_comment_body(content: str, metadata: str) -> str:
         return metadata
     return content
 
+_PROGRESS_LINK_PREFIXES = (
+    "Sharing session at: ",
+    "View the Oz converation: ",
+)
+
+
+def _format_progress_link_section(session_link: str) -> str:
+    normalized_link = session_link.strip()
+    if "/conversation/" in normalized_link:
+        return f"View the Oz converation: {normalized_link}"
+    return f"Sharing session at: {normalized_link}"
+
 
 def append_comment_sections(existing_body: str, metadata: str, sections: list[str]) -> str:
     content, metadata = split_comment_body(existing_body, metadata)
     normalized_sections = [section.strip() for section in sections if section and section.strip()]
     if not content:
         return build_comment_body("\n\n".join(normalized_sections), metadata)
-
-    updated = content
+    updated_sections = [section.strip() for section in content.split("\n\n") if section.strip()]
     for section in normalized_sections:
-        if section not in updated:
-            updated = f"{updated}\n\n{section}"
-    return build_comment_body(updated, metadata)
+        if section.startswith(_PROGRESS_LINK_PREFIXES):
+            updated_sections = [
+                existing_section
+                for existing_section in updated_sections
+                if not existing_section.startswith(_PROGRESS_LINK_PREFIXES)
+            ]
+            updated_sections.append(section)
+            continue
+        if section not in updated_sections:
+            updated_sections.append(section)
+    return build_comment_body("\n\n".join(updated_sections), metadata)
 
 
 def resolve_oz_assigner_login(
@@ -311,7 +330,7 @@ class WorkflowProgressComment:
     def record_session_link(self, session_link: str) -> None:
         if not session_link.strip():
             return
-        self._append_sections([f"Sharing session at: {session_link.strip()}"])
+        self._append_sections([_format_progress_link_section(session_link)])
 
     def complete(self, status_line: str) -> None:
         self._append_sections([status_line])

--- a/.github/scripts/tests/test_comment_updates.py
+++ b/.github/scripts/tests/test_comment_updates.py
@@ -13,6 +13,13 @@ class CommentUpdateTest(unittest.TestCase):
         self.assertIn("Sharing session at: https://example.test/session/123", updated)
         self.assertIn("I created a spec PR for this issue: https://example.test/pr/1", updated)
         self.assertTrue(updated.endswith(metadata))
+    def test_replaces_existing_session_link_when_url_changes(self) -> None:
+        metadata = "<!-- meta -->"
+        existing = build_comment_body("@alice\n\nOz is working on this issue.\n\nSharing session at: https://example.test/session/123", metadata)
+        updated = append_comment_sections(existing, metadata, ["View the Oz converation: https://example.test/conversation/456"])
+        self.assertNotIn("https://example.test/session/123", updated)
+        self.assertIn("View the Oz converation: https://example.test/conversation/456", updated)
+        self.assertTrue(updated.endswith(metadata))
     def test_progress_comment_keeps_history_in_single_comment(self) -> None:
         github = FakeGitHubClient()
         progress = WorkflowProgressComment(
@@ -33,6 +40,24 @@ class CommentUpdateTest(unittest.TestCase):
         self.assertIn("Oz is starting work on product and tech specs for this issue.", body)
         self.assertIn("Sharing session at: https://example.test/session/123", body)
         self.assertIn("I created a spec PR for this issue: https://example.test/pr/1", body)
+    def test_progress_comment_replaces_session_link_when_run_moves_to_conversation(self) -> None:
+        github = FakeGitHubClient()
+        progress = WorkflowProgressComment(
+            github,
+            "acme",
+            "widgets",
+            42,
+            workflow="create-spec-from-issue",
+            requester_login="alice",
+        )
+        progress.start("Oz is starting work on product and tech specs for this issue.")
+        progress.record_session_link("https://example.test/session/123")
+        progress.record_session_link("https://example.test/conversation/456")
+
+        self.assertEqual(len(github.comments), 1)
+        body = github.comments[0]["body"]
+        self.assertNotIn("https://example.test/session/123", body)
+        self.assertIn("View the Oz converation: https://example.test/conversation/456", body)
 
     def test_separate_runs_create_separate_comments(self) -> None:
         github = FakeGitHubClient()


### PR DESCRIPTION
## Summary
- replace existing progress links when a session URL is later upgraded to a conversation URL
- keep workflow progress in a single comment while updating the latest Oz link

## Testing
- env PYTHONPATH=/Users/captainsafia/repos/oz-for-oss-session-link-transport-fix/.github/scripts python3 -m unittest discover -s /Users/captainsafia/repos/oz-for-oss-session-link-transport-fix/.github/scripts/tests -p test_comment_updates.py

## Artifacts
- Conversation: https://staging.warp.dev/conversation/0b49f356-863b-4f92-bf8f-ad1515d6b48c

Co-Authored-By: Oz <oz-agent@warp.dev>
