### PR TITLE
Make oz runs publicly viewable

### DIFF
--- a/.github/scripts/oz_workflows/oz_client.py
+++ b/.github/scripts/oz_workflows/oz_client.py
@@ -26,7 +26,7 @@ DEFAULT_OZ_ORIGIN_TOKEN_ENV_NAME = "STAGING_ORIGIN_TOKEN"
 # WARP_SESSION_SHARING_PUBLIC_ACCESS environment variable; set it to "NONE" or
 # "OFF" to disable public sharing for a run.
 DEFAULT_SESSION_SHARING_PUBLIC_ACCESS = "VIEWER"
-_SESSION_SHARING_DISABLED_VALUES = {"", "NONE", "OFF", "DISABLED", "FALSE", "0"}
+_SESSION_SHARING_DISABLED_VALUES = {"NONE", "OFF", "DISABLED", "FALSE", "0"}
 _SESSION_SHARING_SUPPORTED_LEVELS = {"VIEWER", "EDITOR"}
 
 
@@ -74,9 +74,9 @@ def _resolve_session_sharing_public_access() -> str | None:
             f"{raw!r} is not a supported value; expected one of "
             f"{sorted(_SESSION_SHARING_SUPPORTED_LEVELS)} or a disable value "
             f"({sorted(_SESSION_SHARING_DISABLED_VALUES - {''})}). "
-            "Falling back to the default public-access level."
+            "Disabling public session sharing for this run."
         )
-        return DEFAULT_SESSION_SHARING_PUBLIC_ACCESS
+        return None
     return normalized
 
 

--- a/.github/scripts/oz_workflows/oz_client.py
+++ b/.github/scripts/oz_workflows/oz_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Callable, cast
+from typing import Any, Callable, cast
 
 from oz_agent_sdk import OzAPI
 from oz_agent_sdk.types import AgentRunParams, AmbientAgentConfigParam, McpServerConfigParam
@@ -15,6 +15,19 @@ from .env import optional_env, parse_mcp_servers, repo_slug, require_env, worksp
 TERMINAL_STATES = {"SUCCEEDED", "FAILED", "ERROR", "CANCELLED"}
 DEFAULT_OZ_API_BASE_URL = "https://staging.warp.dev/api/v1"
 DEFAULT_OZ_ORIGIN_TOKEN_ENV_NAME = "STAGING_ORIGIN_TOKEN"
+
+# Default public-access level for the run's shared session.
+#
+# The oz-for-oss workflows are intended for OSS repositories where community
+# members should be able to view agent activity through the session link
+# without being invited to the run's team. We therefore opt every run into
+# anyone-with-link viewer access by default. Callers that want to opt out or
+# pick a different level can override this via the
+# WARP_SESSION_SHARING_PUBLIC_ACCESS environment variable; set it to "NONE" or
+# "OFF" to disable public sharing for a run.
+DEFAULT_SESSION_SHARING_PUBLIC_ACCESS = "VIEWER"
+_SESSION_SHARING_DISABLED_VALUES = {"", "NONE", "OFF", "DISABLED", "FALSE", "0"}
+_SESSION_SHARING_SUPPORTED_LEVELS = {"VIEWER", "EDITOR"}
 
 
 def oz_api_base_url() -> str:
@@ -40,6 +53,31 @@ def build_oz_client() -> OzAPI:
             "x-oz-api-source": "GITHUB_ACTION",
         },
     )
+
+
+def _resolve_session_sharing_public_access() -> str | None:
+    """Resolve the configured public-access level for session sharing.
+
+    Returns the level string (``"VIEWER"`` or ``"EDITOR"``) when public session
+    sharing should be enabled for the run, or ``None`` when the caller has
+    explicitly disabled public sharing.
+    """
+    raw = optional_env("WARP_SESSION_SHARING_PUBLIC_ACCESS")
+    if raw == "":
+        return DEFAULT_SESSION_SHARING_PUBLIC_ACCESS
+    normalized = raw.upper()
+    if normalized in _SESSION_SHARING_DISABLED_VALUES:
+        return None
+    if normalized not in _SESSION_SHARING_SUPPORTED_LEVELS:
+        warning(
+            "WARP_SESSION_SHARING_PUBLIC_ACCESS="
+            f"{raw!r} is not a supported value; expected one of "
+            f"{sorted(_SESSION_SHARING_SUPPORTED_LEVELS)} or a disable value "
+            f"({sorted(_SESSION_SHARING_DISABLED_VALUES - {''})}). "
+            "Falling back to the default public-access level."
+        )
+        return DEFAULT_SESSION_SHARING_PUBLIC_ACCESS
+    return normalized
 
 
 def build_agent_config(
@@ -71,6 +109,19 @@ def build_agent_config(
         warning(
             "WARP_AGENT_PROFILE is set, but the Oz Python SDK does not expose CLI profile support. Ignoring it."
         )
+
+    # Opt runs into anyone-with-link viewer access so community members can
+    # follow along via the session link. This relies on the server-side
+    # `session_sharing.public_access` field added in APP-3762; the field is
+    # typed once the Oz SDK is regenerated from the updated OpenAPI spec. In
+    # the meantime the request body is serialized from this TypedDict
+    # (total=False) so the extra key passes through at runtime.
+    public_access = _resolve_session_sharing_public_access()
+    if public_access is not None:
+        cast(dict[str, Any], config)["session_sharing"] = {
+            "public_access": public_access,
+        }
+
     return config
 
 

--- a/.github/scripts/tests/test_oz_client.py
+++ b/.github/scripts/tests/test_oz_client.py
@@ -238,6 +238,101 @@ class BuildAgentConfigTest(unittest.TestCase):
                 workspace=Path("/tmp"),
             )
 
+    @patch.dict(os.environ, {"WARP_ENVIRONMENT_ID": "default-env"}, clear=True)
+    def test_defaults_session_sharing_to_viewer(self) -> None:
+        config = build_agent_config(
+            config_name="review-pull-request",
+            workspace=Path("/tmp"),
+        )
+        self.assertEqual(
+            dict(config).get("session_sharing"),
+            {"public_access": "VIEWER"},
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "WARP_ENVIRONMENT_ID": "default-env",
+            "WARP_SESSION_SHARING_PUBLIC_ACCESS": "EDITOR",
+        },
+        clear=True,
+    )
+    def test_session_sharing_can_be_set_to_editor(self) -> None:
+        config = build_agent_config(
+            config_name="review-pull-request",
+            workspace=Path("/tmp"),
+        )
+        self.assertEqual(
+            dict(config).get("session_sharing"),
+            {"public_access": "EDITOR"},
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "WARP_ENVIRONMENT_ID": "default-env",
+            "WARP_SESSION_SHARING_PUBLIC_ACCESS": "viewer",
+        },
+        clear=True,
+    )
+    def test_session_sharing_is_case_insensitive(self) -> None:
+        config = build_agent_config(
+            config_name="review-pull-request",
+            workspace=Path("/tmp"),
+        )
+        self.assertEqual(
+            dict(config).get("session_sharing"),
+            {"public_access": "VIEWER"},
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "WARP_ENVIRONMENT_ID": "default-env",
+            "WARP_SESSION_SHARING_PUBLIC_ACCESS": "none",
+        },
+        clear=True,
+    )
+    def test_session_sharing_can_be_disabled(self) -> None:
+        config = build_agent_config(
+            config_name="review-pull-request",
+            workspace=Path("/tmp"),
+        )
+        self.assertNotIn("session_sharing", dict(config))
+
+    @patch.dict(
+        os.environ,
+        {
+            "WARP_ENVIRONMENT_ID": "default-env",
+            "WARP_SESSION_SHARING_PUBLIC_ACCESS": "off",
+        },
+        clear=True,
+    )
+    def test_session_sharing_off_also_disables(self) -> None:
+        config = build_agent_config(
+            config_name="review-pull-request",
+            workspace=Path("/tmp"),
+        )
+        self.assertNotIn("session_sharing", dict(config))
+
+    @patch.dict(
+        os.environ,
+        {
+            "WARP_ENVIRONMENT_ID": "default-env",
+            "WARP_SESSION_SHARING_PUBLIC_ACCESS": "bogus",
+        },
+        clear=True,
+    )
+    def test_unknown_session_sharing_value_falls_back_to_default(self) -> None:
+        config = build_agent_config(
+            config_name="review-pull-request",
+            workspace=Path("/tmp"),
+        )
+        self.assertEqual(
+            dict(config).get("session_sharing"),
+            {"public_access": "VIEWER"},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/tests/test_oz_client.py
+++ b/.github/scripts/tests/test_oz_client.py
@@ -323,15 +323,12 @@ class BuildAgentConfigTest(unittest.TestCase):
         },
         clear=True,
     )
-    def test_unknown_session_sharing_value_falls_back_to_default(self) -> None:
+    def test_unknown_session_sharing_value_disables_sharing(self) -> None:
         config = build_agent_config(
             config_name="review-pull-request",
             workspace=Path("/tmp"),
         )
-        self.assertEqual(
-            dict(config).get("session_sharing"),
-            {"public_access": "VIEWER"},
-        )
+        self.assertNotIn("session_sharing", dict(config))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Specify this config when creating the oz agent run:

```
"session_sharing": {
    "public_access": "VIEWER"
  }
```

Depending on the server and client PRs implementing the tech and product spec for app-3762

## Testing

Only checked that this produces the correct payload. Will have to test e2e in staging.

Tested the payload itself e2e with all relevant PRs:
- https://github.com/warpdotdev/warp-server/pull/10526
- https://github.com/warpdotdev/oz-agent-worker/pull/53
- https://github.com/warpdotdev/warp-external/pull/854

https://www.loom.com/share/4848563ff61d46af829f90d42d2be792