### PR TITLE
Validate review comments against PR diffs

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -47,6 +47,8 @@ Write comments with these constraints:
 - Prefer single-line comments.
 - Keep ranges to at most 10 lines.
 - Restrict inline comments to valid changed lines in this PR.
+- Only create file-level or inline comments for files that exist in this PR's diff.
+- If the relevant file or line is not part of the diff, put the feedback in `summary` instead of `comments`.
 
 ## Suggestion Blocks
 

--- a/.agents/skills/review-spec/SKILL.md
+++ b/.agents/skills/review-spec/SKILL.md
@@ -50,6 +50,8 @@ Write comments with these constraints:
 - Prefer single-line comments.
 - Keep ranges to at most 10 lines.
 - Restrict inline comments to valid changed lines in this PR.
+- Only create file-level or inline comments for files that exist in this PR's diff.
+- If the relevant file or line is not part of the diff, put the feedback in `summary` instead of `comments`.
 
 ## Suggestion Blocks
 

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 from contextlib import closing
 
 import json
+import re
 from textwrap import dedent
+from typing import Any
 from github import Auth, Github
 
 from oz_workflows.env import optional_env, repo_parts, repo_slug, require_env, workspace
@@ -14,6 +16,141 @@ from oz_workflows.helpers import (
 )
 from oz_workflows.oz_client import build_agent_config, run_agent
 from oz_workflows.transport import cleanup_transport_comments, new_transport_token, poll_for_transport_payload
+
+HUNK_HEADER_PATTERN = re.compile(
+    r"^@@ -(?P<old_start>\d+)(?:,(?P<old_count>\d+))? \+(?P<new_start>\d+)(?:,(?P<new_count>\d+))? @@"
+)
+
+
+def _normalize_review_path(value: Any) -> str:
+    return (
+        str(value or "")
+        .strip()
+        .removeprefix("a/")
+        .removeprefix("b/")
+        .removeprefix("./")
+    )
+
+
+def _commentable_lines_for_patch(patch: str | None) -> dict[str, set[int]]:
+    commentable_lines = {"LEFT": set(), "RIGHT": set()}
+    if not patch:
+        return commentable_lines
+
+    old_line: int | None = None
+    new_line: int | None = None
+
+    for raw_line in patch.splitlines():
+        header_match = HUNK_HEADER_PATTERN.match(raw_line)
+        if header_match:
+            old_line = int(header_match.group("old_start"))
+            new_line = int(header_match.group("new_start"))
+            continue
+        if old_line is None or new_line is None or raw_line.startswith("\\"):
+            continue
+        marker = raw_line[:1]
+        if marker == "-":
+            commentable_lines["LEFT"].add(old_line)
+            old_line += 1
+        elif marker == "+":
+            commentable_lines["RIGHT"].add(new_line)
+            new_line += 1
+        elif marker == " ":
+            commentable_lines["RIGHT"].add(new_line)
+            old_line += 1
+            new_line += 1
+
+    return commentable_lines
+
+
+def _build_diff_line_map(pr: Any) -> dict[str, dict[str, set[int]]]:
+    return {
+        _normalize_review_path(file.filename): _commentable_lines_for_patch(
+            getattr(file, "patch", None)
+        )
+        for file in pr.get_files()
+    }
+
+
+def _normalize_review_payload(
+    review: dict[str, Any], diff_line_map: dict[str, dict[str, set[int]]]
+) -> tuple[str, list[dict[str, Any]]]:
+    if not isinstance(review, dict):
+        raise ValueError("Review payload must be a JSON object.")
+
+    summary = review.get("summary") or ""
+    if not isinstance(summary, str):
+        raise ValueError("Review payload `summary` must be a string.")
+
+    raw_comments = review.get("comments") or []
+    if not isinstance(raw_comments, list):
+        raise ValueError("Review payload `comments` must be a list.")
+
+    normalized_comments: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for index, raw_comment in enumerate(raw_comments):
+        if not isinstance(raw_comment, dict):
+            errors.append(f"`comments[{index}]` must be an object.")
+            continue
+
+        path = _normalize_review_path(raw_comment.get("path"))
+        line = raw_comment.get("line")
+        body = str(raw_comment.get("body") or "").strip()
+        side = raw_comment.get("side") if raw_comment.get("side") in {"LEFT", "RIGHT"} else "RIGHT"
+
+        if not path:
+            errors.append(f"`comments[{index}]` is missing `path`.")
+            continue
+        if path not in diff_line_map:
+            errors.append(
+                f"`comments[{index}]` references `{path}`, which is not part of the PR diff. Move that feedback to `summary` instead."
+            )
+            continue
+        if not isinstance(line, int) or line <= 0:
+            errors.append(
+                f"`comments[{index}]` for `{path}` must include a positive integer `line`."
+            )
+            continue
+        if not body:
+            errors.append(f"`comments[{index}]` for `{path}` is missing `body`.")
+            continue
+
+        allowed_lines = diff_line_map[path][side]
+        if line not in allowed_lines:
+            errors.append(
+                f"`comments[{index}]` references `{path}:{line}` on `{side}`, which is not commentable in the PR diff."
+            )
+            continue
+
+        normalized_comment: dict[str, Any] = {
+            "path": path,
+            "line": line,
+            "side": side,
+            "body": body,
+        }
+
+        if "start_line" in raw_comment and raw_comment.get("start_line") is not None:
+            start_line = raw_comment.get("start_line")
+            if not isinstance(start_line, int) or start_line <= 0 or start_line >= line:
+                errors.append(
+                    f"`comments[{index}]` for `{path}` has invalid `start_line`; it must be a positive integer smaller than `line`."
+                )
+                continue
+            if start_line not in allowed_lines:
+                errors.append(
+                    f"`comments[{index}]` references `{path}:{start_line}` on `{side}` as `start_line`, which is not commentable in the PR diff."
+                )
+                continue
+            normalized_comment["start_line"] = start_line
+            normalized_comment["start_side"] = side
+
+        normalized_comments.append(normalized_comment)
+
+    if errors:
+        raise ValueError("Invalid review payload:\n- " + "\n- ".join(errors))
+
+    return summary.strip(), normalized_comments
 
 
 def main() -> None:
@@ -99,6 +236,7 @@ def main() -> None:
             - You are running in a cloud environment rather than a local workflow checkout.
             - Fetch the PR branch, generate `pr_description.txt`, and generate `pr_diff.txt` yourself before applying the review skill.
             - The annotated diff must use the same prefixes as the old workflow: `[OLD:n]`, `[NEW:n]`, and `[OLD:n,NEW:m]`.
+            - Only include comments for files and lines that exist in the generated PR diff. If feedback does not map to a diff file or commentable diff line, put it in `summary` instead of `comments`.
             - If spec context is present above, write it to `spec_context.md` before reviewing so the repository's `check-impl-against-spec` skill can be used.
             - Do not post the final review directly.
             - After you create and validate `review.json`, gzip the UTF-8 contents of that file and then base64 encode the compressed bytes.
@@ -129,25 +267,8 @@ def main() -> None:
             )
             pr.get_issue_comment(transport_comment_id).delete()
             review = json.loads(payload["decoded_payload"])
-            summary = str(review.get("summary") or "").strip()
-            comments = []
-            for raw_comment in review.get("comments", []):
-                path = str(raw_comment.get("path") or "").strip().removeprefix("a/").removeprefix("b/").removeprefix("./")
-                line = raw_comment.get("line")
-                body = str(raw_comment.get("body") or "").strip()
-                if not path or not isinstance(line, int) or line <= 0 or not body:
-                    continue
-                normalized = {
-                    "path": path,
-                    "line": line,
-                    "side": raw_comment.get("side") if raw_comment.get("side") in {"LEFT", "RIGHT"} else "RIGHT",
-                    "body": body,
-                }
-                start_line = raw_comment.get("start_line")
-                if isinstance(start_line, int) and 0 < start_line < line:
-                    normalized["start_line"] = start_line
-                    normalized["start_side"] = normalized["side"]
-                comments.append(normalized)
+            diff_line_map = _build_diff_line_map(pr)
+            summary, comments = _normalize_review_payload(review, diff_line_map)
             if not summary and not comments:
                 progress.complete("I completed the review and did not identify any actionable feedback for this pull request.")
                 return

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -23,13 +23,9 @@ HUNK_HEADER_PATTERN = re.compile(
 
 
 def _normalize_review_path(value: Any) -> str:
-    return (
-        str(value or "")
-        .strip()
-        .removeprefix("a/")
-        .removeprefix("b/")
-        .removeprefix("./")
-    )
+    path = str(value or "").strip()
+    path = re.sub(r"^(a/|b/|\./)", "", path)
+    return path
 
 
 def _commentable_lines_for_patch(patch: str | None) -> dict[str, set[int]]:
@@ -56,6 +52,7 @@ def _commentable_lines_for_patch(patch: str | None) -> dict[str, set[int]]:
             commentable_lines["RIGHT"].add(new_line)
             new_line += 1
         elif marker == " ":
+            commentable_lines["LEFT"].add(old_line)
             commentable_lines["RIGHT"].add(new_line)
             old_line += 1
             new_line += 1
@@ -147,8 +144,8 @@ def _normalize_review_payload(
 
         normalized_comments.append(normalized_comment)
 
-    if errors:
-        raise ValueError("Invalid review payload:\n- " + "\n- ".join(errors))
+    for err in errors:
+        print(f"[review-validation] Dropped comment: {err}")
 
     return summary.strip(), normalized_comments
 

--- a/.github/scripts/tests/test_review_pr.py
+++ b/.github/scripts/tests/test_review_pr.py
@@ -2,7 +2,37 @@ from __future__ import annotations
 
 import unittest
 
-from review_pr import _commentable_lines_for_patch, _normalize_review_payload
+from review_pr import (
+    _commentable_lines_for_patch,
+    _normalize_review_path,
+    _normalize_review_payload,
+)
+
+
+class NormalizeReviewPathTest(unittest.TestCase):
+    def test_strips_a_prefix(self) -> None:
+        self.assertEqual(_normalize_review_path("a/src/file.py"), "src/file.py")
+
+    def test_strips_b_prefix(self) -> None:
+        self.assertEqual(_normalize_review_path("b/src/file.py"), "src/file.py")
+
+    def test_strips_dot_slash_prefix(self) -> None:
+        self.assertEqual(_normalize_review_path("./src/file.py"), "src/file.py")
+
+    def test_does_not_double_strip_a_b_path(self) -> None:
+        self.assertEqual(_normalize_review_path("a/b/real_dir/file.py"), "b/real_dir/file.py")
+
+    def test_no_prefix(self) -> None:
+        self.assertEqual(_normalize_review_path("src/file.py"), "src/file.py")
+
+    def test_none_value(self) -> None:
+        self.assertEqual(_normalize_review_path(None), "")
+
+    def test_empty_string(self) -> None:
+        self.assertEqual(_normalize_review_path(""), "")
+
+    def test_whitespace_stripped(self) -> None:
+        self.assertEqual(_normalize_review_path("  a/src/file.py  "), "src/file.py")
 
 
 class CommentableLinesForPatchTest(unittest.TestCase):
@@ -14,8 +44,49 @@ class CommentableLinesForPatchTest(unittest.TestCase):
  unchanged
 """
         result = _commentable_lines_for_patch(patch)
-        self.assertEqual(result["LEFT"], {11})
+        self.assertEqual(result["LEFT"], {10, 11, 12})
         self.assertEqual(result["RIGHT"], {10, 11, 12})
+
+    def test_context_lines_commentable_on_left(self) -> None:
+        patch = """@@ -5,3 +5,3 @@
+ context_a
+-removed
++added
+ context_b
+"""
+        result = _commentable_lines_for_patch(patch)
+        self.assertIn(5, result["LEFT"])
+        self.assertIn(7, result["LEFT"])
+        self.assertIn(5, result["RIGHT"])
+        self.assertIn(7, result["RIGHT"])
+
+    def test_multi_hunk_patch(self) -> None:
+        patch = """@@ -1,3 +1,3 @@
+ ctx
+-old1
++new1
+ ctx
+@@ -20,3 +20,3 @@
+ ctx
+-old2
++new2
+ ctx
+"""
+        result = _commentable_lines_for_patch(patch)
+        self.assertIn(2, result["LEFT"])
+        self.assertIn(2, result["RIGHT"])
+        self.assertIn(21, result["LEFT"])
+        self.assertIn(21, result["RIGHT"])
+
+    def test_empty_patch(self) -> None:
+        result = _commentable_lines_for_patch("")
+        self.assertEqual(result["LEFT"], set())
+        self.assertEqual(result["RIGHT"], set())
+
+    def test_none_patch(self) -> None:
+        result = _commentable_lines_for_patch(None)
+        self.assertEqual(result["LEFT"], set())
+        self.assertEqual(result["RIGHT"], set())
 
 
 class NormalizeReviewPayloadTest(unittest.TestCase):
@@ -48,7 +119,7 @@ class NormalizeReviewPayloadTest(unittest.TestCase):
             ],
         )
 
-    def test_rejects_comment_for_file_outside_diff(self) -> None:
+    def test_drops_comment_for_file_outside_diff(self) -> None:
         review = {
             "summary": "",
             "comments": [
@@ -61,15 +132,13 @@ class NormalizeReviewPayloadTest(unittest.TestCase):
             ],
         }
 
-        with self.assertRaisesRegex(
-            ValueError, "not part of the PR diff"
-        ):
-            _normalize_review_payload(
-                review,
-                {"src/example.py": {"LEFT": set(), "RIGHT": {1, 2, 3}}},
-            )
+        summary, comments = _normalize_review_payload(
+            review,
+            {"src/example.py": {"LEFT": set(), "RIGHT": {1, 2, 3}}},
+        )
+        self.assertEqual(comments, [])
 
-    def test_rejects_comment_for_non_commentable_line(self) -> None:
+    def test_drops_comment_for_non_commentable_line(self) -> None:
         review = {
             "summary": "",
             "comments": [
@@ -82,13 +151,172 @@ class NormalizeReviewPayloadTest(unittest.TestCase):
             ],
         }
 
-        with self.assertRaisesRegex(
-            ValueError, "not commentable in the PR diff"
-        ):
-            _normalize_review_payload(
-                review,
-                {"src/example.py": {"LEFT": {11}, "RIGHT": {10, 11, 12}}},
-            )
+        summary, comments = _normalize_review_payload(
+            review,
+            {"src/example.py": {"LEFT": {11}, "RIGHT": {10, 11, 12}}},
+        )
+        self.assertEqual(comments, [])
+
+    def test_keeps_valid_comments_when_some_are_invalid(self) -> None:
+        review = {
+            "summary": "Mixed bag.",
+            "comments": [
+                {
+                    "path": "src/example.py",
+                    "line": 10,
+                    "side": "RIGHT",
+                    "body": "Valid comment.",
+                },
+                {
+                    "path": "src/missing.py",
+                    "line": 1,
+                    "side": "RIGHT",
+                    "body": "Invalid file.",
+                },
+            ],
+        }
+
+        summary, comments = _normalize_review_payload(
+            review,
+            {"src/example.py": {"LEFT": set(), "RIGHT": {10, 11, 12}}},
+        )
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(comments[0]["body"], "Valid comment.")
+
+    def test_rejects_non_dict_payload(self) -> None:
+        with self.assertRaisesRegex(ValueError, "JSON object"):
+            _normalize_review_payload("not a dict", {})
+
+    def test_rejects_non_string_summary(self) -> None:
+        with self.assertRaisesRegex(ValueError, "`summary` must be a string"):
+            _normalize_review_payload({"summary": 42}, {})
+
+    def test_rejects_non_list_comments(self) -> None:
+        with self.assertRaisesRegex(ValueError, "`comments` must be a list"):
+            _normalize_review_payload({"summary": "", "comments": "nope"}, {})
+
+    def test_drops_non_dict_comment_entry(self) -> None:
+        review = {
+            "summary": "",
+            "comments": ["not a dict"],
+        }
+        summary, comments = _normalize_review_payload(review, {})
+        self.assertEqual(comments, [])
+
+    def test_accepts_valid_start_line(self) -> None:
+        review = {
+            "summary": "",
+            "comments": [
+                {
+                    "path": "src/example.py",
+                    "line": 12,
+                    "start_line": 10,
+                    "side": "RIGHT",
+                    "body": "Multi-line comment.",
+                }
+            ],
+        }
+        diff_line_map = {"src/example.py": {"LEFT": set(), "RIGHT": {10, 11, 12}}}
+        summary, comments = _normalize_review_payload(review, diff_line_map)
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(comments[0]["start_line"], 10)
+        self.assertEqual(comments[0]["start_side"], "RIGHT")
+
+    def test_drops_comment_with_invalid_start_line(self) -> None:
+        review = {
+            "summary": "",
+            "comments": [
+                {
+                    "path": "src/example.py",
+                    "line": 10,
+                    "start_line": 15,
+                    "side": "RIGHT",
+                    "body": "start_line >= line.",
+                }
+            ],
+        }
+        diff_line_map = {"src/example.py": {"LEFT": set(), "RIGHT": {10, 11, 12, 15}}}
+        summary, comments = _normalize_review_payload(review, diff_line_map)
+        self.assertEqual(comments, [])
+
+    def test_drops_comment_with_non_commentable_start_line(self) -> None:
+        review = {
+            "summary": "",
+            "comments": [
+                {
+                    "path": "src/example.py",
+                    "line": 12,
+                    "start_line": 8,
+                    "side": "RIGHT",
+                    "body": "start_line not in diff.",
+                }
+            ],
+        }
+        diff_line_map = {"src/example.py": {"LEFT": set(), "RIGHT": {10, 11, 12}}}
+        summary, comments = _normalize_review_payload(review, diff_line_map)
+        self.assertEqual(comments, [])
+
+    def test_drops_comment_missing_body(self) -> None:
+        review = {
+            "summary": "",
+            "comments": [
+                {
+                    "path": "src/example.py",
+                    "line": 10,
+                    "side": "RIGHT",
+                    "body": "",
+                }
+            ],
+        }
+        diff_line_map = {"src/example.py": {"LEFT": set(), "RIGHT": {10}}}
+        summary, comments = _normalize_review_payload(review, diff_line_map)
+        self.assertEqual(comments, [])
+
+    def test_drops_comment_missing_path(self) -> None:
+        review = {
+            "summary": "",
+            "comments": [
+                {
+                    "line": 10,
+                    "side": "RIGHT",
+                    "body": "No path.",
+                }
+            ],
+        }
+        summary, comments = _normalize_review_payload(review, {})
+        self.assertEqual(comments, [])
+
+    def test_drops_comment_with_non_integer_line(self) -> None:
+        review = {
+            "summary": "",
+            "comments": [
+                {
+                    "path": "src/example.py",
+                    "line": "ten",
+                    "side": "RIGHT",
+                    "body": "Bad line.",
+                }
+            ],
+        }
+        diff_line_map = {"src/example.py": {"LEFT": set(), "RIGHT": {10}}}
+        summary, comments = _normalize_review_payload(review, diff_line_map)
+        self.assertEqual(comments, [])
+
+    def test_defaults_side_to_right(self) -> None:
+        review = {
+            "summary": "",
+            "comments": [
+                {
+                    "path": "src/example.py",
+                    "line": 10,
+                    "body": "No explicit side.",
+                }
+            ],
+        }
+        diff_line_map = {"src/example.py": {"LEFT": set(), "RIGHT": {10}}}
+        summary, comments = _normalize_review_payload(review, diff_line_map)
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(comments[0]["side"], "RIGHT")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_review_pr.py
+++ b/.github/scripts/tests/test_review_pr.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import unittest
+
+from review_pr import _commentable_lines_for_patch, _normalize_review_payload
+
+
+class CommentableLinesForPatchTest(unittest.TestCase):
+    def test_tracks_valid_left_and_right_lines_from_patch(self) -> None:
+        patch = """@@ -10,3 +10,4 @@
+ context
+-old_value
++new_value
+ unchanged
+"""
+        result = _commentable_lines_for_patch(patch)
+        self.assertEqual(result["LEFT"], {11})
+        self.assertEqual(result["RIGHT"], {10, 11, 12})
+
+
+class NormalizeReviewPayloadTest(unittest.TestCase):
+    def test_accepts_comment_on_changed_file_and_line(self) -> None:
+        review = {
+            "summary": "## Overview\nLooks fine.",
+            "comments": [
+                {
+                    "path": "src/example.py",
+                    "line": 12,
+                    "side": "RIGHT",
+                    "body": "⚠️ [IMPORTANT] Handle the missing branch.",
+                }
+            ],
+        }
+        diff_line_map = {"src/example.py": {"LEFT": {11}, "RIGHT": {10, 11, 12}}}
+
+        summary, comments = _normalize_review_payload(review, diff_line_map)
+
+        self.assertEqual(summary, "## Overview\nLooks fine.")
+        self.assertEqual(
+            comments,
+            [
+                {
+                    "path": "src/example.py",
+                    "line": 12,
+                    "side": "RIGHT",
+                    "body": "⚠️ [IMPORTANT] Handle the missing branch.",
+                }
+            ],
+        )
+
+    def test_rejects_comment_for_file_outside_diff(self) -> None:
+        review = {
+            "summary": "",
+            "comments": [
+                {
+                    "path": "src/missing.py",
+                    "line": 12,
+                    "side": "RIGHT",
+                    "body": "💡 [SUGGESTION] Mentioned file is outside the diff.",
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(
+            ValueError, "not part of the PR diff"
+        ):
+            _normalize_review_payload(
+                review,
+                {"src/example.py": {"LEFT": set(), "RIGHT": {1, 2, 3}}},
+            )
+
+    def test_rejects_comment_for_non_commentable_line(self) -> None:
+        review = {
+            "summary": "",
+            "comments": [
+                {
+                    "path": "src/example.py",
+                    "line": 99,
+                    "side": "RIGHT",
+                    "body": "⚠️ [IMPORTANT] Wrong line.",
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(
+            ValueError, "not commentable in the PR diff"
+        ):
+            _normalize_review_payload(
+                review,
+                {"src/example.py": {"LEFT": {11}, "RIGHT": {10, 11, 12}}},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- teach the PR review skills to keep feedback in `summary` when it does not map to a file or line in the diff
- validate agent-generated `review.json` against the PR diff before calling the GitHub review API
- add unit coverage for diff line extraction and invalid review payloads

## Testing
- env PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p 'test_review_pr.py'
- env PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests

## Artifacts
- Conversation: https://staging.warp.dev/conversation/7dc7faea-ae92-4bfa-b6c9-6ef2e8a61f8c

Co-Authored-By: Oz <oz-agent@warp.dev>
