### PR TITLE
fix: always use COMMENT action for bot and org-member PR reviews

### DIFF
--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -494,9 +494,18 @@ def main() -> None:
         # PRs keep the existing COMMENT-only behavior. Spec-only PRs are
         # intentionally exempted from the gate so humans stay in the loop
         # earlier for spec changes.
-        is_non_member = _is_non_member_pr(pr) and not spec_only
+        #
+        # GitHub App bot accounts (login ends with "[bot]") report
+        # author_association as "NONE" even though they are org-owned, so
+        # _is_non_member_pr would incorrectly classify them as external
+        # contributors. Exclude them from the non-member path explicitly.
         pr_author_login = str(
             getattr(getattr(pr, "user", None), "login", "") or ""
+        )
+        is_non_member = (
+            _is_non_member_pr(pr)
+            and not spec_only
+            and not pr_author_login.endswith("[bot]")
         )
         non_member_review_section = ""
         if is_non_member:
@@ -641,6 +650,16 @@ def main() -> None:
                     event = "COMMENT"
                     recommended_reviewers = []
             else:
+                event = "COMMENT"
+                recommended_reviewers = []
+            # Deterministic post-verdict guard: always use COMMENT for PRs
+            # opened by the bot itself (GitHub App accounts whose login ends
+            # with "[bot]") or by org members/collaborators, regardless of
+            # any verdict the agent emitted in review.json. This is the
+            # authoritative filter — it applies even if the non-member
+            # classification above changes, ensuring APPROVE and
+            # REQUEST_CHANGES never land on trusted-author PRs.
+            if pr_author_login.endswith("[bot]") or not _is_non_member_pr(pr):
                 event = "COMMENT"
                 recommended_reviewers = []
             if not summary and not comments and event == "COMMENT":

--- a/.github/scripts/tests/test_review_pr.py
+++ b/.github/scripts/tests/test_review_pr.py
@@ -611,6 +611,14 @@ class IsNonMemberPrTest(unittest.TestCase):
     def test_missing_attribute_is_non_member(self) -> None:
         self.assertTrue(_is_non_member_pr(SimpleNamespace()))
 
+    def test_bot_account_association_is_none(self) -> None:
+        # GitHub App bot accounts report author_association as "NONE", so
+        # _is_non_member_pr returns True for them. The bot-login guard in
+        # main() (``pr_author_login.endswith("[bot]")``) is what prevents
+        # APPROVE/REQUEST_CHANGES from being used for bot-authored PRs.
+        pr = SimpleNamespace(author_association="NONE")
+        self.assertTrue(_is_non_member_pr(pr))
+
 
 class NormalizeReviewerLoginsTest(unittest.TestCase):
     def test_strips_at_signs_and_deduplicates(self) -> None:


### PR DESCRIPTION
## Summary

- **Root cause**: GitHub App bot accounts (e.g. `oz-agent[bot]`) report `author_association` as `"NONE"`, so `_is_non_member_pr` incorrectly classified them as external contributors. This caused the workflow to ask the agent for an `APPROVE`/`REQUEST_CHANGES` verdict and then post that as the formal review action on bot-authored PRs.
- **Fix 1 (pre-prompt)**: Exclude bot logins (ending with `[bot]`) from `is_non_member` at prompt-build time, so the agent is never asked for a verdict on bot-authored or org-member PRs.
- **Fix 2 (post-verdict, deterministic)**: Add an explicit guard immediately after the review event is resolved — if the PR author is a bot account or an org member/collaborator, the event is unconditionally reset to `COMMENT`. This guard is authoritative regardless of how the non-member classification is computed, satisfying the requirement to filter this out deterministically after reading the verdict from the agent.

## Test plan

- [ ] Existing `IsNonMemberPrTest` still passes (behavior of `_is_non_member_pr` is unchanged).
- [ ] New `test_bot_account_association_is_none` documents that bots have `"NONE"` association and that the filtering happens via the `[bot]` login guard in `main()`.
- [ ] Manual verification: open a PR with `oz-agent[bot]` as author; confirm the workflow posts a `COMMENT` review (not `APPROVE` or `REQUEST_CHANGES`).
- [ ] Manual verification: open a PR as an org member; confirm the review uses `COMMENT`.
- [ ] External contributor PRs should still receive `APPROVE`/`REQUEST_CHANGES` as before.

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._