### PR TITLE
revert: revert PR #288 (re-apply production environment switch)

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -149,5 +149,5 @@ If the prompt says you are in a cloud-environment workflow and the expected loca
 - Convert the raw diff into `pr_diff.txt` using the annotated format above before reviewing.
 - If the prompt includes spec context to materialize, write it to `spec_context.md` before running the review.
 - Still produce `review.json` and validate it with `jq`.
-- After validation, upload the result via `oz-dev artifact upload review.json`.
-- IMPORTANT: the upload command is `oz-dev artifact upload` (singular `artifact`). Do not use `artifacts` (plural) — that is not a valid subcommand and will fail.
+- After validation, upload the result via `oz artifact upload review.json`.
+- IMPORTANT: the upload command is `oz artifact upload` (singular `artifact`). Do not use `artifacts` (plural) — that is not a valid subcommand and will fail.

--- a/.agents/skills/review-spec/SKILL.md
+++ b/.agents/skills/review-spec/SKILL.md
@@ -144,5 +144,5 @@ If the prompt says you are in a cloud-environment workflow and the expected loca
   This isolates only the changes introduced by the PR, not accumulated state from other branches.
 - Convert the raw diff into `pr_diff.txt` using the annotated format above before reviewing.
 - Still produce `review.json` and validate it with `jq`.
-- After validation, upload the result via `oz-dev artifact upload review.json`.
-- IMPORTANT: the upload command is `oz-dev artifact upload` (singular `artifact`). Do not use `artifacts` (plural) — that is not a valid subcommand and will fail.
+- After validation, upload the result via `oz artifact upload review.json`.
+- IMPORTANT: the upload command is `oz artifact upload` (singular `artifact`). Do not use `artifacts` (plural) — that is not a valid subcommand and will fail.

--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -90,5 +90,5 @@ If the prompt says you are running in a cloud workflow:
 
 - still perform the triage as above
 - do not apply labels or edit the issue directly yourself
-- after validating `triage_result.json` with `jq`, upload it via `oz-dev artifact upload triage_result.json`
-- IMPORTANT: the upload command is `oz-dev artifact upload` (singular `artifact`). Do not use `artifacts` (plural) — that is not a valid subcommand and will fail.
+- after validating `triage_result.json` with `jq`, upload it via `oz artifact upload triage_result.json`
+- IMPORTANT: the upload command is `oz artifact upload` (singular `artifact`). Do not use `artifacts` (plural) — that is not a valid subcommand and will fail.

--- a/.github/scripts/create_implementation_from_issue.py
+++ b/.github/scripts/create_implementation_from_issue.py
@@ -162,7 +162,7 @@ def main() -> None:
               - `branch_name`: the branch you pushed to. You may customize it by appending a short descriptive slug to the default (e.g. `{target_branch}-add-retry-logic`), but it must start with `{target_branch}`.
               - `pr_title`: a conventional-commit-style PR title derived from the actual changes (e.g. `feat: add retry logic for transient API failures`).
               - `pr_summary`: the full markdown PR body (this replaces the former `pr_description.md` contents). The first line must be `Closes #{{issue_number}}` so GitHub auto-closes the issue when the PR merges.
-            - After writing `pr-metadata.json`, upload it as an artifact via `oz-dev artifact upload pr-metadata.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
+            - After writing `pr-metadata.json`, upload it as an artifact via `oz artifact upload pr-metadata.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
             - If you produce changes, commit them to the branch specified in your `pr-metadata.json` `branch_name` field and push that branch to origin.
             - Do not open or update the pull request yourself.
             - If no implementation diff is warranted, do not push the branch.

--- a/.github/scripts/create_spec_from_issue.py
+++ b/.github/scripts/create_spec_from_issue.py
@@ -103,7 +103,7 @@ def main() -> None:
               - `branch_name`: the branch you pushed to (use `{branch_name}` exactly).
               - `pr_title`: a conventional-commit-style PR title for the spec changes (e.g. `spec: {issue_title}`).
               - `pr_summary`: the full markdown PR body (this replaces the former `pr_description.md` contents).
-            - After writing `pr-metadata.json`, upload it as an artifact via `oz-dev artifact upload pr-metadata.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
+            - After writing `pr-metadata.json`, upload it as an artifact via `oz artifact upload pr-metadata.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
             - If you produce spec changes, commit only the spec changes to branch `{branch_name}` and push that branch to origin.
             - Do not open or update the pull request yourself.
             - If there is no worthwhile spec diff, do not push the branch.

--- a/.github/scripts/enforce_pr_issue_state.py
+++ b/.github/scripts/enforce_pr_issue_state.py
@@ -144,7 +144,7 @@ def main() -> None:
             - If there is no clear match, set `close_comment` to a concise PR comment explaining that this {change_kind} PR could not be matched to an issue marked `{required_label}` and include this contribution docs link: {contribution_docs_url}
             - Do not close the PR yourself.
             - Validate the JSON with `jq`.
-            - After validating the JSON, upload it as an artifact via `oz-dev artifact upload issue_association.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
+            - After validating the JSON, upload it as an artifact via `oz artifact upload issue_association.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
             """
         ).strip()
 

--- a/.github/scripts/oz_workflows/oz_client.py
+++ b/.github/scripts/oz_workflows/oz_client.py
@@ -19,24 +19,11 @@ def oz_api_base_url() -> str:
     """Return the configured Oz API base URL.
 
     Callers must explicitly set ``WARP_API_BASE_URL`` so that every workflow
-    declares which Oz environment (staging vs. production) it targets. This
-    avoids silently running against staging when the variable is forgotten,
-    which is especially important for forks of this OSS template repository.
+    declares which Oz environment it targets. This avoids silently running
+    against an unexpected environment when the variable is forgotten, which
+    is especially important for forks of this OSS template repository.
     """
     return require_env("WARP_API_BASE_URL")
-
-
-def oz_origin_token() -> str:
-    """Return the origin token required for Oz API requests.
-
-    Callers must explicitly set ``WARP_ORIGIN_TOKEN_ENV_NAME`` to the name of
-    the environment variable that holds the origin token. Pairing it with
-    ``WARP_API_BASE_URL`` forces every workflow to declare which environment
-    it targets and which secret it pulls, and fails fast with a clear error
-    when either is missing.
-    """
-    origin_token_env_name = require_env("WARP_ORIGIN_TOKEN_ENV_NAME")
-    return require_env(origin_token_env_name)
 
 
 def build_oz_client() -> OzAPI:
@@ -45,7 +32,6 @@ def build_oz_client() -> OzAPI:
         api_key=require_env("WARP_API_KEY"),
         base_url=oz_api_base_url(),
         default_headers={
-            "X-Warp-Origin-Token": oz_origin_token(),
             "x-oz-api-source": "GITHUB_ACTION",
         },
     )

--- a/.github/scripts/respond_to_pr_comment.py
+++ b/.github/scripts/respond_to_pr_comment.py
@@ -201,7 +201,7 @@ def _run_implementation(
           - `branch_name`: the branch you pushed to (use `{head_branch}` exactly).
           - `pr_title`: a conventional-commit-style PR title that reflects the PR's current combined scope (e.g. `feat: add retry logic for transient API failures` when implementation has been added on top of a spec PR).
           - `pr_summary`: the full markdown PR body reflecting the PR's current combined scope. When the original PR body started with `Closes #<issue_number>` or `Fixes #<issue_number>`, preserve that line at the top so GitHub still auto-closes the linked issue when the PR merges.
-        - After writing `pr-metadata.json`, upload it as an artifact via `oz-dev artifact upload pr-metadata.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
+        - After writing `pr-metadata.json`, upload it as an artifact via `oz artifact upload pr-metadata.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
         - If your changes are minor tweaks that do not change the PR's scope (for example, fixing a typo in a spec, adjusting wording, or small bug fixes within the PR's existing scope), do not write or upload `pr-metadata.json`. Leaving it out signals that the existing PR title and description should remain unchanged.
 
         Resolved Review Comment Reporting:
@@ -216,7 +216,7 @@ def _run_implementation(
           }}
         - Each `summary` must be a short, reviewer-facing explanation (1-3 sentences) describing what changed.
         - Validate the JSON with `jq` after writing it.
-        - Upload it as an artifact via `oz-dev artifact upload resolved_review_comments.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
+        - Upload it as an artifact via `oz artifact upload resolved_review_comments.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
         - Do not upload the artifact when no review comments were resolved. Omitting the file is the correct signal that no review threads need to be closed.
         {coauthor_directives}
         """

--- a/.github/scripts/respond_to_triaged_issue_comment.py
+++ b/.github/scripts/respond_to_triaged_issue_comment.py
@@ -124,7 +124,7 @@ def main() -> None:
             - Do not include HTML metadata inside `analysis_comment`.
             - Validate `issue_response.json` with `jq`.
             - Do not create issue comments or make other GitHub changes.
-            - After validating the JSON, upload it as an artifact via `oz-dev artifact upload issue_response.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
+            - After validating the JSON, upload it as an artifact via `oz artifact upload issue_response.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
             """
         ).strip()
 

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -410,7 +410,7 @@ def main() -> None:
             - Only include comments for files and lines that exist in the generated PR diff. If feedback does not map to a diff file or commentable diff line, put it in `summary` instead of `comments`.
             - If spec context is present above, write it to `spec_context.md` before reviewing so the repository's `check-impl-against-spec` skill can be used.
             - Do not post the final review directly.
-            - After you create and validate `review.json`, upload it as an artifact via `oz-dev artifact upload review.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
+            - After you create and validate `review.json`, upload it as an artifact via `oz artifact upload review.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
             """
         ).strip()
         if repo_local_section:

--- a/.github/scripts/tests/test_oz_client.py
+++ b/.github/scripts/tests/test_oz_client.py
@@ -18,79 +18,31 @@ from oz_workflows.oz_client import (
 
 
 class BuildOzClientTest(unittest.TestCase):
-    def test_honors_base_url_and_origin_token_env(self) -> None:
-        """``build_oz_client`` forwards ``WARP_API_BASE_URL`` and the
-        origin token env-var name to the ``OzAPI`` client.
-
-        Both the staging and production configurations are covered to
-        confirm that no base URL is hard-coded.
+    def test_honors_base_url_env(self) -> None:
+        """``build_oz_client`` forwards ``WARP_API_BASE_URL`` to the ``OzAPI``
+        client and does not send any origin-token header.
         """
-        cases = [
-            (
-                "staging",
-                {
-                    "WARP_API_KEY": "fake-key",
-                    "WARP_API_BASE_URL": "https://staging.warp.dev/api/v1",
-                    "WARP_ORIGIN_TOKEN_ENV_NAME": "STAGING_ORIGIN_TOKEN",
-                    "STAGING_ORIGIN_TOKEN": "fake-token",
-                },
-                "https://staging.warp.dev/api/v1",
-                "fake-token",
-            ),
-            (
-                "production",
-                {
-                    "WARP_API_KEY": "fake-key",
-                    "WARP_API_BASE_URL": "https://app.warp.dev/api/v1",
-                    "WARP_ORIGIN_TOKEN_ENV_NAME": "PROD_ORIGIN_TOKEN",
-                    "PROD_ORIGIN_TOKEN": "prod-token",
-                },
-                "https://app.warp.dev/api/v1",
-                "prod-token",
-            ),
-        ]
-        for label, env, expected_base_url, expected_token in cases:
-            with self.subTest(label=label):
-                with patch.dict(os.environ, env, clear=True), patch(
-                    "oz_workflows.oz_client.OzAPI"
-                ) as mock_oz_api:
-                    build_oz_client()
-                    _args, kwargs = mock_oz_api.call_args
-                    headers = kwargs["default_headers"]
-                    self.assertEqual(kwargs["base_url"], expected_base_url)
-                    self.assertEqual(headers["x-oz-api-source"], "GITHUB_ACTION")
-                    self.assertEqual(
-                        headers["X-Warp-Origin-Token"], expected_token
-                    )
+        env = {
+            "WARP_API_KEY": "fake-key",
+            "WARP_API_BASE_URL": "https://app.warp.dev/api/v1",
+        }
+        with patch.dict(os.environ, env, clear=True), patch(
+            "oz_workflows.oz_client.OzAPI"
+        ) as mock_oz_api:
+            build_oz_client()
+            _args, kwargs = mock_oz_api.call_args
+            headers = kwargs["default_headers"]
+            self.assertEqual(kwargs["base_url"], "https://app.warp.dev/api/v1")
+            self.assertEqual(headers["x-oz-api-source"], "GITHUB_ACTION")
+            self.assertNotIn("X-Warp-Origin-Token", headers)
 
-    def test_requires_base_url_and_origin_token_env_name(self) -> None:
-        """Missing required env vars must surface as ``RuntimeError``."""
-        cases = [
-            (
-                "missing_base_url",
-                {
-                    "WARP_API_KEY": "fake-key",
-                    "WARP_ORIGIN_TOKEN_ENV_NAME": "STAGING_ORIGIN_TOKEN",
-                    "STAGING_ORIGIN_TOKEN": "fake-token",
-                },
-                "WARP_API_BASE_URL",
-            ),
-            (
-                "missing_origin_token_env_name",
-                {
-                    "WARP_API_KEY": "fake-key",
-                    "WARP_API_BASE_URL": "https://staging.warp.dev/api/v1",
-                    "STAGING_ORIGIN_TOKEN": "fake-token",
-                },
-                "WARP_ORIGIN_TOKEN_ENV_NAME",
-            ),
-        ]
-        for label, env, expected_missing in cases:
-            with self.subTest(label=label):
-                with patch.dict(os.environ, env, clear=True):
-                    with self.assertRaises(RuntimeError) as ctx:
-                        build_oz_client()
-                    self.assertIn(expected_missing, str(ctx.exception))
+    def test_requires_base_url(self) -> None:
+        """Missing ``WARP_API_BASE_URL`` must surface as ``RuntimeError``."""
+        env = {"WARP_API_KEY": "fake-key"}
+        with patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(RuntimeError) as ctx:
+                build_oz_client()
+            self.assertIn("WARP_API_BASE_URL", str(ctx.exception))
 
 
 class SkillSpecTest(unittest.TestCase):

--- a/.github/scripts/tests/test_respond_to_pr_comment.py
+++ b/.github/scripts/tests/test_respond_to_pr_comment.py
@@ -236,7 +236,7 @@ class RunImplementationPromptTest(unittest.TestCase):
         self.assertIn("pr-metadata.json", prompt)
         self.assertIn("pr_title", prompt)
         self.assertIn("pr_summary", prompt)
-        self.assertIn("oz-dev artifact upload pr-metadata.json", prompt)
+        self.assertIn("oz artifact upload pr-metadata.json", prompt)
         # The prompt must describe when to write the artifact and when to
         # skip it so small tweaks don't churn the PR description.
         self.assertIn("materially change", prompt)

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -291,7 +291,7 @@ def process_issue(
         - Populate `issue_body` with the markdown triage summary that should be posted as a separate issue comment. Do not rewrite the original issue description, and do not include HTML metadata in `issue_body`.
         - Validate `triage_result.json` with `jq`.
         - Do not create issue comments or make other GitHub changes.
-        - After validating the JSON, upload it as an artifact via `oz-dev artifact upload triage_result.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
+        - After validating the JSON, upload it as an artifact via `oz artifact upload triage_result.json`. The subcommand is `artifact` (singular); do not use `artifacts`.
         """
     ).strip()
     # Append the fenced repo-local references after the base prompt so a

--- a/.github/workflows/create-implementation-from-issue-local.yml
+++ b/.github/workflows/create-implementation-from-issue-local.yml
@@ -32,7 +32,6 @@ jobs:
     name: Create implementation diff
     permissions:
       contents: write
-      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/create-implementation-from-issue.yml

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      id-token: write
       issues: write
       pull-requests: write
     env:
@@ -40,22 +39,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -68,7 +51,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/create_implementation_from_issue.py"

--- a/.github/workflows/create-spec-from-issue-local.yml
+++ b/.github/workflows/create-spec-from-issue-local.yml
@@ -32,7 +32,6 @@ jobs:
     name: Create spec diff
     permissions:
       contents: write
-      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/create-spec-from-issue.yml

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      id-token: write
       issues: write
       pull-requests: write
     env:
@@ -40,22 +39,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -68,7 +51,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/create_spec_from_issue.py"

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -32,7 +32,6 @@ jobs:
       WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: read
-      id-token: write
       issues: write
       pull-requests: write
     outputs:
@@ -54,22 +53,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -85,7 +68,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/enforce_pr_issue_state.py"

--- a/.github/workflows/respond-to-pr-comment-local.yml
+++ b/.github/workflows/respond-to-pr-comment-local.yml
@@ -15,7 +15,6 @@ jobs:
       (github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request))
     permissions:
       contents: write
-      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/respond-to-pr-comment.yml

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -21,7 +21,6 @@ jobs:
       WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: write
-      id-token: write
       issues: write
       pull-requests: write
     steps:
@@ -43,22 +42,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -71,7 +54,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/respond_to_pr_comment.py"

--- a/.github/workflows/respond-to-triaged-issue-comment-local.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment-local.yml
@@ -18,7 +18,6 @@ jobs:
       !contains(github.event.issue.labels.*.name, 'ready-to-implement')
     permissions:
       contents: read
-      id-token: write
       issues: write
     uses: ./.github/workflows/respond-to-triaged-issue-comment.yml
     secrets: inherit

--- a/.github/workflows/respond-to-triaged-issue-comment.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      id-token: write
       issues: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
@@ -43,22 +42,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -71,7 +54,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/respond_to_triaged_issue_comment.py"

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -50,7 +50,6 @@ jobs:
       WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: read
-      id-token: write
       pull-requests: write
       issues: write
     steps:
@@ -130,25 +129,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        if: steps.resolve.outputs.should_run == 'true'
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        if: steps.resolve.outputs.should_run == 'true'
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        if: steps.resolve.outputs.should_run == 'true'
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         if: steps.resolve.outputs.should_run == 'true'
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
@@ -170,7 +150,5 @@ jobs:
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/review_pr.py"

--- a/.github/workflows/triage-new-issues-local.yml
+++ b/.github/workflows/triage-new-issues-local.yml
@@ -47,7 +47,6 @@ jobs:
       )
     permissions:
       contents: read
-      id-token: write
       issues: write
     uses: ./.github/workflows/triage-new-issues.yml
     with:

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -29,7 +29,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      id-token: write
       issues: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
@@ -54,22 +53,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -84,7 +67,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/triage_new_issues.py"

--- a/.github/workflows/trigger-implementation-on-plan-approved-local.yml
+++ b/.github/workflows/trigger-implementation-on-plan-approved-local.yml
@@ -13,7 +13,6 @@ jobs:
     name: Trigger implementation for approved plan
     permissions:
       contents: write
-      id-token: write
       issues: write
       pull-requests: write
     uses: ./.github/workflows/trigger-implementation-on-plan-approved.yml

--- a/.github/workflows/trigger-implementation-on-plan-approved.yml
+++ b/.github/workflows/trigger-implementation-on-plan-approved.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      id-token: write
       issues: write
       pull-requests: write
     env:
@@ -40,22 +39,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -72,7 +55,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/trigger_implementation_on_plan_approved.py"

--- a/.github/workflows/update-dedupe-local.yml
+++ b/.github/workflows/update-dedupe-local.yml
@@ -14,7 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     uses: ./.github/workflows/update-dedupe.yml
     with:
       lookback_days: ${{ github.event.inputs.lookback_days || '7' }}

--- a/.github/workflows/update-dedupe.yml
+++ b/.github/workflows/update-dedupe.yml
@@ -20,7 +20,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
       WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
@@ -42,22 +41,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -71,7 +54,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/update_dedupe.py"

--- a/.github/workflows/update-pr-review-local.yml
+++ b/.github/workflows/update-pr-review-local.yml
@@ -14,7 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     uses: ./.github/workflows/update-pr-review.yml
     with:
       lookback_days: ${{ github.event.inputs.lookback_days || '7' }}

--- a/.github/workflows/update-pr-review.yml
+++ b/.github/workflows/update-pr-review.yml
@@ -20,7 +20,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
       WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
@@ -42,22 +41,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -71,7 +54,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/update_pr_review.py"

--- a/.github/workflows/update-triage-local.yml
+++ b/.github/workflows/update-triage-local.yml
@@ -14,7 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     uses: ./.github/workflows/update-triage.yml
     with:
       lookback_days: ${{ github.event.inputs.lookback_days || '7' }}

--- a/.github/workflows/update-triage.yml
+++ b/.github/workflows/update-triage.yml
@@ -20,7 +20,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
       WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
@@ -42,22 +41,6 @@ jobs:
           ref: ${{ env.WORKFLOW_CODE_REF }}
           path: ${{ env.WORKFLOW_CODE_PATH }}
           token: ${{ steps.app_token.outputs.token }}
-      - name: Authenticate to Google Cloud for staging secret access
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Resolve staging origin token
-        id: staging_origin_token
-        run: |
-          token="$(gcloud --project=warp-server-staging secrets versions access latest --secret=staging-origin-token)"
-          printf '::add-mask::%s\n' "$token"
-          {
-            echo 'token<<EOF'
-            printf '%s\n' "$token"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Set up Oz Python environment
         uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main
         with:
@@ -71,7 +54,5 @@ jobs:
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}
           WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
-          WARP_API_BASE_URL: https://staging.warp.dev/api/v1
-          WARP_ORIGIN_TOKEN_ENV_NAME: STAGING_ORIGIN_TOKEN
-          STAGING_ORIGIN_TOKEN: ${{ steps.staging_origin_token.outputs.token }}
+          WARP_API_BASE_URL: https://app.warp.dev/api/v1
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/update_triage.py"


### PR DESCRIPTION
## Summary

- Reverts PR #288 ("Revert 'chore: switch Oz workflows to production environment (#286)'")
- Re-applies the production environment changes from PR #286: switches `WARP_API_BASE_URL` to the production endpoint, removes staging-specific `oz_origin_token()` / `X-Warp-Origin-Token` header / `STAGING_ORIGIN_TOKEN` plumbing, and drops the GCP auth / Cloud SDK steps and `id-token: write` permissions

## Test plan

- [ ] Verify workflows run successfully against the production environment
- [ ] Confirm no staging-specific origin token header is sent in requests

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._