### PR TITLE
Revert "chore: switch Oz workflows to production environment (#286)"

### DIFF
--- a/.github/scripts/oz_workflows/oz_client.py
+++ b/.github/scripts/oz_workflows/oz_client.py
@@ -19,11 +19,24 @@ def oz_api_base_url() -> str:
     """Return the configured Oz API base URL.
 
     Callers must explicitly set ``WARP_API_BASE_URL`` so that every workflow
-    declares which Oz environment it targets. This avoids silently running
-    against an unexpected environment when the variable is forgotten, which
-    is especially important for forks of this OSS template repository.
+    declares which Oz environment (staging vs. production) it targets. This
+    avoids silently running against staging when the variable is forgotten,
+    which is especially important for forks of this OSS template repository.
     """
     return require_env("WARP_API_BASE_URL")
+
+
+def oz_origin_token() -> str:
+    """Return the origin token required for Oz API requests.
+
+    Callers must explicitly set ``WARP_ORIGIN_TOKEN_ENV_NAME`` to the name of
+    the environment variable that holds the origin token. Pairing it with
+    ``WARP_API_BASE_URL`` forces every workflow to declare which environment
+    it targets and which secret it pulls, and fails fast with a clear error
+    when either is missing.
+    """
+    origin_token_env_name = require_env("WARP_ORIGIN_TOKEN_ENV_NAME")
+    return require_env(origin_token_env_name)
 
 
 def build_oz_client() -> OzAPI:
@@ -32,6 +45,7 @@ def build_oz_client() -> OzAPI:
         api_key=require_env("WARP_API_KEY"),
         base_url=oz_api_base_url(),
         default_headers={
+            "X-Warp-Origin-Token": oz_origin_token(),
             "x-oz-api-source": "GITHUB_ACTION",
         },
     )

--- a/.github/scripts/tests/test_oz_client.py
+++ b/.github/scripts/tests/test_oz_client.py
@@ -18,31 +18,79 @@ from oz_workflows.oz_client import (
 
 
 class BuildOzClientTest(unittest.TestCase):
-    def test_honors_base_url_env(self) -> None:
-        """``build_oz_client`` forwards ``WARP_API_BASE_URL`` to the ``OzAPI``
-        client and does not send any origin-token header.
-        """
-        env = {
-            "WARP_API_KEY": "fake-key",
-            "WARP_API_BASE_URL": "https://app.warp.dev/api/v1",
-        }
-        with patch.dict(os.environ, env, clear=True), patch(
-            "oz_workflows.oz_client.OzAPI"
-        ) as mock_oz_api:
-            build_oz_client()
-            _args, kwargs = mock_oz_api.call_args
-            headers = kwargs["default_headers"]
-            self.assertEqual(kwargs["base_url"], "https://app.warp.dev/api/v1")
-            self.assertEqual(headers["x-oz-api-source"], "GITHUB_ACTION")
-            self.assertNotIn("X-Warp-Origin-Token", headers)
+    def test_honors_base_url_and_origin_token_env(self) -> None:
+        """``build_oz_client`` forwards ``WARP_API_BASE_URL`` and the
+        origin token env-var name to the ``OzAPI`` client.
 
-    def test_requires_base_url(self) -> None:
-        """Missing ``WARP_API_BASE_URL`` must surface as ``RuntimeError``."""
-        env = {"WARP_API_KEY": "fake-key"}
-        with patch.dict(os.environ, env, clear=True):
-            with self.assertRaises(RuntimeError) as ctx:
-                build_oz_client()
-            self.assertIn("WARP_API_BASE_URL", str(ctx.exception))
+        Both the staging and production configurations are covered to
+        confirm that no base URL is hard-coded.
+        """
+        cases = [
+            (
+                "staging",
+                {
+                    "WARP_API_KEY": "fake-key",
+                    "WARP_API_BASE_URL": "https://staging.warp.dev/api/v1",
+                    "WARP_ORIGIN_TOKEN_ENV_NAME": "STAGING_ORIGIN_TOKEN",
+                    "STAGING_ORIGIN_TOKEN": "fake-token",
+                },
+                "https://staging.warp.dev/api/v1",
+                "fake-token",
+            ),
+            (
+                "production",
+                {
+                    "WARP_API_KEY": "fake-key",
+                    "WARP_API_BASE_URL": "https://app.warp.dev/api/v1",
+                    "WARP_ORIGIN_TOKEN_ENV_NAME": "PROD_ORIGIN_TOKEN",
+                    "PROD_ORIGIN_TOKEN": "prod-token",
+                },
+                "https://app.warp.dev/api/v1",
+                "prod-token",
+            ),
+        ]
+        for label, env, expected_base_url, expected_token in cases:
+            with self.subTest(label=label):
+                with patch.dict(os.environ, env, clear=True), patch(
+                    "oz_workflows.oz_client.OzAPI"
+                ) as mock_oz_api:
+                    build_oz_client()
+                    _args, kwargs = mock_oz_api.call_args
+                    headers = kwargs["default_headers"]
+                    self.assertEqual(kwargs["base_url"], expected_base_url)
+                    self.assertEqual(headers["x-oz-api-source"], "GITHUB_ACTION")
+                    self.assertEqual(
+                        headers["X-Warp-Origin-Token"], expected_token
+                    )
+
+    def test_requires_base_url_and_origin_token_env_name(self) -> None:
+        """Missing required env vars must surface as ``RuntimeError``."""
+        cases = [
+            (
+                "missing_base_url",
+                {
+                    "WARP_API_KEY": "fake-key",
+                    "WARP_ORIGIN_TOKEN_ENV_NAME": "STAGING_ORIGIN_TOKEN",
+                    "STAGING_ORIGIN_TOKEN": "fake-token",
+                },
+                "WARP_API_BASE_URL",
+            ),
+            (
+                "missing_origin_token_env_name",
+                {
+                    "WARP_API_KEY": "fake-key",
+                    "WARP_API_BASE_URL": "https://staging.warp.dev/api/v1",
+                    "STAGING_ORIGIN_TOKEN": "fake-token",
+                },
+                "WARP_ORIGIN_TOKEN_ENV_NAME",
+            ),
+        ]
+        for label, env, expected_missing in cases:
+            with self.subTest(label=label):
+                with patch.dict(os.environ, env, clear=True):
+                    with self.assertRaises(RuntimeError) as ctx:
+                        build_oz_client()
+                    self.assertIn(expected_missing, str(ctx.exception))
 
 
 class SkillSpecTest(unittest.TestCase):

--- a/.github/workflows/create-implementation-from-issue-local.yml
+++ b/.github/workflows/create-implementation-from-issue-local.yml
@@ -32,6 +32,7 @@ jobs:
     name: Create implementation diff
     permissions:
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/create-implementation-from-issue.yml

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     env:
@@ -39,6 +40,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -51,5 +68,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/create_implementation_from_issue.py"

--- a/.github/workflows/create-spec-from-issue-local.yml
+++ b/.github/workflows/create-spec-from-issue-local.yml
@@ -32,6 +32,7 @@ jobs:
     name: Create spec diff
     permissions:
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/create-spec-from-issue.yml

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     env:
@@ -39,6 +40,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -51,5 +68,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/create_spec_from_issue.py"

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -32,6 +32,7 @@ jobs:
       WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
     outputs:
@@ -53,6 +54,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -68,5 +85,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/enforce_pr_issue_state.py"

--- a/.github/workflows/respond-to-pr-comment-local.yml
+++ b/.github/workflows/respond-to-pr-comment-local.yml
@@ -15,6 +15,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request))
     permissions:
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/respond-to-pr-comment.yml

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -21,6 +21,7 @@ jobs:
       WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     steps:
@@ -42,6 +43,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -54,5 +71,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/respond_to_pr_comment.py"

--- a/.github/workflows/respond-to-triaged-issue-comment-local.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment-local.yml
@@ -18,6 +18,7 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'ready-to-implement')
     permissions:
       contents: read
+      id-token: write
       issues: write
     uses: ./.github/workflows/respond-to-triaged-issue-comment.yml
     secrets: inherit

--- a/.github/workflows/respond-to-triaged-issue-comment.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      id-token: write
       issues: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
@@ -42,6 +43,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -54,5 +71,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/respond_to_triaged_issue_comment.py"

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -50,6 +50,7 @@ jobs:
       WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: read
+      id-token: write
       pull-requests: write
       issues: write
     steps:
@@ -129,6 +130,25 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        if: steps.resolve.outputs.should_run == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        if: steps.resolve.outputs.should_run == 'true'
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        if: steps.resolve.outputs.should_run == 'true'
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         if: steps.resolve.outputs.should_run == 'true'
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
@@ -150,5 +170,7 @@ jobs:
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/review_pr.py"

--- a/.github/workflows/triage-new-issues-local.yml
+++ b/.github/workflows/triage-new-issues-local.yml
@@ -47,6 +47,7 @@ jobs:
       )
     permissions:
       contents: read
+      id-token: write
       issues: write
     uses: ./.github/workflows/triage-new-issues.yml
     with:

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      id-token: write
       issues: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
@@ -53,6 +54,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -67,5 +84,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/triage_new_issues.py"

--- a/.github/workflows/trigger-implementation-on-plan-approved-local.yml
+++ b/.github/workflows/trigger-implementation-on-plan-approved-local.yml
@@ -13,6 +13,7 @@ jobs:
     name: Trigger implementation for approved plan
     permissions:
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/trigger-implementation-on-plan-approved.yml

--- a/.github/workflows/trigger-implementation-on-plan-approved.yml
+++ b/.github/workflows/trigger-implementation-on-plan-approved.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
+      id-token: write
       issues: write
       pull-requests: write
     env:
@@ -39,6 +40,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -55,5 +72,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/trigger_implementation_on_plan_approved.py"

--- a/.github/workflows/update-dedupe-local.yml
+++ b/.github/workflows/update-dedupe-local.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     uses: ./.github/workflows/update-dedupe.yml
     with:
       lookback_days: ${{ github.event.inputs.lookback_days || '7' }}

--- a/.github/workflows/update-dedupe.yml
+++ b/.github/workflows/update-dedupe.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
       WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
@@ -41,6 +42,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -54,5 +71,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/update_dedupe.py"

--- a/.github/workflows/update-pr-review-local.yml
+++ b/.github/workflows/update-pr-review-local.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     uses: ./.github/workflows/update-pr-review.yml
     with:
       lookback_days: ${{ github.event.inputs.lookback_days || '7' }}

--- a/.github/workflows/update-pr-review.yml
+++ b/.github/workflows/update-pr-review.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
       WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
@@ -41,6 +42,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -54,5 +71,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/update_pr_review.py"

--- a/.github/workflows/update-triage-local.yml
+++ b/.github/workflows/update-triage-local.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     uses: ./.github/workflows/update-triage.yml
     with:
       lookback_days: ${{ github.event.inputs.lookback_days || '7' }}

--- a/.github/workflows/update-triage.yml
+++ b/.github/workflows/update-triage.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
       WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
@@ -41,6 +42,22 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
+      - name: Authenticate to Google Cloud for staging secret access
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Resolve staging origin token
+        id: staging_origin_token
+        run: |
+          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
+          printf '::add-mask::%s\n' "$token"
+          {
+            echo 'token<<EOF'
+            printf '%s\n' "$token"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -54,5 +71,7 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://app.warp.dev/api/v1
+          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
+          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
+          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/update_triage.py"


### PR DESCRIPTION
## Summary

- Reverts commit 77d33ad1b91dcfa162232b2b365a88cc4291efe6
- Restores the staging-specific plumbing: `oz_origin_token()`, `X-Warp-Origin-Token` header, `WARP_ORIGIN_TOKEN_ENV_NAME`, `STAGING_ORIGIN_TOKEN`, GCP auth / Cloud SDK steps, and `id-token: write` permissions across reusable workflows and their `-local` wrappers
- Reverts `WARP_API_BASE_URL` back to the staging endpoint

## Test plan

- [ ] Verify workflows run successfully against the staging environment
- [ ] Confirm origin token header is sent in requests

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._