### PR TITLE
Harden workflow transport comments

### DIFF
--- a/.github/scripts/enforce_pr_issue_state.py
+++ b/.github/scripts/enforce_pr_issue_state.py
@@ -9,7 +9,11 @@ from oz_workflows.actions import set_output
 from oz_workflows.env import optional_env, repo_parts, repo_slug, require_env, workspace
 from oz_workflows.helpers import extract_issue_numbers_from_text, ORG_MEMBER_ASSOCIATIONS, WorkflowProgressComment
 from oz_workflows.oz_client import build_agent_config, run_agent
-from oz_workflows.transport import new_transport_token, poll_for_transport_payload
+from oz_workflows.transport import (
+    create_transport_placeholder_comment,
+    new_transport_token,
+    poll_for_transport_payload,
+)
 
 
 def _is_pr_author_org_member(pr: dict) -> bool:
@@ -95,6 +99,14 @@ def main() -> None:
         ]
 
         transport_token = new_transport_token()
+        transport_comment_id = create_transport_placeholder_comment(
+            github,
+            owner,
+            repo,
+            pr_number,
+            token=transport_token,
+            kind="issue-association",
+        )
         prompt = dedent(
             f"""
             Determine whether pull request #{pr_number} in repository {owner}/{repo} is clearly associated with one of the ready issues below.
@@ -117,9 +129,11 @@ def main() -> None:
               {{"matched": boolean, "issue_number": number | null, "rationale": string, "close_comment": string}}
             - If there is no clear match, set `close_comment` to a concise PR comment explaining that this {change_kind} PR could not be matched to an issue marked `{required_label}` and include this contribution docs link: {contribution_docs_url}
             - Do not close the PR yourself.
+            - A reserved transport comment already exists on PR #{pr_number} as issue comment ID {transport_comment_id}. Do not create another transport comment.
             - Gzip the UTF-8 JSON payload before base64 encoding it for the transport comment.
-            - Post exactly one temporary issue comment on PR #{pr_number} whose body is a single HTML comment in this exact format:
+            - Replace the entire body of issue comment ID {transport_comment_id} with a single HTML comment in this exact format:
               <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"issue-association","encoding":"gzip+base64","payload":"<BASE64_OF_GZIPPED_JSON>"}} -->
+            - After editing issue comment ID {transport_comment_id}, fetch that same issue comment and verify its body exactly matches what you wrote before exiting.
             """
         ).strip()
 
@@ -140,6 +154,7 @@ def main() -> None:
             owner,
             repo,
             pr_number,
+            comment_id=transport_comment_id,
             token=transport_token,
             kind="issue-association",
         )

--- a/.github/scripts/oz_workflows/transport.py
+++ b/.github/scripts/oz_workflows/transport.py
@@ -11,6 +11,8 @@ import zlib
 from typing import Any
 from github.Repository import Repository
 
+from .helpers import _create_issue_comment, _delete_issue_comment, _get_issue_comment
+
 
 TRANSPORT_PATTERN = re.compile(r"<!-- oz-workflow-transport (?P<payload>\{.*\}) -->", re.DOTALL)
 BASE64_ENCODING = "base64"
@@ -19,6 +21,50 @@ GZIP_BASE64_ENCODING = "gzip+base64"
 
 def new_transport_token() -> str:
     return uuid.uuid4().hex
+
+
+def _transport_comment_body(
+    *,
+    token: str,
+    kind: str,
+    payload: str = "",
+    encoding: str = "",
+) -> str:
+    transport_payload: dict[str, str] = {
+        "token": token,
+        "kind": kind,
+    }
+    if payload:
+        transport_payload["encoding"] = encoding or BASE64_ENCODING
+        transport_payload["payload"] = payload
+    else:
+        transport_payload["state"] = "pending"
+    return f"<!-- oz-workflow-transport {json.dumps(transport_payload, separators=(',', ':'))} -->"
+
+
+def create_transport_placeholder_comment(
+    github: Repository | Any,
+    owner: str,
+    repo: str,
+    issue_number: int,
+    *,
+    token: str,
+    kind: str,
+) -> int:
+    """Create a reserved transport comment whose ID can be handed to the agent."""
+    created = _create_issue_comment(
+        github,
+        owner,
+        repo,
+        issue_number,
+        _transport_comment_body(token=token, kind=kind),
+    )
+    comment_id = created.get("id") if isinstance(created, dict) else getattr(created, "id", None)
+    if comment_id is None:
+        raise RuntimeError(
+            f"Failed to create transport placeholder comment for {kind} ({token})"
+        )
+    return int(comment_id)
 
 
 def encode_transport_payload(decoded_payload: str, *, encoding: str = GZIP_BASE64_ENCODING) -> str:
@@ -52,6 +98,8 @@ def parse_transport_comment(body: str) -> dict[str, Any] | None:
         if not isinstance(payload, dict):
             return None
         encoded = str(payload.get("payload", "") or "")
+        if not encoded.strip():
+            return None
         encoding = str(payload.get("encoding") or BASE64_ENCODING).strip().lower()
         decoded = decode_transport_payload(encoded, encoding=encoding)
     except (TypeError, ValueError, json.JSONDecodeError, binascii.Error, UnicodeDecodeError, OSError, zlib.error, EOFError):
@@ -90,7 +138,6 @@ def cleanup_transport_comments(
                     if hasattr(comment, "delete"):
                         comment.delete()
                     else:
-                        from .helpers import _delete_issue_comment
 
                         _delete_issue_comment(
                             github, owner, repo, issue_number, int(comment_id)
@@ -107,6 +154,7 @@ def poll_for_transport_payload(
     repo: str,
     issue_number: int,
     *,
+    comment_id: int,
     token: str,
     kind: str,
     timeout_seconds: int = 600,
@@ -114,25 +162,27 @@ def poll_for_transport_payload(
 ) -> tuple[dict[str, Any], int]:
     deadline = time.monotonic() + timeout_seconds
     while True:
-        if hasattr(github, "get_issue"):
-            comments = list(github.get_issue(issue_number).get_comments())
-        else:
-            comments = github.list_issue_comments(owner, repo, issue_number)
-        for comment in reversed(comments):
+        try:
+            comment = _get_issue_comment(
+                github,
+                owner,
+                repo,
+                comment_id,
+                issue_number=issue_number,
+            )
+        except Exception:
+            comment = None
+        if comment is not None:
             body = (
                 str(comment.get("body") or "")
                 if isinstance(comment, dict)
                 else str(getattr(comment, "body", "") or "")
             )
             parsed = parse_transport_comment(body)
-            if not parsed:
-                continue
-            if parsed.get("token") != token or parsed.get("kind") != kind:
-                continue
-            comment_id = comment.get("id") if isinstance(comment, dict) else getattr(comment, "id", None)
-            return parsed, int(comment_id)
+            if parsed and parsed.get("token") == token and parsed.get("kind") == kind:
+                return parsed, comment_id
         if time.monotonic() >= deadline:
             raise RuntimeError(
-                f"Timed out waiting for Oz transport payload {kind} ({token}) on issue/PR #{issue_number}"
+                f"Timed out waiting for Oz transport payload {kind} ({token}) in comment {comment_id} on issue/PR #{issue_number}"
             )
         time.sleep(poll_interval_seconds)

--- a/.github/scripts/oz_workflows/transport.py
+++ b/.github/scripts/oz_workflows/transport.py
@@ -4,6 +4,7 @@ import base64
 import binascii
 import gzip
 import json
+import logging
 import re
 import time
 import uuid
@@ -138,7 +139,6 @@ def cleanup_transport_comments(
                     if hasattr(comment, "delete"):
                         comment.delete()
                     else:
-
                         _delete_issue_comment(
                             github, owner, repo, issue_number, int(comment_id)
                         )
@@ -170,7 +170,13 @@ def poll_for_transport_payload(
                 comment_id,
                 issue_number=issue_number,
             )
-        except Exception:
+        except Exception as exc:
+            logging.warning(
+                "Failed to fetch transport comment %d on issue/PR #%d: %s",
+                comment_id,
+                issue_number,
+                exc,
+            )
             comment = None
         if comment is not None:
             body = (

--- a/.github/scripts/respond_to_triaged_issue_comment.py
+++ b/.github/scripts/respond_to_triaged_issue_comment.py
@@ -14,7 +14,12 @@ from oz_workflows.helpers import (
     triggering_comment_prompt_text,
 )
 from oz_workflows.oz_client import build_agent_config, run_agent
-from oz_workflows.transport import cleanup_transport_comments, new_transport_token, poll_for_transport_payload
+from oz_workflows.transport import (
+    cleanup_transport_comments,
+    create_transport_placeholder_comment,
+    new_transport_token,
+    poll_for_transport_payload,
+)
 from oz_workflows.triage import extract_original_issue_report
 
 
@@ -72,6 +77,14 @@ def main() -> None:
         original_report = extract_original_issue_report(current_body)
         triggering_comment_text = triggering_comment_prompt_text(event)
         transport_token = new_transport_token()
+        transport_comment_id = create_transport_placeholder_comment(
+            github,
+            owner,
+            repo,
+            issue_number,
+            token=transport_token,
+            kind="issue-comment-response",
+        )
         prompt = dedent(
             f"""
             Respond inline to a mention on GitHub issue #{issue_number} in repository {owner}/{repo}.
@@ -120,9 +133,11 @@ def main() -> None:
             - `analysis_comment` must be a direct reply suitable for posting as Oz's inline response.
             - Do not include HTML metadata or transport markup inside `analysis_comment`.
             - Validate `issue_response.json` with `jq`.
+            - A reserved transport comment already exists on issue #{issue_number} as issue comment ID {transport_comment_id}. Do not create another transport comment.
             - After validating the JSON, gzip the UTF-8 contents of `issue_response.json` and then base64 encode the compressed bytes.
-            - After validating the JSON, post exactly one temporary issue comment on issue #{issue_number} whose body is a single HTML comment in this exact format:
+            - After validating the JSON, replace the entire body of issue comment ID {transport_comment_id} with a single HTML comment in this exact format:
               <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"issue-comment-response","encoding":"gzip+base64","payload":"<BASE64_OF_GZIPPED_RESPONSE_JSON>"}} -->
+            - After editing issue comment ID {transport_comment_id}, fetch that same issue comment and verify its body exactly matches what you wrote before exiting.
             """
         ).strip()
 
@@ -143,9 +158,10 @@ def main() -> None:
                 owner,
                 repo,
                 issue_number,
+                comment_id=transport_comment_id,
                 token=transport_token,
                 kind="issue-comment-response",
-            timeout_seconds=600,
+                timeout_seconds=600,
             )
             issue.get_comment(transport_comment_id).delete()
             result = json.loads(payload["decoded_payload"])

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -13,7 +13,12 @@ from oz_workflows.helpers import (
     WorkflowProgressComment,
 )
 from oz_workflows.oz_client import build_agent_config, run_agent
-from oz_workflows.transport import cleanup_transport_comments, new_transport_token, poll_for_transport_payload
+from oz_workflows.transport import (
+    cleanup_transport_comments,
+    create_transport_placeholder_comment,
+    new_transport_token,
+    poll_for_transport_payload,
+)
 
 
 def main() -> None:
@@ -69,6 +74,14 @@ def main() -> None:
         skill_name = "review-spec" if spec_only else "review-pr"
 
         transport_token = new_transport_token()
+        transport_comment_id = create_transport_placeholder_comment(
+            github,
+            owner,
+            repo,
+            pr_number,
+            token=transport_token,
+            kind="review-json",
+        )
         focus_line = (
             f"Additional focus from @{requester}: {focus}"
             if focus
@@ -101,9 +114,11 @@ def main() -> None:
             - The annotated diff must use the same prefixes as the old workflow: `[OLD:n]`, `[NEW:n]`, and `[OLD:n,NEW:m]`.
             - If spec context is present above, write it to `spec_context.md` before reviewing so the repository's `check-impl-against-spec` skill can be used.
             - Do not post the final review directly.
+            - A reserved transport comment already exists on PR #{pr_number} as issue comment ID {transport_comment_id}. Do not create another transport comment.
             - After you create and validate `review.json`, gzip the UTF-8 contents of that file and then base64 encode the compressed bytes.
-            - After you create and validate `review.json`, post exactly one temporary issue comment on PR #{pr_number} whose body is a single HTML comment in this exact format:
+            - After you create and validate `review.json`, replace the entire body of issue comment ID {transport_comment_id} with a single HTML comment in this exact format:
               <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"review-json","encoding":"gzip+base64","payload":"<BASE64_OF_GZIPPED_REVIEW_JSON>"}} -->
+            - After editing issue comment ID {transport_comment_id}, fetch that same issue comment and verify its body exactly matches what you wrote before exiting.
             """
         ).strip()
 
@@ -124,6 +139,7 @@ def main() -> None:
                 owner,
                 repo,
                 pr_number,
+                comment_id=transport_comment_id,
                 token=transport_token,
                 kind="review-json",
             )

--- a/.github/scripts/tests/test_transport.py
+++ b/.github/scripts/tests/test_transport.py
@@ -9,6 +9,7 @@ from oz_workflows.transport import (
     GZIP_BASE64_ENCODING,
     TRANSPORT_PATTERN,
     cleanup_transport_comments,
+    create_transport_placeholder_comment,
     encode_transport_payload,
     parse_transport_comment,
     poll_for_transport_payload,
@@ -98,6 +99,18 @@ class ParseTransportCommentTest(unittest.TestCase):
         )
         self.assertIsNone(parse_transport_comment(body))
 
+    def test_returns_none_for_placeholder_comment_without_payload(self) -> None:
+        body = transport_comment(
+            json.dumps(
+                {
+                    "token": "abc",
+                    "kind": "review-json",
+                    "state": "pending",
+                }
+            )
+        )
+        self.assertIsNone(parse_transport_comment(body))
+
     def test_returns_none_for_corrupt_gzip_body(self) -> None:
         # Valid gzip header (1f 8b) but corrupt compressed data after the header.
         # This triggers zlib.error rather than gzip.BadGzipFile / OSError.
@@ -136,8 +149,44 @@ class ParseTransportCommentTest(unittest.TestCase):
         self.assertLess(len(compressed), len(plain))
 
 
+class CreateTransportPlaceholderCommentTest(unittest.TestCase):
+    def test_creates_reserved_transport_comment(self) -> None:
+        class FakeClient:
+            def __init__(self) -> None:
+                self.comments: list[dict[str, object]] = []
+
+            def create_comment(
+                self,
+                owner: str,
+                repo: str,
+                issue_number: int,
+                body: str,
+            ) -> dict[str, object]:
+                comment = {"id": len(self.comments) + 1, "body": body}
+                self.comments.append(comment)
+                return comment
+
+        fake = FakeClient()
+        comment_id = create_transport_placeholder_comment(
+            fake,
+            "acme",
+            "widgets",
+            42,
+            token="abc",
+            kind="review-json",
+        )
+
+        self.assertEqual(comment_id, 1)
+        self.assertEqual(len(fake.comments), 1)
+        body = str(fake.comments[0]["body"])
+        self.assertRegex(body, TRANSPORT_PATTERN)
+        self.assertIn('"token":"abc"', body)
+        self.assertIn('"kind":"review-json"', body)
+        self.assertIn('"state":"pending"', body)
+
+
 class PollForTransportPayloadTest(unittest.TestCase):
-    def test_skips_malformed_transport_comments(self) -> None:
+    def test_reads_the_reserved_transport_comment_by_id(self) -> None:
         valid_comment = transport_comment(
             json.dumps(
                 {
@@ -148,24 +197,16 @@ class PollForTransportPayloadTest(unittest.TestCase):
                 }
             )
         )
-        malformed_comment = transport_comment(
-            json.dumps(
-                {
-                    "token": "abc",
-                    "kind": "review-json",
-                    "encoding": BASE64_ENCODING,
-                    "payload": "%%%not-base64%%%",
-                }
-            )
-        )
 
         class FakeGitHubClient:
-            def list_issue_comments(self, owner: str, repo: str, issue_number: int) -> list[dict[str, object]]:
-                self.request = (owner, repo, issue_number)
-                return [
-                    {"id": 1, "body": valid_comment},
-                    {"id": 2, "body": malformed_comment},
-                ]
+            def get_comment(
+                self,
+                owner: str,
+                repo: str,
+                comment_id: int,
+            ) -> dict[str, object]:
+                self.request = (owner, repo, comment_id)
+                return {"id": comment_id, "body": valid_comment}
 
         github = FakeGitHubClient()
         parsed, comment_id = poll_for_transport_payload(
@@ -173,14 +214,67 @@ class PollForTransportPayloadTest(unittest.TestCase):
             "warpdotdev",
             "oz-for-oss",
             42,
+            comment_id=7,
             token="abc",
             kind="review-json",
             timeout_seconds=0,
             poll_interval_seconds=0,
         )
 
-        self.assertEqual(github.request, ("warpdotdev", "oz-for-oss", 42))
-        self.assertEqual(comment_id, 1)
+        self.assertEqual(github.request, ("warpdotdev", "oz-for-oss", 7))
+        self.assertEqual(comment_id, 7)
+        self.assertEqual(parsed["decoded_payload"], '{"hello": "world"}')
+
+    def test_waits_for_reserved_comment_to_be_filled(self) -> None:
+        placeholder_comment = transport_comment(
+            json.dumps(
+                {
+                    "token": "abc",
+                    "kind": "review-json",
+                    "state": "pending",
+                }
+            )
+        )
+        final_comment = transport_comment(
+            json.dumps(
+                {
+                    "token": "abc",
+                    "kind": "review-json",
+                    "encoding": BASE64_ENCODING,
+                    "payload": encoded_payload({"hello": "world"}, encoding=BASE64_ENCODING),
+                }
+            )
+        )
+
+        class FakeGitHubClient:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def get_comment(
+                self,
+                owner: str,
+                repo: str,
+                comment_id: int,
+            ) -> dict[str, object]:
+                self.calls += 1
+                body = placeholder_comment if self.calls == 1 else final_comment
+                return {"id": comment_id, "body": body}
+
+        github = FakeGitHubClient()
+        parsed, comment_id = poll_for_transport_payload(
+            github,
+            "warpdotdev",
+            "oz-for-oss",
+            42,
+            comment_id=7,
+            token="abc",
+            kind="review-json",
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        self.assertEqual(comment_id, 7)
+        self.assertEqual(github.calls, 2)
         self.assertEqual(parsed["decoded_payload"], '{"hello": "world"}')
 
 
@@ -206,7 +300,12 @@ class CleanupTransportCommentsTest(unittest.TestCase):
                 ]
                 self.deleted_ids: list[int] = []
 
-            def list_issue_comments(self, owner: str, repo: str, issue_number: int) -> list[dict[str, object]]:
+            def list_issue_comments(
+                self,
+                owner: str,
+                repo: str,
+                issue_number: int,
+            ) -> list[dict[str, object]]:
                 return list(self.comments)
 
             def delete_comment(self, owner: str, repo: str, comment_id: int) -> None:
@@ -228,7 +327,12 @@ class CleanupTransportCommentsTest(unittest.TestCase):
                 ]
                 self.deleted_ids: list[int] = []
 
-            def list_issue_comments(self, owner: str, repo: str, issue_number: int) -> list[dict[str, object]]:
+            def list_issue_comments(
+                self,
+                owner: str,
+                repo: str,
+                issue_number: int,
+            ) -> list[dict[str, object]]:
                 return list(self.comments)
 
             def delete_comment(self, owner: str, repo: str, comment_id: int) -> None:
@@ -242,10 +346,14 @@ class CleanupTransportCommentsTest(unittest.TestCase):
 
     def test_swallows_errors_silently(self) -> None:
         class FakeClient:
-            def list_issue_comments(self, owner: str, repo: str, issue_number: int) -> list[dict[str, object]]:
+            def list_issue_comments(
+                self,
+                owner: str,
+                repo: str,
+                issue_number: int,
+            ) -> list[dict[str, object]]:
                 raise RuntimeError("API error")
 
-        # Should not raise
         cleanup_transport_comments(FakeClient(), "acme", "widgets", 42)
 
 

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -24,7 +24,12 @@ from oz_workflows.helpers import (
     WorkflowProgressComment,
 )
 from oz_workflows.oz_client import build_agent_config, run_agent
-from oz_workflows.transport import cleanup_transport_comments, new_transport_token, poll_for_transport_payload
+from oz_workflows.transport import (
+    cleanup_transport_comments,
+    create_transport_placeholder_comment,
+    new_transport_token,
+    poll_for_transport_payload,
+)
 from oz_workflows.triage import (
     compose_triaged_issue_body,
     dedupe_strings,
@@ -201,6 +206,14 @@ def process_issue(
     original_report = extract_original_issue_report(current_body)
     recent_issues_text = format_recent_issues_for_dedupe(recent_open_issues, issue_number)
     transport_token = new_transport_token()
+    transport_comment_id = create_transport_placeholder_comment(
+        github,
+        owner,
+        repo,
+        issue_number,
+        token=transport_token,
+        kind="issue-triage",
+    )
     prompt = dedent(
         f"""
         Triage GitHub issue #{issue_number} in repository {owner}/{repo}.
@@ -276,10 +289,11 @@ def process_issue(
         - Keep the triage analysis in the visible issue body, and include SME `@mentions` there when useful.
         - Do not include the preserved original-report appendix in `issue_body`; the workflow will append it automatically.
         - Validate `triage_result.json` with `jq`.
-        - Do not update GitHub directly beyond the transport comment below.
+        - A reserved transport comment already exists on issue #{issue_number} as issue comment ID {transport_comment_id}. Do not create another transport comment or make other GitHub changes.
         - After validating the JSON, gzip the UTF-8 contents of `triage_result.json` and then base64 encode the compressed bytes.
-        - After validating the JSON, post exactly one temporary issue comment on issue #{issue_number} whose body is a single HTML comment in this exact format:
+        - After validating the JSON, replace the entire body of issue comment ID {transport_comment_id} with a single HTML comment in this exact format:
           <!-- oz-workflow-transport {{"token":"{transport_token}","kind":"issue-triage","encoding":"gzip+base64","payload":"<BASE64_OF_GZIPPED_TRIAGE_JSON>"}} -->
+        - After editing issue comment ID {transport_comment_id}, fetch that same issue comment and verify its body exactly matches what you wrote before exiting.
         """
     ).strip()
 
@@ -297,6 +311,7 @@ def process_issue(
             owner,
             repo,
             issue_number,
+            comment_id=transport_comment_id,
             token=transport_token,
             kind="issue-triage",
             timeout_seconds=600,


### PR DESCRIPTION
## Summary
- Reserve transport placeholder comments before launching Oz agents and pass the comment ID into the prompt.
- Update transport polling to read the single reserved comment instead of scanning issue or PR comments.
- Require agents to edit and verify the reserved comment, and extend transport tests for placeholder and single-comment polling behavior.

## Testing
- `PYTHONPATH=/Users/captainsafia/repos/oz-for-oss-worktrees/harden-transport-comments/.github/scripts python3 -m unittest discover -s /Users/captainsafia/repos/oz-for-oss-worktrees/harden-transport-comments/.github/scripts/tests -p 'test_transport.py'`
- `PYTHONPATH=/Users/captainsafia/repos/oz-for-oss-worktrees/harden-transport-comments/.github/scripts python3 -m unittest discover -s /Users/captainsafia/repos/oz-for-oss-worktrees/harden-transport-comments/.github/scripts/tests -p 'test_triage.py'`
- `PYTHONPATH=/Users/captainsafia/repos/oz-for-oss-worktrees/harden-transport-comments/.github/scripts python3 -m unittest discover -s /Users/captainsafia/repos/oz-for-oss-worktrees/harden-transport-comments/.github/scripts/tests -p 'test_enforce_pr_issue_state.py'`

## Artifacts
- Conversation: https://staging.warp.dev/conversation/d8fce3c0-f0fe-4460-8e69-9bbbf5d3e279

Co-Authored-By: Oz <oz-agent@warp.dev>
