### PR TITLE
fix: compress workflow transport payloads

### DIFF
--- a/.github/scripts/enforce_pr_issue_state.py
+++ b/.github/scripts/enforce_pr_issue_state.py
@@ -117,8 +117,9 @@ def main() -> None:
               {{"matched": boolean, "issue_number": number | null, "rationale": string, "close_comment": string}}
             - If there is no clear match, set `close_comment` to a concise PR comment explaining that this {change_kind} PR could not be matched to an issue marked `{required_label}` and include this contribution docs link: {contribution_docs_url}
             - Do not close the PR yourself.
+            - Gzip the UTF-8 JSON payload before base64 encoding it for the transport comment.
             - Post exactly one temporary issue comment on PR #{pr_number} whose body is a single HTML comment in this exact format:
-              <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"issue-association","encoding":"base64","payload":"<BASE64_OF_JSON>"}} -->
+              <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"issue-association","encoding":"gzip+base64","payload":"<BASE64_OF_GZIPPED_JSON>"}} -->
             """
         ).strip()
 

--- a/.github/scripts/oz_workflows/transport.py
+++ b/.github/scripts/oz_workflows/transport.py
@@ -19,6 +19,7 @@ GZIP_BASE64_ENCODING = "gzip+base64"
 def new_transport_token() -> str:
     return uuid.uuid4().hex
 
+
 def encode_transport_payload(decoded_payload: str, *, encoding: str = GZIP_BASE64_ENCODING) -> str:
     payload_bytes = decoded_payload.encode("utf-8")
     if encoding == BASE64_ENCODING:

--- a/.github/scripts/oz_workflows/transport.py
+++ b/.github/scripts/oz_workflows/transport.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import gzip
 import json
 import re
 import time
@@ -11,10 +12,33 @@ from github.Repository import Repository
 
 
 TRANSPORT_PATTERN = re.compile(r"<!-- oz-workflow-transport (?P<payload>\{.*\}) -->", re.DOTALL)
+BASE64_ENCODING = "base64"
+GZIP_BASE64_ENCODING = "gzip+base64"
 
 
 def new_transport_token() -> str:
     return uuid.uuid4().hex
+
+def encode_transport_payload(decoded_payload: str, *, encoding: str = GZIP_BASE64_ENCODING) -> str:
+    payload_bytes = decoded_payload.encode("utf-8")
+    if encoding == BASE64_ENCODING:
+        encoded_bytes = payload_bytes
+    elif encoding == GZIP_BASE64_ENCODING:
+        encoded_bytes = gzip.compress(payload_bytes, compresslevel=9, mtime=0)
+    else:
+        raise ValueError(f"Unsupported transport encoding: {encoding}")
+    return base64.b64encode(encoded_bytes).decode("utf-8")
+
+
+def decode_transport_payload(encoded_payload: str, *, encoding: str) -> str:
+    decoded_bytes = base64.b64decode(encoded_payload, validate=True)
+    if encoding == BASE64_ENCODING:
+        payload_bytes = decoded_bytes
+    elif encoding == GZIP_BASE64_ENCODING:
+        payload_bytes = gzip.decompress(decoded_bytes)
+    else:
+        raise ValueError(f"Unsupported transport encoding: {encoding}")
+    return payload_bytes.decode("utf-8")
 
 
 def parse_transport_comment(body: str) -> dict[str, Any] | None:
@@ -25,9 +49,10 @@ def parse_transport_comment(body: str) -> dict[str, Any] | None:
         payload = json.loads(match.group("payload"))
         if not isinstance(payload, dict):
             return None
-        encoded = payload.get("payload", "")
-        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
-    except (TypeError, ValueError, json.JSONDecodeError, binascii.Error, UnicodeDecodeError):
+        encoded = str(payload.get("payload", "") or "")
+        encoding = str(payload.get("encoding") or BASE64_ENCODING).strip().lower()
+        decoded = decode_transport_payload(encoded, encoding=encoding)
+    except (TypeError, ValueError, json.JSONDecodeError, binascii.Error, UnicodeDecodeError, OSError):
         return None
     payload["decoded_payload"] = decoded
     return payload

--- a/.github/scripts/respond_to_triaged_issue_comment.py
+++ b/.github/scripts/respond_to_triaged_issue_comment.py
@@ -120,8 +120,9 @@ def main() -> None:
             - `analysis_comment` must be a direct reply suitable for posting as Oz's inline response.
             - Do not include HTML metadata or transport markup inside `analysis_comment`.
             - Validate `issue_response.json` with `jq`.
+            - After validating the JSON, gzip the UTF-8 contents of `issue_response.json` and then base64 encode the compressed bytes.
             - After validating the JSON, post exactly one temporary issue comment on issue #{issue_number} whose body is a single HTML comment in this exact format:
-              <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"issue-comment-response","encoding":"base64","payload":"<BASE64_OF_RESPONSE_JSON>"}} -->
+              <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"issue-comment-response","encoding":"gzip+base64","payload":"<BASE64_OF_GZIPPED_RESPONSE_JSON>"}} -->
             """
         ).strip()
 

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -101,8 +101,9 @@ def main() -> None:
             - The annotated diff must use the same prefixes as the old workflow: `[OLD:n]`, `[NEW:n]`, and `[OLD:n,NEW:m]`.
             - If spec context is present above, write it to `spec_context.md` before reviewing so the repository's `check-impl-against-spec` skill can be used.
             - Do not post the final review directly.
+            - After you create and validate `review.json`, gzip the UTF-8 contents of that file and then base64 encode the compressed bytes.
             - After you create and validate `review.json`, post exactly one temporary issue comment on PR #{pr_number} whose body is a single HTML comment in this exact format:
-              <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"review-json","encoding":"base64","payload":"<BASE64_OF_REVIEW_JSON>"}} -->
+              <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"review-json","encoding":"gzip+base64","payload":"<BASE64_OF_GZIPPED_REVIEW_JSON>"}} -->
             """
         ).strip()
 

--- a/.github/scripts/tests/test_transport.py
+++ b/.github/scripts/tests/test_transport.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
-import base64
 import json
 import unittest
-from oz_workflows.transport import parse_transport_comment, poll_for_transport_payload
+
+from oz_workflows.transport import (
+    BASE64_ENCODING,
+    GZIP_BASE64_ENCODING,
+    encode_transport_payload,
+    parse_transport_comment,
+    poll_for_transport_payload,
+)
 
 
 def transport_comment(payload: str) -> str:
     return f"<!-- oz-workflow-transport {payload} -->"
 
 
-def encoded_payload(payload: dict[str, str]) -> str:
-    return base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+def encoded_payload(payload: dict[str, object], *, encoding: str = GZIP_BASE64_ENCODING) -> str:
+    return encode_transport_payload(json.dumps(payload), encoding=encoding)
 
 
 class ParseTransportCommentTest(unittest.TestCase):
@@ -21,14 +27,44 @@ class ParseTransportCommentTest(unittest.TestCase):
                 {
                     "token": "abc",
                     "kind": "review-json",
-                    "encoding": "base64",
-                    "payload": encoded_payload({"hello": "world"}),
+                    "encoding": BASE64_ENCODING,
+                    "payload": encoded_payload({"hello": "world"}, encoding=BASE64_ENCODING),
                 }
             )
         )
         parsed = parse_transport_comment(body)
         self.assertIsNotNone(parsed)
         self.assertEqual(parsed["decoded_payload"], '{"hello": "world"}')
+
+    def test_defaults_missing_encoding_to_base64(self) -> None:
+        body = transport_comment(
+            json.dumps(
+                {
+                    "token": "abc",
+                    "kind": "review-json",
+                    "payload": encoded_payload({"hello": "world"}, encoding=BASE64_ENCODING),
+                }
+            )
+        )
+        parsed = parse_transport_comment(body)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["decoded_payload"], '{"hello": "world"}')
+
+    def test_decodes_gzip_base64_payload(self) -> None:
+        body = transport_comment(
+            json.dumps(
+                {
+                    "token": "abc",
+                    "kind": "review-json",
+                    "encoding": GZIP_BASE64_ENCODING,
+                    "payload": encoded_payload({"hello": "world"}, encoding=GZIP_BASE64_ENCODING),
+                }
+            )
+        )
+        parsed = parse_transport_comment(body)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["decoded_payload"], '{"hello": "world"}')
+
     def test_returns_none_for_malformed_json(self) -> None:
         body = transport_comment('{"token": "abc", "kind": }')
         self.assertIsNone(parse_transport_comment(body))
@@ -39,12 +75,45 @@ class ParseTransportCommentTest(unittest.TestCase):
                 {
                     "token": "abc",
                     "kind": "review-json",
-                    "encoding": "base64",
+                    "encoding": BASE64_ENCODING,
                     "payload": "%%%not-base64%%%",
                 }
             )
         )
         self.assertIsNone(parse_transport_comment(body))
+
+    def test_returns_none_for_invalid_gzip_payload(self) -> None:
+        body = transport_comment(
+            json.dumps(
+                {
+                    "token": "abc",
+                    "kind": "review-json",
+                    "encoding": GZIP_BASE64_ENCODING,
+                    "payload": encoded_payload({"hello": "world"}, encoding=BASE64_ENCODING),
+                }
+            )
+        )
+        self.assertIsNone(parse_transport_comment(body))
+
+    def test_gzip_encoding_reduces_large_review_like_payload(self) -> None:
+        review_payload = {
+            "summary": "Request changes",
+            "comments": [
+                {
+                    "path": "foo.py",
+                    "line": index + 1,
+                    "side": "RIGHT",
+                    "body": (
+                        "⚠️ [IMPORTANT] "
+                        + "This review comment repeats similar context and suggestion text. " * 6
+                    ),
+                }
+                for index in range(40)
+            ],
+        }
+        plain = encoded_payload(review_payload, encoding=BASE64_ENCODING)
+        compressed = encoded_payload(review_payload, encoding=GZIP_BASE64_ENCODING)
+        self.assertLess(len(compressed), len(plain))
 
 
 class PollForTransportPayloadTest(unittest.TestCase):
@@ -54,8 +123,8 @@ class PollForTransportPayloadTest(unittest.TestCase):
                 {
                     "token": "abc",
                     "kind": "review-json",
-                    "encoding": "base64",
-                    "payload": encoded_payload({"hello": "world"}),
+                    "encoding": BASE64_ENCODING,
+                    "payload": encoded_payload({"hello": "world"}, encoding=BASE64_ENCODING),
                 }
             )
         )
@@ -64,7 +133,7 @@ class PollForTransportPayloadTest(unittest.TestCase):
                 {
                     "token": "abc",
                     "kind": "review-json",
-                    "encoding": "base64",
+                    "encoding": BASE64_ENCODING,
                     "payload": "%%%not-base64%%%",
                 }
             )

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -267,8 +267,9 @@ def process_issue(
         - Do not include the preserved original-report appendix in `issue_body`; the workflow will append it automatically.
         - Validate `triage_result.json` with `jq`.
         - Do not update GitHub directly beyond the transport comment below.
+        - After validating the JSON, gzip the UTF-8 contents of `triage_result.json` and then base64 encode the compressed bytes.
         - After validating the JSON, post exactly one temporary issue comment on issue #{issue_number} whose body is a single HTML comment in this exact format:
-          <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"issue-triage","encoding":"base64","payload":"<BASE64_OF_TRIAGE_JSON>"}} -->
+          <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"issue-triage","encoding":"gzip+base64","payload":"<BASE64_OF_GZIPPED_TRIAGE_JSON>"}} -->
         """
     ).strip()
 


### PR DESCRIPTION
## Summary
- add gzip+base64 transport helpers while preserving legacy base64 decoding compatibility
- update workflow prompts to instruct compressed transport comments for review, triage, response, and issue association flows
- expand transport tests to cover gzip decoding, missing-encoding fallback, invalid gzip payloads, and size reduction for large review-like payloads

## Testing
- env PYTHONPATH=/Users/captainsafia/repos/oz-for-oss/.github/scripts python3 /Users/captainsafia/repos/oz-for-oss/.github/scripts/tests/test_transport.py
- python3 -m py_compile /Users/captainsafia/repos/oz-for-oss/.github/scripts/oz_workflows/transport.py /Users/captainsafia/repos/oz-for-oss/.github/scripts/review_pr.py /Users/captainsafia/repos/oz-for-oss/.github/scripts/triage_new_issues.py /Users/captainsafia/repos/oz-for-oss/.github/scripts/respond_to_triaged_issue_comment.py /Users/captainsafia/repos/oz-for-oss/.github/scripts/enforce_pr_issue_state.py /Users/captainsafia/repos/oz-for-oss/.github/scripts/tests/test_transport.py

## Artifacts
- Conversation: https://staging.warp.dev/conversation/448c31a6-3cae-4bd0-9866-fc918015c78b

Co-Authored-By: Oz <oz-agent@warp.dev>
