### PR TITLE
chore: update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/comment-on-unready-assigned-issue.yml
+++ b/.github/workflows/comment-on-unready-assigned-issue.yml
@@ -24,16 +24,16 @@ jobs:
           owner: ${{ github.repository_owner }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout workflow code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -30,11 +30,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Checkout workflow code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
           ref: ${{ env.WORKFLOW_CODE_REF }}
@@ -57,7 +57,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -30,11 +30,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Checkout workflow code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
           ref: ${{ env.WORKFLOW_CODE_REF }}
@@ -57,7 +57,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -46,9 +46,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout workflow code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
           ref: ${{ env.WORKFLOW_CODE_REF }}
@@ -71,7 +71,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies

--- a/.github/workflows/pr-hooks.yml
+++ b/.github/workflows/pr-hooks.yml
@@ -31,9 +31,9 @@ jobs:
       comment_id: ${{ steps.resolve.outputs.comment_id }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -30,7 +30,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Authenticate to Google Cloud for staging secret access
@@ -50,7 +50,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies

--- a/.github/workflows/respond-to-triaged-issue-comment.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment.yml
@@ -28,11 +28,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Checkout workflow code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
           ref: ${{ env.WORKFLOW_CODE_REF }}
@@ -55,7 +55,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -54,9 +54,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout workflow code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
           ref: ${{ env.WORKFLOW_CODE_REF }}
@@ -79,7 +79,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,11 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ inputs.pr_number }}/merge
+      - name: Lint GitHub Actions workflows
+        if: steps.filter.outputs.has_code_changes == 'true'
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color
       - name: Set up Python
         if: steps.filter.outputs.has_code_changes == 'true'
         uses: actions/setup-python@v6

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,12 +31,12 @@ jobs:
           echo "has_code_changes=$has_code" >> "$GITHUB_OUTPUT"
       - name: Checkout PR
         if: steps.filter.outputs.has_code_changes == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ inputs.pr_number }}/merge
       - name: Set up Python
         if: steps.filter.outputs.has_code_changes == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -41,11 +41,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Checkout workflow code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
           ref: ${{ env.WORKFLOW_CODE_REF }}
@@ -68,7 +68,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies

--- a/.github/workflows/update-pr-review.yml
+++ b/.github/workflows/update-pr-review.yml
@@ -34,9 +34,9 @@ jobs:
           owner: ${{ github.repository_owner }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout workflow code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
           ref: ${{ env.WORKFLOW_CODE_REF }}
@@ -59,7 +59,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install Python workflow dependencies


### PR DESCRIPTION
## Summary
- bump actions/checkout from v4 to v5 in the affected workflows
- bump actions/setup-python from v5 to v6 in the affected workflows

## Validation
- verified there are no remaining actions/checkout@v4 or actions/setup-python@v5 references in the worktree
- actionlint is not installed locally

Co-Authored-By: Oz <oz-agent@warp.dev>
