### PR TITLE
fix: resolve FETCH_CONTEXT_SCRIPT path relative to WORKFLOW_CODE_PATH

### DIFF
--- a/.github/scripts/respond_to_pr_comment.py
+++ b/.github/scripts/respond_to_pr_comment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from contextlib import closing
+import os
 
 from datetime import timedelta
 from textwrap import dedent
@@ -26,7 +27,12 @@ from oz_workflows.helpers import (
 )
 from oz_workflows.oz_client import build_agent_config, run_agent
 
-FETCH_CONTEXT_SCRIPT = ".agents/skills/implement-specs/scripts/fetch_github_context.py"
+# The fetch_github_context.py script lives in the oz-for-oss repo, which is
+# checked out by the workflow at the path given by WORKFLOW_CODE_PATH
+# (defaulting to __oz_shared). The bare relative path used here previously
+# pointed into the caller's repo root, where the script does not exist.
+_WORKFLOW_CODE_PATH = os.environ.get("WORKFLOW_CODE_PATH", "__oz_shared")
+FETCH_CONTEXT_SCRIPT = f"{_WORKFLOW_CODE_PATH}/.agents/skills/implement-specs/scripts/fetch_github_context.py"
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

- `FETCH_CONTEXT_SCRIPT` in `respond_to_pr_comment.py` was a bare relative path (`.agents/skills/implement-specs/scripts/fetch_github_context.py`) pointing into the **caller repo's root**
- `fetch_github_context.py` lives in **oz-for-oss**, checked out by the workflow at `__oz_shared/` (the `WORKFLOW_CODE_PATH` env var)
- Caller repos like `warp-external` don't have `fetch_github_context.py` at that path — the agent got a `FileNotFoundError`, found the triggering comment absent from the empty output, and followed the prompt's no-op instruction
- This caused org MEMBERs (e.g. `kevinchevalier` with `author_association: MEMBER`) to be falsely treated as untrusted users when using `respond-to-pr-comment`

**Fix**: derive the script path from `WORKFLOW_CODE_PATH` (the env var the workflow already sets to the oz-for-oss checkout location), defaulting to `__oz_shared`.

## Test plan

- [ ] Comment `@oz-agent` on a PR in warp-external as an org MEMBER — agent should now successfully run `fetch_github_context.py` and act on the request rather than no-op
- [ ] Verify that `WORKFLOW_CODE_PATH` is available in the Python execution environment (it's a job-level env var in the `respond` job of `respond-to-pr-comment.yml`, inherited by all steps)
- [ ] Confirm the resolved path matches `__oz_shared/.agents/skills/implement-specs/scripts/fetch_github_context.py` at runtime

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._