### PR TITLE
Make respond-to-pr-comment workflow reusable

### DIFF
--- a/.github/workflows/respond-to-pr-comment-local.yml
+++ b/.github/workflows/respond-to-pr-comment-local.yml
@@ -1,0 +1,22 @@
+name: Respond to PR Comment (Local)
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+concurrency:
+  group: respond-to-pr-comment-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+jobs:
+  respond:
+    if: >-
+      contains(github.event.comment.body, '@oz-agent') &&
+      contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association) &&
+      (github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request))
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/respond-to-pr-comment.yml
+    secrets: inherit

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -1,22 +1,24 @@
 name: Respond to PR Comment
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-concurrency:
-  group: respond-to-pr-comment-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: false
+  workflow_call:
+    secrets:
+      OZ_MGMT_GHA_APP_ID:
+        required: true
+      OZ_MGMT_GHA_PRIVATE_KEY:
+        required: true
+      WARP_API_KEY:
+        required: true
 jobs:
   respond:
     if: >-
-      contains(github.event.comment.body, '@oz-agent') &&
-      contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association) &&
       github.event.comment.user.type != 'Bot' &&
-      !endsWith(github.event.comment.user.login, '[bot]') &&
-      (github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request))
+      !endsWith(github.event.comment.user.login, '[bot]')
     name: Respond to PR comment
     runs-on: ubuntu-slim
+    env:
+      WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
+      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: write
       id-token: write
@@ -34,6 +36,13 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - name: Checkout workflow code
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ env.WORKFLOW_CODE_REPOSITORY }}
+          ref: ${{ env.WORKFLOW_CODE_REF }}
+          path: ${{ env.WORKFLOW_CODE_PATH }}
+          token: ${{ steps.app_token.outputs.token }}
       - name: Authenticate to Google Cloud for staging secret access
         uses: google-github-actions/auth@v2
         with:
@@ -57,14 +66,14 @@ jobs:
       - name: Install Python workflow dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r .github/scripts/requirements.txt
+          python -m pip install -r "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/requirements.txt"
       - name: Run respond-to-pr-comment workflow
         env:
-          PYTHONPATH: .github/scripts
+          PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
           STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
-        run: python .github/scripts/respond_to_pr_comment.py
+        run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/respond_to_pr_comment.py"


### PR DESCRIPTION
## Summary

- Converts `respond-to-pr-comment.yml` from a directly-triggered workflow (listening on `issue_comment` / `pull_request_review_comment`) to a reusable `workflow_call` workflow
- Follows the same pattern as `respond-to-triaged-issue-comment.yml` and other reusable workflows in this repo
- Adds the `WORKFLOW_CODE_REPOSITORY/REF/PATH` checkout pattern so the workflow can run in the context of external repositories
- Moves bot-filter conditions (`user.type != 'Bot'`, `!endsWith(..., '[bot]')`) into the job's `if:` guard; event-trigger conditions and concurrency move to the calling repo's indirection workflow

## Test plan

- [ ] Confirm the warp-external indirection workflow (companion PR) correctly delegates to this workflow on `@oz-agent` / `@warp-agent` PR comments
- [ ] Verify bot comments are still filtered out by the job-level `if:` guard
- [ ] Verify `pull_request_review_comment` and `issue_comment` (on PRs) both trigger as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)