### PR TITLE
fix: skip review for PRs authored by bots or org members

### DIFF
--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -14,6 +14,7 @@ from github.GithubException import GithubException
 from oz_workflows.env import optional_env, repo_parts, repo_slug, require_env, workspace
 from oz_workflows.helpers import (
     format_review_start_line,
+    is_automation_user,
     is_spec_only_pr,
     ORG_MEMBER_ASSOCIATIONS,
     POWERED_BY_SUFFIX,
@@ -76,6 +77,20 @@ def _is_non_member_pr(pr: Any) -> bool:
     """
     association = getattr(pr, "author_association", "") or ""
     return association not in ORG_MEMBER_ASSOCIATIONS
+
+
+def _is_bot_or_member_pr(pr: Any) -> bool:
+    """Return True when the PR author is a bot or an org member/collaborator.
+
+    Both cases should be skipped entirely: the workflow must not review its
+    own PRs (bot author) or PRs opened by org members, since those are
+    already subject to human review processes.
+    """
+    author = getattr(pr, "user", None)
+    if is_automation_user(author):
+        return True
+    association = str(getattr(pr, "author_association", "") or "")
+    return association in ORG_MEMBER_ASSOCIATIONS
 
 
 def _normalize_reviewer_logins(
@@ -410,6 +425,8 @@ def main() -> None:
         github = client.get_repo(repo_slug())
         pr = github.get_pull(pr_number)
         if pr.state != "open":
+            return
+        if _is_bot_or_member_pr(pr):
             return
         if comment_id_raw:
             pr.get_issue_comment(int(comment_id_raw)).create_reaction("eyes")

--- a/.github/scripts/tests/test_review_pr.py
+++ b/.github/scripts/tests/test_review_pr.py
@@ -8,6 +8,7 @@ from review_pr import (
     _commentable_lines_for_patch,
     _extract_suggestion_blocks,
     _format_review_completion_message,
+    _is_bot_or_member_pr,
     _is_non_member_pr,
     _line_content_for_patch,
     _normalize_review_path,
@@ -610,6 +611,48 @@ class IsNonMemberPrTest(unittest.TestCase):
 
     def test_missing_attribute_is_non_member(self) -> None:
         self.assertTrue(_is_non_member_pr(SimpleNamespace()))
+
+
+class IsBotOrMemberPrTest(unittest.TestCase):
+    def test_bot_user_type_returns_true(self) -> None:
+        pr = SimpleNamespace(
+            user=SimpleNamespace(login="oz-agent[bot]", type="Bot"),
+            author_association="NONE",
+        )
+        self.assertTrue(_is_bot_or_member_pr(pr))
+
+    def test_login_ending_in_bot_returns_true(self) -> None:
+        pr = SimpleNamespace(
+            user=SimpleNamespace(login="github-actions[bot]", type="User"),
+            author_association="CONTRIBUTOR",
+        )
+        self.assertTrue(_is_bot_or_member_pr(pr))
+
+    def test_org_member_associations_return_true(self) -> None:
+        for association in ["MEMBER", "OWNER", "COLLABORATOR"]:
+            with self.subTest(association=association):
+                pr = SimpleNamespace(
+                    user=SimpleNamespace(login="alice", type="User"),
+                    author_association=association,
+                )
+                self.assertTrue(_is_bot_or_member_pr(pr))
+
+    def test_external_contributor_returns_false(self) -> None:
+        for association in ["", "NONE", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR"]:
+            with self.subTest(association=association):
+                pr = SimpleNamespace(
+                    user=SimpleNamespace(login="alice", type="User"),
+                    author_association=association,
+                )
+                self.assertFalse(_is_bot_or_member_pr(pr))
+
+    def test_missing_user_attribute_falls_back_to_association(self) -> None:
+        pr = SimpleNamespace(author_association="NONE")
+        self.assertFalse(_is_bot_or_member_pr(pr))
+
+    def test_missing_user_attribute_member_association_returns_true(self) -> None:
+        pr = SimpleNamespace(author_association="MEMBER")
+        self.assertTrue(_is_bot_or_member_pr(pr))
 
 
 class NormalizeReviewerLoginsTest(unittest.TestCase):

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -84,6 +84,12 @@ jobs:
           focus = os.environ.get("INPUT_FOCUS", "")
           comment_id = os.environ.get("INPUT_COMMENT_ID", "")
           pr_number = input_pr_number or str(pr.get("number") or "")
+          pr_user = pr.get("user") or {}
+          pr_author_login = (pr_user.get("login") or "").strip().lower()
+          pr_author_type = (pr_user.get("type") or "").strip().lower()
+          pr_author_association = (pr.get("author_association") or "").strip()
+          is_bot_author = pr_author_type == "bot" or pr_author_login.endswith("[bot]")
+          is_member_author = pr_author_association in {"COLLABORATOR", "MEMBER", "OWNER"}
           matches_direct_trigger = (
               (action == "opened" and not pr.get("draft", False))
               or action == "ready_for_review"
@@ -92,6 +98,8 @@ jobs:
           )
           if input_pr_number:
               should_run = True
+          elif is_bot_author or is_member_author:
+              should_run = False
           elif head_ref.startswith("cherrypick"):
               should_run = False
           elif has_pr_hooks and event_name == "pull_request_target":
@@ -107,7 +115,9 @@ jobs:
               fh.write(focus)
               fh.write("\n__EOF__\n")
               fh.write(f"comment_id={comment_id}\n")
-              if has_pr_hooks and event_name == "pull_request_target" and not input_pr_number:
+              if is_bot_author or is_member_author:
+                  fh.write("skip_reason=bot-or-org-member-author\n")
+              elif has_pr_hooks and event_name == "pull_request_target" and not input_pr_number:
                   fh.write("skip_reason=pr-hooks-present\n")
               elif head_ref.startswith("cherrypick"):
                   fh.write("skip_reason=cherrypick-branch\n")


### PR DESCRIPTION
## Summary

- The review workflow was leaving APPROVE or REQUEST_CHANGES reviews on PRs opened by the Oz bot itself (whose `author_association` is `NONE`, so it incorrectly fell into the non-member APPROVE/REQUEST_CHANGES path).
- It was also leaving COMMENT-type reviews on PRs opened by org members (MEMBER, OWNER, COLLABORATOR), even though those go through human review processes.

## Root cause

`_is_non_member_pr` only checks `author_association`. GitHub Apps (bots) typically have `author_association = "NONE"` even when installed on the org, so they were treated as external contributors and subject to the APPROVE/REQUEST_CHANGES gate.

## Fix

- Adds `_is_bot_or_member_pr(pr)` which returns `True` when the PR author is a bot (`user.type == "Bot"` or login ends with `[bot]`) or an org member (`COLLABORATOR`, `MEMBER`, `OWNER`).
- `main()` returns early for these PRs before any side effects (no reaction, no progress comment, no agent run).
- The `Resolve review context` step in the workflow YAML also gains the same check so the agent is never started at all for direct `pull_request_target` triggers on these PRs.
- All 47 tests pass.

## Test plan

- [ ] Open a PR as `oz-agent[bot]` → workflow should skip with `skip_reason=bot-or-org-member-author`
- [ ] Open a PR as an org member → workflow should skip with the same reason
- [ ] Open a PR as an external contributor → workflow should proceed as before

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._