### PR TITLE
Apply review-action gate to all PRs, including member PRs

### DIFF
--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -95,6 +95,34 @@ def _is_non_member_pr(pr: Any) -> bool:
     return normalized not in ORG_MEMBER_ASSOCIATIONS
 
 
+def _should_gate_review(pr: Any, *, spec_only: bool) -> bool:
+    """Return True if the PR should go through the review-action gate.
+
+    The review-action gate asks the agent to commit to a verdict
+    (``APPROVE`` or ``REQUEST_CHANGES``) and a list of recommended
+    reviewers, which the workflow turns into a formal pull-request
+    review plus reviewer requests.
+
+    A PR is gated when:
+    - it is not a spec-only PR (spec-only PRs intentionally stay on the
+      ``COMMENT`` path so humans stay in the loop earlier for spec
+      changes), and
+    - it is not authored by an automation account (bots, including the
+      Oz bot reviewing its own PRs, always fall back to ``COMMENT`` so
+      we never attempt an APPROVE/REQUEST_CHANGES on an automation
+      PR; GitHub also rejects self-APPROVE on bot-authored PRs).
+
+    Note: organization membership is intentionally not part of this
+    predicate. All non-bot, non-spec PRs receive the gate regardless of
+    the author's ``author_association``.
+    """
+    if spec_only:
+        return False
+    if is_automation_user(getattr(pr, "user", None)):
+        return False
+    return True
+
+
 def _stakeholder_logins(entries: list[dict[str, Any]]) -> set[str]:
     """Return the set of owner logins that appear in ``.github/STAKEHOLDERS``.
 
@@ -545,7 +573,7 @@ def main() -> None:
         # automation accounts fall back to COMMENT-only behavior. Spec-only
         # PRs are intentionally exempted from the gate so humans stay in
         # the loop earlier for spec changes.
-        is_review_gated = not spec_only and not is_automation_user(getattr(pr, "user", None))
+        is_review_gated = _should_gate_review(pr, spec_only=spec_only)
         pr_author_login = str(
             getattr(getattr(pr, "user", None), "login", "") or ""
         )

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -537,21 +537,21 @@ def main() -> None:
         else:
             repo_local_section = ""
 
-        # Non-member PRs go through an additional "review action" gate: the
+        # All non-bot, non-spec PRs go through the review-action gate: the
         # agent is asked to emit a verdict (APPROVE or REQUEST_CHANGES) and
         # a list of matching ``.github/STAKEHOLDERS`` logins to request as
         # human reviewers, and the workflow turns those into a real
-        # pull-request review plus reviewer requests. Member/collaborator
-        # PRs keep the existing COMMENT-only behavior. Spec-only PRs are
-        # intentionally exempted from the gate so humans stay in the loop
-        # earlier for spec changes.
-        is_non_member = _is_non_member_pr(pr) and not spec_only
+        # pull-request review plus reviewer requests. PRs authored by
+        # automation accounts fall back to COMMENT-only behavior. Spec-only
+        # PRs are intentionally exempted from the gate so humans stay in
+        # the loop earlier for spec changes.
+        is_review_gated = not spec_only and not is_automation_user(getattr(pr, "user", None))
         pr_author_login = str(
             getattr(getattr(pr, "user", None), "login", "") or ""
         )
-        non_member_review_section = ""
+        review_action_section = ""
         stakeholder_logins: set[str] = set()
-        if is_non_member:
+        if is_review_gated:
             stakeholders_entries = load_stakeholders(
                 Path(workspace()) / ".github" / "STAKEHOLDERS"
             )
@@ -559,12 +559,11 @@ def main() -> None:
             stakeholders_block = format_stakeholders_for_prompt(
                 stakeholders_entries
             )
-            non_member_review_section = dedent(
+            review_action_section = dedent(
                 f"""
-                Non-Member Review Action:
-                - The PR author (@{pr_author_login or 'unknown'}) is not a
-                  repository member or collaborator, so this review must
-                  commit to a verdict rather than just leaving comments.
+                Review Action:
+                - This review must commit to a verdict rather than just
+                  leaving comments.
                 - Choose exactly one ``verdict`` for the review, using the
                   GitHub review event naming:
                   - ``APPROVE`` when the PR looks ready for a human to
@@ -647,12 +646,12 @@ def main() -> None:
                 "\n\n" + repo_local_section.rstrip() + "\n\nCloud Workflow Requirements:",
                 1,
             )
-        if non_member_review_section:
-            # Append the non-member review-action block after the Cloud
-            # Workflow Requirements so the base review behavior (comments
-            # etc.) is still described up front, and the additional
+        if review_action_section:
+            # Append the review-action block after the Cloud Workflow
+            # Requirements so the base review behavior (comments etc.) is
+            # still described up front, and the additional
             # verdict/stakeholder contract is laid out separately.
-            prompt = prompt + "\n\n" + non_member_review_section
+            prompt = prompt + "\n\n" + review_action_section
 
         config = build_agent_config(
             config_name="review-pull-request",
@@ -673,7 +672,7 @@ def main() -> None:
             summary, comments = _normalize_review_payload(
                 review, diff_line_map, diff_content_map
             )
-            if is_non_member:
+            if is_review_gated:
                 try:
                     event, recommended_reviewers = _resolve_non_member_review_action(
                         review,
@@ -687,7 +686,7 @@ def main() -> None:
                     # failing the whole workflow and throwing away the
                     # feedback that was produced.
                     logger.exception(
-                        "Falling back to COMMENT for non-member PR #%s in %s/%s due to invalid review action payload",
+                        "Falling back to COMMENT for PR #%s in %s/%s due to invalid review action payload",
                         pr_number,
                         owner,
                         repo,
@@ -698,10 +697,10 @@ def main() -> None:
                 event = "COMMENT"
                 recommended_reviewers = []
             if not summary and not comments and event == "COMMENT":
-                # For member PRs the legacy short-circuit stands: if the
-                # agent had nothing to say, skip posting an empty review.
-                # Non-member PRs always post so the verdict lands on the
-                # PR even when the agent has no inline comments.
+                # For bot-authored PRs the COMMENT short-circuit stands:
+                # if the agent had nothing to say, skip posting an empty
+                # review. Review-gated PRs always post so the verdict lands
+                # on the PR even when the agent has no inline comments.
                 progress.complete("I completed the review and did not identify any actionable feedback for this pull request.")
                 return
             review_body = f"{summary or 'Automated review'}\n\n{POWERED_BY_SUFFIX}"

--- a/.github/scripts/tests/test_review_pr.py
+++ b/.github/scripts/tests/test_review_pr.py
@@ -14,6 +14,7 @@ from review_pr import (
     _normalize_review_payload,
     _normalize_reviewer_logins,
     _resolve_non_member_review_action,
+    _should_gate_review,
     _stakeholder_logins,
     _validate_suggestion_blocks,
 )
@@ -657,6 +658,94 @@ class IsNonMemberPrTest(unittest.TestCase):
                 with self.subTest(label=label, association=association):
                     pr = SimpleNamespace(author_association=association, user=user)
                     self.assertFalse(_is_non_member_pr(pr))
+
+
+class ShouldGateReviewTest(unittest.TestCase):
+    """Covers the ``_should_gate_review`` production predicate.
+
+    The review-action gate applies to every non-bot, non-spec PR
+    regardless of ``author_association``. These tests lock in that
+    contract so future revisions (for example, restoring a
+    members-excluded gate) have to update the predicate and its tests
+    together.
+    """
+
+    def test_non_bot_pr_is_gated_regardless_of_association(self) -> None:
+        """Org membership must not affect the gate decision.
+
+        The whole point of this change is to apply the gate to member
+        and non-member PRs alike, so every realistic
+        ``author_association`` value should still result in a gated
+        review when the author is not an automation account.
+        """
+        associations = [
+            "NONE",
+            "CONTRIBUTOR",
+            "FIRST_TIME_CONTRIBUTOR",
+            "COLLABORATOR",
+            "MEMBER",
+            "OWNER",
+            "",
+            None,
+        ]
+        for association in associations:
+            with self.subTest(association=association):
+                pr = SimpleNamespace(
+                    author_association=association,
+                    user=SimpleNamespace(login="alice", type="User"),
+                )
+                self.assertTrue(_should_gate_review(pr, spec_only=False))
+
+    def test_spec_only_pr_is_not_gated(self) -> None:
+        pr = SimpleNamespace(
+            author_association="NONE",
+            user=SimpleNamespace(login="alice", type="User"),
+        )
+        self.assertFalse(_should_gate_review(pr, spec_only=True))
+
+    def test_bot_authored_pr_is_not_gated(self) -> None:
+        """Bot PRs always fall back to COMMENT regardless of spec_only.
+
+        GitHub rejects self-APPROVE on bot-authored PRs and we do not
+        want the review workflow leaving a formal verdict on
+        automation-authored changes.
+        """
+        bot_cases = [
+            ("bot_type", SimpleNamespace(login="some-user", type="Bot")),
+            ("bot_suffix", SimpleNamespace(login="dependabot[bot]", type="User")),
+            ("oz_agent", SimpleNamespace(login="oz-agent[bot]", type="Bot")),
+        ]
+        for label, user in bot_cases:
+            with self.subTest(label=label):
+                pr = SimpleNamespace(
+                    author_association="MEMBER",
+                    user=user,
+                )
+                self.assertFalse(_should_gate_review(pr, spec_only=False))
+                self.assertFalse(_should_gate_review(pr, spec_only=True))
+
+    def test_spec_only_short_circuits_before_user_check(self) -> None:
+        """Spec-only PRs skip the gate even when ``pr.user`` is missing.
+
+        This guards against regressions where the gate accidentally
+        depends on a fully-populated ``pr`` object for spec PRs.
+        """
+        self.assertFalse(
+            _should_gate_review(SimpleNamespace(), spec_only=True)
+        )
+
+    def test_missing_user_attribute_is_treated_as_non_bot(self) -> None:
+        """A PR with no ``user`` attribute falls through to the gate.
+
+        ``is_automation_user`` returns False for a missing/None user,
+        so the predicate must gate such a PR. In production the PR
+        object from PyGithub always has a ``user`` populated; this
+        test just documents the defensive behavior for a bare
+        ``SimpleNamespace``.
+        """
+        self.assertTrue(
+            _should_gate_review(SimpleNamespace(), spec_only=False)
+        )
 
 
 class NormalizeReviewerLoginsTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Previously the APPROVE/REQUEST\_CHANGES verdict and stakeholder review request in `review_pr.py` only applied to non-member PRs; member and collaborator PRs received a COMMENT-only review with no stakeholder notification.
- This change removes the member/non-member distinction: any non-bot, non-spec-only PR now goes through the full review-action gate regardless of the author's org membership.
- Bot-authored PRs and spec-only PRs remain on the COMMENT-only path, unchanged.

## Test plan

- [x] All 390 existing unit tests pass (`pytest .github/scripts/tests/`)
- [x] `test_review_pr.py` — 52 tests pass, covering the affected helpers
- [ ] Verify a member PR in a repo using `pr-hooks.yml` now receives an APPROVE/REQUEST\_CHANGES review with stakeholder requests rather than a COMMENT-only review

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._