### PR TITLE
fix: gate comment workflows on GitHub bot metadata

### DIFF
--- a/.github/scripts/create_implementation_from_issue.py
+++ b/.github/scripts/create_implementation_from_issue.py
@@ -13,6 +13,7 @@ from oz_workflows.helpers import (
     build_pr_body,
     coauthor_prompt_lines,
     conventional_commit_prefix,
+    is_automation_user,
     org_member_comments_text,
     record_run_session_link,
     resolve_coauthor_line,
@@ -30,6 +31,8 @@ IMPLEMENT_ISSUE_SKILL = "implement-issue"
 def main() -> None:
     owner, repo = repo_parts()
     event = load_event()
+    if is_automation_user((event.get("comment") or {}).get("user")):
+        return
     issue = event["issue"]
     issue_number = int(issue["number"])
     issue_title = issue["title"]

--- a/.github/scripts/create_spec_from_issue.py
+++ b/.github/scripts/create_spec_from_issue.py
@@ -12,6 +12,7 @@ from oz_workflows.helpers import (
     build_spec_preview_section,
     build_pr_body,
     coauthor_prompt_lines,
+    is_automation_user,
     org_member_comments_text,
     record_run_session_link,
     resolve_coauthor_line,
@@ -30,6 +31,8 @@ CREATE_TECH_SPEC_SKILL = "create-tech-spec"
 def main() -> None:
     owner, repo = repo_parts()
     event = load_event()
+    if is_automation_user((event.get("comment") or {}).get("user")):
+        return
     issue = event["issue"]
     issue_number = int(issue["number"])
     issue_title = issue["title"]

--- a/.github/scripts/oz_workflows/helpers.py
+++ b/.github/scripts/oz_workflows/helpers.py
@@ -35,6 +35,16 @@ def _login(item: Any) -> str:
     return str(getattr(item, "login", "") or "")
 
 
+def is_automation_user(user: Any) -> bool:
+    """Return whether *user* is an automation account that should not trigger workflows."""
+    login = _login(user).strip().lower()
+    user_type = str(_field(user, "type", "") or "").strip().lower()
+    return (
+        user_type == "bot"
+        or (bool(login) and login.endswith("[bot]"))
+    )
+
+
 def _timestamp_text(value: Any) -> str:
     if isinstance(value, datetime):
         return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/.github/scripts/resolve_review_context.py
+++ b/.github/scripts/resolve_review_context.py
@@ -4,7 +4,7 @@ import re
 
 from oz_workflows.actions import notice, set_output
 from oz_workflows.env import load_event, optional_env
-from oz_workflows.helpers import ORG_MEMBER_ASSOCIATIONS
+from oz_workflows.helpers import ORG_MEMBER_ASSOCIATIONS, is_automation_user
 
 
 SLASH_COMMAND_PATTERN = re.compile(
@@ -42,7 +42,7 @@ def main() -> None:
             bool(issue.get("pull_request"))
             and bool(match)
             and comment.get("author_association") in ORG_MEMBER_ASSOCIATIONS
-            and requester != "github-actions[bot]"
+            and not is_automation_user(comment.get("user"))
         )
         if should_review:
             pr_number = str(issue["number"])

--- a/.github/scripts/respond_to_pr_comment.py
+++ b/.github/scripts/respond_to_pr_comment.py
@@ -12,6 +12,7 @@ from oz_workflows.helpers import (
     branch_updated_since,
     build_next_steps_section,
     coauthor_prompt_lines,
+    is_automation_user,
     org_member_comments_text,
     record_run_session_link,
     resolve_coauthor_line,
@@ -25,6 +26,8 @@ from oz_workflows.oz_client import build_agent_config, run_agent
 def main() -> None:
     owner, repo = repo_parts()
     event = load_event()
+    if is_automation_user((event.get("comment") or {}).get("user")):
+        return
     github_event_name = optional_env("GITHUB_EVENT_NAME")
     with closing(Github(auth=Auth.Token(require_env("GH_TOKEN")))) as client:
         github = client.get_repo(repo_slug())

--- a/.github/scripts/respond_to_triaged_issue_comment.py
+++ b/.github/scripts/respond_to_triaged_issue_comment.py
@@ -10,6 +10,7 @@ from oz_workflows.env import load_event, repo_parts, repo_slug, require_env, wor
 from oz_workflows.helpers import (
     WorkflowProgressComment,
     format_issue_comments_for_prompt,
+    is_automation_user,
     record_run_session_link,
     triggering_comment_prompt_text,
 )
@@ -48,6 +49,8 @@ def extract_analysis_comment(result: dict[str, Any]) -> str:
 def main() -> None:
     owner, repo = repo_parts()
     event = load_event()
+    if is_automation_user((event.get("comment") or {}).get("user")):
+        return
     issue_number = int(event["issue"]["number"])
     triggering_comment_id = int((event.get("comment") or {}).get("id") or 0) or None
     requester = ((event.get("comment") or {}).get("user") or {}).get("login") or ""

--- a/.github/scripts/tests/test_helpers.py
+++ b/.github/scripts/tests/test_helpers.py
@@ -11,6 +11,7 @@ from oz_workflows.helpers import (
     coauthor_prompt_lines,
     conventional_commit_prefix,
     extract_issue_numbers_from_text,
+    is_automation_user,
     is_spec_only_pr,
     org_member_comments_text,
     resolve_coauthor_line,
@@ -61,6 +62,16 @@ class TriggeringCommentPromptTextTest(unittest.TestCase):
             ),
             "@alice commented:\n@oz-agent please focus on rollout safety",
         )
+
+class IsAutomationUserTest(unittest.TestCase):
+    def test_detects_github_bot_user_type(self) -> None:
+        self.assertTrue(is_automation_user({"login": "some-user", "type": "Bot"}))
+
+    def test_detects_bot_suffix_login(self) -> None:
+        self.assertTrue(is_automation_user({"login": "dependabot[bot]", "type": "User"}))
+
+    def test_returns_false_for_human_user(self) -> None:
+        self.assertFalse(is_automation_user({"login": "alice", "type": "User"}))
 
 
 class ResolveProgressRequesterLoginTest(unittest.TestCase):

--- a/.github/scripts/tests/test_helpers.py
+++ b/.github/scripts/tests/test_helpers.py
@@ -73,6 +73,9 @@ class IsAutomationUserTest(unittest.TestCase):
     def test_returns_false_for_human_user(self) -> None:
         self.assertFalse(is_automation_user({"login": "alice", "type": "User"}))
 
+    def test_returns_false_for_none_user(self) -> None:
+        self.assertFalse(is_automation_user(None))
+
 
 class ResolveProgressRequesterLoginTest(unittest.TestCase):
     def test_prefers_explicit_requester_login(self) -> None:

--- a/.github/scripts/tests/test_triage.py
+++ b/.github/scripts/tests/test_triage.py
@@ -214,16 +214,36 @@ class TriageWorkflowGuardsTest(unittest.TestCase):
     def _normalized_workflow_text(self, filename: str) -> str:
         workflow_path = Path(__file__).resolve().parents[2] / "workflows" / filename
         return " ".join(workflow_path.read_text(encoding="utf-8").split())
+    def test_comment_workflows_ignore_automation_commenters(self) -> None:
+        automation_guard = (
+            "github.event.comment.user.type != 'Bot' && "
+            "!endsWith(github.event.comment.user.login, '[bot]')"
+        )
+        for filename in (
+            "triage-new-issues.yml",
+            "triage-new-issues-local.yml",
+            "respond-to-triaged-issue-comment.yml",
+            "respond-to-triaged-issue-comment-local.yml",
+            "respond-to-pr-comment.yml",
+            "create-spec-from-issue-local.yml",
+            "create-implementation-from-issue-local.yml",
+            "pr-hooks.yml",
+        ):
+            with self.subTest(filename=filename):
+                self.assertIn(
+                    automation_guard,
+                    self._normalized_workflow_text(filename),
+                )
 
     def test_reusable_workflow_ignores_bot_issue_comment_events(self) -> None:
         self.assertIn(
-            "if: >- github.event_name != 'issue_comment' || github.event.comment.user.type != 'Bot'",
+            "if: >- github.event_name != 'issue_comment' || ( github.event.comment.user.type != 'Bot' && !endsWith(github.event.comment.user.login, '[bot]') )",
             self._normalized_workflow_text("triage-new-issues.yml"),
         )
 
     def test_local_workflow_ignores_bot_issue_comment_events(self) -> None:
         self.assertIn(
-            "github.event_name == 'issue_comment' && !github.event.issue.pull_request && github.event.comment.user.type != 'Bot' && (",
+            "github.event_name == 'issue_comment' && !github.event.issue.pull_request && github.event.comment.user.type != 'Bot' && !endsWith(github.event.comment.user.login, '[bot]') && (",
             self._normalized_workflow_text("triage-new-issues-local.yml"),
         )
 

--- a/.github/scripts/tests/test_triage.py
+++ b/.github/scripts/tests/test_triage.py
@@ -214,6 +214,7 @@ class TriageWorkflowGuardsTest(unittest.TestCase):
     def _normalized_workflow_text(self, filename: str) -> str:
         workflow_path = Path(__file__).resolve().parents[2] / "workflows" / filename
         return " ".join(workflow_path.read_text(encoding="utf-8").split())
+
     def test_comment_workflows_ignore_automation_commenters(self) -> None:
         automation_guard = (
             "github.event.comment.user.type != 'Bot' && "

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -19,6 +19,7 @@ from oz_workflows.helpers import (
     _timestamp_text,
     build_comment_body,
     format_issue_comments_for_prompt,
+    is_automation_user,
     record_run_session_link,
     triggering_comment_prompt_text,
     WorkflowProgressComment,
@@ -85,6 +86,9 @@ def main() -> None:
     owner, repo = repo_parts()
     event = load_event()
     event_name = optional_env("GITHUB_EVENT_NAME")
+    if event_name == "issue_comment" and is_automation_user((event.get("comment") or {}).get("user")):
+        append_summary("Skipping automation-authored issue comment.\n")
+        return
     triage_config = load_triage_config(workspace() / ".github" / "issue-triage" / "config.json")
     configured_labels = triage_config["labels"]
     stakeholder_entries = load_stakeholders(workspace() / ".github" / "STAKEHOLDERS")

--- a/.github/workflows/create-implementation-from-issue-local.yml
+++ b/.github/workflows/create-implementation-from-issue-local.yml
@@ -25,7 +25,9 @@ jobs:
         !github.event.issue.pull_request &&
         contains(github.event.issue.labels.*.name, 'ready-to-implement') &&
         contains(github.event.comment.body, '@oz-agent') &&
-        contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association)
+        contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association) &&
+        github.event.comment.user.type != 'Bot' &&
+        !endsWith(github.event.comment.user.login, '[bot]')
       )
     name: Create implementation diff
     permissions:

--- a/.github/workflows/create-spec-from-issue-local.yml
+++ b/.github/workflows/create-spec-from-issue-local.yml
@@ -25,7 +25,9 @@ jobs:
         !github.event.issue.pull_request &&
         contains(github.event.issue.labels.*.name, 'ready-to-spec') &&
         contains(github.event.comment.body, '@oz-agent') &&
-        contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association)
+        contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association) &&
+        github.event.comment.user.type != 'Bot' &&
+        !endsWith(github.event.comment.user.login, '[bot]')
       )
     name: Create spec diff
     permissions:

--- a/.github/workflows/pr-hooks.yml
+++ b/.github/workflows/pr-hooks.yml
@@ -20,7 +20,14 @@ concurrency:
   cancel-in-progress: false
 jobs:
   resolve_review_context:
-    if: github.event_name != 'pull_request_target'
+    if: >-
+      github.event_name != 'pull_request_target' &&
+      (
+        github.event_name != 'issue_comment' || (
+          github.event.comment.user.type != 'Bot' &&
+          !endsWith(github.event.comment.user.login, '[bot]')
+        )
+      )
     runs-on: ubuntu-slim
     outputs:
       should_review: ${{ steps.resolve.outputs.should_review }}

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -12,7 +12,8 @@ jobs:
     if: >-
       contains(github.event.comment.body, '@oz-agent') &&
       contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association) &&
-      github.event.comment.user.login != 'github-actions[bot]' &&
+      github.event.comment.user.type != 'Bot' &&
+      !endsWith(github.event.comment.user.login, '[bot]') &&
       (github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request))
     name: Respond to PR comment
     runs-on: ubuntu-slim

--- a/.github/workflows/respond-to-triaged-issue-comment-local.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment-local.yml
@@ -10,6 +10,8 @@ jobs:
     if: >-
       github.event_name == 'issue_comment' &&
       !github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
+      !endsWith(github.event.comment.user.login, '[bot]') &&
       contains(github.event.comment.body, '@oz-agent') &&
       contains(github.event.issue.labels.*.name, 'triaged') &&
       !contains(github.event.issue.labels.*.name, 'ready-to-spec') &&

--- a/.github/workflows/respond-to-triaged-issue-comment.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment.yml
@@ -10,6 +10,11 @@ on:
         required: true
 jobs:
   respond_inline:
+    if: >-
+      github.event_name != 'issue_comment' || (
+        github.event.comment.user.type != 'Bot' &&
+        !endsWith(github.event.comment.user.login, '[bot]')
+      )
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/triage-new-issues-local.yml
+++ b/.github/workflows/triage-new-issues-local.yml
@@ -34,6 +34,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
         github.event.comment.user.type != 'Bot' &&
+        !endsWith(github.event.comment.user.login, '[bot]') &&
         (
           (
             contains(github.event.comment.body, '@oz-agent') &&

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -22,7 +22,10 @@ on:
 jobs:
   triage_issues:
     if: >-
-      github.event_name != 'issue_comment' || github.event.comment.user.type != 'Bot'
+      github.event_name != 'issue_comment' || (
+        github.event.comment.user.type != 'Bot' &&
+        !endsWith(github.event.comment.user.login, '[bot]')
+      )
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- ignore automated issue and PR comment triggers using GitHub bot metadata
- apply the same guard in shared workflow scripts for defense in depth
- update workflow and helper tests to cover the simplified bot checks

## Testing
- PYTHONPATH=/Users/captainsafia/repos/cougar-caldera/.github/scripts python3 -m unittest discover -s /Users/captainsafia/repos/cougar-caldera/.github/scripts/tests -p 'test_*.py'

## Artifacts
- Conversation: https://staging.warp.dev/conversation/e65c5bff-d3ab-4687-8625-d7c0e7fec835

Co-Authored-By: Oz <oz-agent@warp.dev>
