### PR TITLE
fix: move trust check into reusable workflows

### DIFF
--- a/.github/workflows/create-implementation-from-issue-local.yml
+++ b/.github/workflows/create-implementation-from-issue-local.yml
@@ -8,77 +8,13 @@ concurrency:
   group: create-implementation-issue-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 jobs:
-  # For ``issue_comment`` triggers, ``author_association`` can report
-  # ``CONTRIBUTOR`` for actual org members (private membership, etc.),
-  # so we fall back to ``GET /orgs/{org}/members/{login}`` via the app
-  # token before allowing the implementation run. Non-comment triggers
-  # (assignment / labeling by maintainers) bypass this gate.
-  check_trust:
-    name: Check commenter trust
-    if: >-
-      github.event_name == 'issue_comment' &&
-      !github.event.issue.pull_request &&
-      contains(github.event.issue.labels.*.name, 'ready-to-implement') &&
-      contains(github.event.comment.body, '@oz-agent') &&
-      github.event.comment.user.type != 'Bot' &&
-      !endsWith(github.event.comment.user.login, '[bot]')
-    runs-on: ubuntu-slim
-    outputs:
-      trusted: ${{ steps.evaluate.outputs.trusted }}
-    steps:
-      - name: Create GitHub App token
-        id: app_token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
-          owner: ${{ github.repository_owner }}
-          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      - name: Evaluate commenter trust
-        id: evaluate
-        env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          ASSOCIATION: ${{ github.event.comment.author_association }}
-          ACTOR: ${{ github.event.comment.user.login }}
-          ORG: ${{ github.repository_owner }}
-        run: |
-          set -euo pipefail
-          case "${ASSOCIATION:-}" in
-            OWNER|MEMBER|COLLABORATOR)
-              echo "Treating @${ACTOR} as trusted via author_association=${ASSOCIATION}."
-              echo "trusted=true" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
-          if gh api --silent "/orgs/${ORG}/members/${ACTOR}" 2>/dev/null; then
-            echo "Treating @${ACTOR} as trusted via /orgs/${ORG}/members (association=${ASSOCIATION})."
-            echo "trusted=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Ignoring @oz-agent mention from @${ACTOR}; not an org member (association=${ASSOCIATION})."
-            echo "trusted=false" >> "$GITHUB_OUTPUT"
-          fi
+  # Mention, bot, event-type, and trust gates all live in the reusable
+  # workflow (``create-implementation-from-issue.yml``). This adapter
+  # exists only to subscribe to the GitHub events that can trigger
+  # implementation work (``issues`` assign/label by a maintainer, or a
+  # trusted ``@oz-agent`` / ``@warp-agent`` issue comment) and delegate
+  # them through ``workflow_call``.
   create_implementation:
-    needs: [check_trust]
-    # ``always()`` so the ``issues`` branch still runs even when the
-    # sibling ``check_trust`` job was skipped (it only runs for
-    # ``issue_comment`` triggers).
-    if: >-
-      always() && (
-        (
-          github.event_name == 'issues' &&
-          github.event.action == 'assigned' &&
-          github.event.assignee.login == 'oz-agent' &&
-          contains(github.event.issue.labels.*.name, 'ready-to-implement')
-        ) || (
-          github.event_name == 'issues' &&
-          github.event.action == 'labeled' &&
-          github.event.label.name == 'ready-to-implement' &&
-          contains(github.event.issue.assignees.*.login, 'oz-agent')
-        ) || (
-          github.event_name == 'issue_comment' &&
-          needs.check_trust.outputs.trusted == 'true'
-        )
-      )
-    name: Create implementation diff
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/create-implementation-from-issue-local.yml
+++ b/.github/workflows/create-implementation-from-issue-local.yml
@@ -12,8 +12,8 @@ jobs:
   # workflow (``create-implementation-from-issue.yml``). This adapter
   # exists only to subscribe to the GitHub events that can trigger
   # implementation work (``issues`` assign/label by a maintainer, or a
-  # trusted ``@oz-agent`` / ``@warp-agent`` issue comment) and delegate
-  # them through ``workflow_call``.
+  # trusted ``@oz-agent`` issue comment) and delegate them through
+  # ``workflow_call``.
   create_implementation:
     permissions:
       contents: write

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -28,7 +28,7 @@ jobs:
       github.event_name == 'issue_comment' &&
       !github.event.issue.pull_request &&
       contains(github.event.issue.labels.*.name, 'ready-to-implement') &&
-      (contains(github.event.comment.body, '@oz-agent') || contains(github.event.comment.body, '@warp-agent')) &&
+      contains(github.event.comment.body, '@oz-agent') &&
       github.event.comment.user.type != 'Bot' &&
       !endsWith(github.event.comment.user.login, '[bot]')
     runs-on: ubuntu-slim

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -9,7 +9,84 @@ on:
       WARP_API_KEY:
         required: true
 jobs:
+  # ``author_association`` is scoped to the repository, so an actual org
+  # member may still report as ``CONTRIBUTOR`` (private membership,
+  # contribution-history ordering, etc.). Gate the implementation run
+  # on either the static allowlist OR a positive
+  # ``GET /orgs/{org}/members/{login}`` probe so legitimate maintainer
+  # comments are not dropped.
+  #
+  # Only ``issue_comment`` triggers go through ``check_trust``. The
+  # ``issues`` assign/label branches are already trust-safe because
+  # only maintainers can assign or label, so ``create_implementation``
+  # admits them directly. Downstream adapters only need the ``on:``
+  # triggers plus a pass-through ``uses:`` call; mention, bot,
+  # event-type, and trust gates all live in this file.
+  check_trust:
+    name: Check commenter trust
+    if: >-
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      contains(github.event.issue.labels.*.name, 'ready-to-implement') &&
+      (contains(github.event.comment.body, '@oz-agent') || contains(github.event.comment.body, '@warp-agent')) &&
+      github.event.comment.user.type != 'Bot' &&
+      !endsWith(github.event.comment.user.login, '[bot]')
+    runs-on: ubuntu-slim
+    outputs:
+      trusted: ${{ steps.evaluate.outputs.trusted }}
+    steps:
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          owner: ${{ github.repository_owner }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
+      - name: Evaluate commenter trust
+        id: evaluate
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          ASSOCIATION: ${{ github.event.comment.author_association }}
+          ACTOR: ${{ github.event.comment.user.login }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          case "${ASSOCIATION:-}" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "Treating @${ACTOR} as trusted via author_association=${ASSOCIATION}."
+              echo "trusted=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          if gh api --silent "/orgs/${ORG}/members/${ACTOR}" 2>/dev/null; then
+            echo "Treating @${ACTOR} as trusted via /orgs/${ORG}/members (association=${ASSOCIATION})."
+            echo "trusted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Ignoring @oz-agent mention from @${ACTOR}; not an org member (association=${ASSOCIATION})."
+            echo "trusted=false" >> "$GITHUB_OUTPUT"
+          fi
   create_implementation:
+    needs: [check_trust]
+    # ``always()`` so the ``issues`` branch still runs even when the
+    # sibling ``check_trust`` job was skipped (it only runs for
+    # ``issue_comment`` triggers).
+    if: >-
+      always() && (
+        (
+          github.event_name == 'issues' &&
+          github.event.action == 'assigned' &&
+          github.event.assignee.login == 'oz-agent' &&
+          contains(github.event.issue.labels.*.name, 'ready-to-implement')
+        ) || (
+          github.event_name == 'issues' &&
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'ready-to-implement' &&
+          contains(github.event.issue.assignees.*.login, 'oz-agent')
+        ) || (
+          github.event_name == 'issue_comment' &&
+          needs.check_trust.outputs.trusted == 'true'
+        )
+      )
     name: Create implementation diff
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/create-spec-from-issue-local.yml
+++ b/.github/workflows/create-spec-from-issue-local.yml
@@ -12,8 +12,8 @@ jobs:
   # workflow (``create-spec-from-issue.yml``). This adapter exists only
   # to subscribe to the GitHub events that can trigger spec creation
   # (``issues`` assign/label by a maintainer, or a trusted
-  # ``@oz-agent`` / ``@warp-agent`` issue comment) and delegate them
-  # through ``workflow_call``.
+  # ``@oz-agent`` issue comment) and delegate them through
+  # ``workflow_call``.
   create_spec:
     permissions:
       contents: write

--- a/.github/workflows/create-spec-from-issue-local.yml
+++ b/.github/workflows/create-spec-from-issue-local.yml
@@ -8,77 +8,13 @@ concurrency:
   group: create-spec-issue-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 jobs:
-  # For ``issue_comment`` triggers, ``author_association`` can report
-  # ``CONTRIBUTOR`` for actual org members (private membership, etc.),
-  # so we fall back to ``GET /orgs/{org}/members/{login}`` via the app
-  # token before allowing the spec-creation run. Non-comment triggers
-  # (assignment / labeling by maintainers) bypass this gate.
-  check_trust:
-    name: Check commenter trust
-    if: >-
-      github.event_name == 'issue_comment' &&
-      !github.event.issue.pull_request &&
-      contains(github.event.issue.labels.*.name, 'ready-to-spec') &&
-      contains(github.event.comment.body, '@oz-agent') &&
-      github.event.comment.user.type != 'Bot' &&
-      !endsWith(github.event.comment.user.login, '[bot]')
-    runs-on: ubuntu-slim
-    outputs:
-      trusted: ${{ steps.evaluate.outputs.trusted }}
-    steps:
-      - name: Create GitHub App token
-        id: app_token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
-          owner: ${{ github.repository_owner }}
-          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      - name: Evaluate commenter trust
-        id: evaluate
-        env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          ASSOCIATION: ${{ github.event.comment.author_association }}
-          ACTOR: ${{ github.event.comment.user.login }}
-          ORG: ${{ github.repository_owner }}
-        run: |
-          set -euo pipefail
-          case "${ASSOCIATION:-}" in
-            OWNER|MEMBER|COLLABORATOR)
-              echo "Treating @${ACTOR} as trusted via author_association=${ASSOCIATION}."
-              echo "trusted=true" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
-          if gh api --silent "/orgs/${ORG}/members/${ACTOR}" 2>/dev/null; then
-            echo "Treating @${ACTOR} as trusted via /orgs/${ORG}/members (association=${ASSOCIATION})."
-            echo "trusted=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Ignoring @oz-agent mention from @${ACTOR}; not an org member (association=${ASSOCIATION})."
-            echo "trusted=false" >> "$GITHUB_OUTPUT"
-          fi
+  # Mention, bot, event-type, and trust gates all live in the reusable
+  # workflow (``create-spec-from-issue.yml``). This adapter exists only
+  # to subscribe to the GitHub events that can trigger spec creation
+  # (``issues`` assign/label by a maintainer, or a trusted
+  # ``@oz-agent`` / ``@warp-agent`` issue comment) and delegate them
+  # through ``workflow_call``.
   create_spec:
-    needs: [check_trust]
-    # ``always()`` so the ``issues`` branch still runs even when the
-    # sibling ``check_trust`` job was skipped (it only runs for
-    # ``issue_comment`` triggers).
-    if: >-
-      always() && (
-        (
-          github.event_name == 'issues' &&
-          github.event.action == 'assigned' &&
-          github.event.assignee.login == 'oz-agent' &&
-          contains(github.event.issue.labels.*.name, 'ready-to-spec')
-        ) || (
-          github.event_name == 'issues' &&
-          github.event.action == 'labeled' &&
-          github.event.label.name == 'ready-to-spec' &&
-          contains(github.event.issue.assignees.*.login, 'oz-agent')
-        ) || (
-          github.event_name == 'issue_comment' &&
-          needs.check_trust.outputs.trusted == 'true'
-        )
-      )
-    name: Create spec diff
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -28,7 +28,7 @@ jobs:
       github.event_name == 'issue_comment' &&
       !github.event.issue.pull_request &&
       contains(github.event.issue.labels.*.name, 'ready-to-spec') &&
-      (contains(github.event.comment.body, '@oz-agent') || contains(github.event.comment.body, '@warp-agent')) &&
+      contains(github.event.comment.body, '@oz-agent') &&
       github.event.comment.user.type != 'Bot' &&
       !endsWith(github.event.comment.user.login, '[bot]')
     runs-on: ubuntu-slim

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -9,7 +9,84 @@ on:
       WARP_API_KEY:
         required: true
 jobs:
+  # ``author_association`` is scoped to the repository, so an actual org
+  # member may still report as ``CONTRIBUTOR`` (private membership,
+  # contribution-history ordering, etc.). Gate the spec-creation run
+  # on either the static allowlist OR a positive
+  # ``GET /orgs/{org}/members/{login}`` probe so legitimate maintainer
+  # comments are not dropped.
+  #
+  # Only ``issue_comment`` triggers go through ``check_trust``. The
+  # ``issues`` assign/label branches are already trust-safe because
+  # only maintainers can assign or label, so ``create_spec`` admits
+  # them directly. Downstream adapters only need the ``on:`` triggers
+  # plus a pass-through ``uses:`` call; mention, bot, event-type, and
+  # trust gates all live in this file.
+  check_trust:
+    name: Check commenter trust
+    if: >-
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      contains(github.event.issue.labels.*.name, 'ready-to-spec') &&
+      (contains(github.event.comment.body, '@oz-agent') || contains(github.event.comment.body, '@warp-agent')) &&
+      github.event.comment.user.type != 'Bot' &&
+      !endsWith(github.event.comment.user.login, '[bot]')
+    runs-on: ubuntu-slim
+    outputs:
+      trusted: ${{ steps.evaluate.outputs.trusted }}
+    steps:
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          owner: ${{ github.repository_owner }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
+      - name: Evaluate commenter trust
+        id: evaluate
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          ASSOCIATION: ${{ github.event.comment.author_association }}
+          ACTOR: ${{ github.event.comment.user.login }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          case "${ASSOCIATION:-}" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "Treating @${ACTOR} as trusted via author_association=${ASSOCIATION}."
+              echo "trusted=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          if gh api --silent "/orgs/${ORG}/members/${ACTOR}" 2>/dev/null; then
+            echo "Treating @${ACTOR} as trusted via /orgs/${ORG}/members (association=${ASSOCIATION})."
+            echo "trusted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Ignoring @oz-agent mention from @${ACTOR}; not an org member (association=${ASSOCIATION})."
+            echo "trusted=false" >> "$GITHUB_OUTPUT"
+          fi
   create_spec:
+    needs: [check_trust]
+    # ``always()`` so the ``issues`` branch still runs even when the
+    # sibling ``check_trust`` job was skipped (it only runs for
+    # ``issue_comment`` triggers).
+    if: >-
+      always() && (
+        (
+          github.event_name == 'issues' &&
+          github.event.action == 'assigned' &&
+          github.event.assignee.login == 'oz-agent' &&
+          contains(github.event.issue.labels.*.name, 'ready-to-spec')
+        ) || (
+          github.event_name == 'issues' &&
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'ready-to-spec' &&
+          contains(github.event.issue.assignees.*.login, 'oz-agent')
+        ) || (
+          github.event_name == 'issue_comment' &&
+          needs.check_trust.outputs.trusted == 'true'
+        )
+      )
     name: Create spec diff
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/respond-to-pr-comment-local.yml
+++ b/.github/workflows/respond-to-pr-comment-local.yml
@@ -13,8 +13,8 @@ jobs:
   # Mention, bot, event-type, and trust gates all live in the reusable
   # workflow (``respond-to-pr-comment.yml``). This adapter exists only
   # to subscribe to the three GitHub events that can carry an
-  # ``@oz-agent`` / ``@warp-agent`` mention on a PR and delegate them
-  # through ``workflow_call``.
+  # ``@oz-agent`` mention on a PR and delegate them through
+  # ``workflow_call``.
   respond:
     permissions:
       contents: write

--- a/.github/workflows/respond-to-pr-comment-local.yml
+++ b/.github/workflows/respond-to-pr-comment-local.yml
@@ -10,81 +10,12 @@ concurrency:
   group: respond-to-pr-comment-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false
 jobs:
-  # ``author_association`` is scoped to the repository, so an actual org
-  # member may still report as ``CONTRIBUTOR`` (private membership,
-  # contribution-history ordering, PR review comment edge cases). We
-  # gate the agent run on either the static allowlist OR a positive
-  # ``GET /orgs/{org}/members/{login}`` probe so we do not drop
-  # legitimate maintainer comments without also opening the door to
-  # non-member CONTRIBUTORs.
-  #
-  # Three GitHub events can carry an ``@oz-agent`` mention on a PR:
-  # an ``issue_comment`` on the PR conversation, a
-  # ``pull_request_review_comment`` on a specific line, and the
-  # top-level body of a ``pull_request_review``. The first two expose
-  # the payload under ``github.event.comment``; the last exposes it
-  # under ``github.event.review``. We dispatch all three here so a
-  # mention in a review body triggers the agent the same way an inline
-  # comment or conversation comment does.
-  check_trust:
-    name: Check commenter trust
-    if: >-
-      (
-        (
-          (github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
-          contains(github.event.comment.body, '@oz-agent') &&
-          github.event.comment.user.type != 'Bot' &&
-          !endsWith(github.event.comment.user.login, '[bot]')
-        ) ||
-        (
-          github.event_name == 'pull_request_review' &&
-          contains(github.event.review.body, '@oz-agent') &&
-          github.event.review.user.type != 'Bot' &&
-          !endsWith(github.event.review.user.login, '[bot]')
-        )
-      )
-    runs-on: ubuntu-slim
-    outputs:
-      trusted: ${{ steps.evaluate.outputs.trusted }}
-    steps:
-      - name: Create GitHub App token
-        id: app_token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
-          owner: ${{ github.repository_owner }}
-          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      - name: Evaluate commenter trust
-        id: evaluate
-        env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          # ``pull_request_review`` events carry the author under
-          # ``github.event.review``; comment-based events carry it under
-          # ``github.event.comment``. Use GitHub expression fall-through
-          # so either shape resolves to the right identity without
-          # needing parallel branches below.
-          ASSOCIATION: ${{ github.event.comment.author_association || github.event.review.author_association }}
-          ACTOR: ${{ github.event.comment.user.login || github.event.review.user.login }}
-          ORG: ${{ github.repository_owner }}
-        run: |
-          set -euo pipefail
-          case "${ASSOCIATION:-}" in
-            OWNER|MEMBER|COLLABORATOR)
-              echo "Treating @${ACTOR} as trusted via author_association=${ASSOCIATION}."
-              echo "trusted=true" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-          esac
-          if gh api --silent "/orgs/${ORG}/members/${ACTOR}" 2>/dev/null; then
-            echo "Treating @${ACTOR} as trusted via /orgs/${ORG}/members (association=${ASSOCIATION})."
-            echo "trusted=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Ignoring @oz-agent mention from @${ACTOR}; not an org member (association=${ASSOCIATION})."
-            echo "trusted=false" >> "$GITHUB_OUTPUT"
-          fi
+  # Mention, bot, event-type, and trust gates all live in the reusable
+  # workflow (``respond-to-pr-comment.yml``). This adapter exists only
+  # to subscribe to the three GitHub events that can carry an
+  # ``@oz-agent`` / ``@warp-agent`` mention on a PR and delegate them
+  # through ``workflow_call``.
   respond:
-    needs: check_trust
-    if: needs.check_trust.outputs.trusted == 'true'
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -33,13 +33,13 @@ jobs:
       (
         (
           (github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
-          (contains(github.event.comment.body, '@oz-agent') || contains(github.event.comment.body, '@warp-agent')) &&
+          contains(github.event.comment.body, '@oz-agent') &&
           github.event.comment.user.type != 'Bot' &&
           !endsWith(github.event.comment.user.login, '[bot]')
         ) ||
         (
           github.event_name == 'pull_request_review' &&
-          (contains(github.event.review.body, '@oz-agent') || contains(github.event.review.body, '@warp-agent')) &&
+          contains(github.event.review.body, '@oz-agent') &&
           github.event.review.user.type != 'Bot' &&
           !endsWith(github.event.review.user.login, '[bot]')
         )

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -9,14 +9,83 @@ on:
       WARP_API_KEY:
         required: true
 jobs:
-  respond:
-    # ``pull_request_review`` events carry the author under
-    # ``github.event.review``; comment-based events carry it under
-    # ``github.event.comment``. Fall through to the populated shape so
-    # the bot guard works for all supported event types.
+  # ``author_association`` is scoped to the repository, so an actual org
+  # member may still report as ``CONTRIBUTOR`` (private membership,
+  # contribution-history ordering, PR review comment edge cases). We
+  # gate the agent run on either the static allowlist OR a positive
+  # ``GET /orgs/{org}/members/{login}`` probe so we do not drop
+  # legitimate maintainer comments without also opening the door to
+  # non-member CONTRIBUTORs.
+  #
+  # Three GitHub events can carry an ``@oz-agent`` mention on a PR:
+  # an ``issue_comment`` on the PR conversation, a
+  # ``pull_request_review_comment`` on a specific line, and the
+  # top-level body of a ``pull_request_review``. The first two expose
+  # the payload under ``github.event.comment``; the last exposes it
+  # under ``github.event.review``. We dispatch all three here so a
+  # mention in a review body triggers the agent the same way an inline
+  # comment or conversation comment does. Downstream adapters only need
+  # the ``on:`` triggers plus a pass-through ``uses:`` call; mention,
+  # bot, event-type, and trust gates all live in this file.
+  check_trust:
+    name: Check commenter trust
     if: >-
-      (github.event.comment.user.type || github.event.review.user.type) != 'Bot' &&
-      !endsWith(github.event.comment.user.login || github.event.review.user.login, '[bot]')
+      (
+        (
+          (github.event_name == 'pull_request_review_comment' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
+          (contains(github.event.comment.body, '@oz-agent') || contains(github.event.comment.body, '@warp-agent')) &&
+          github.event.comment.user.type != 'Bot' &&
+          !endsWith(github.event.comment.user.login, '[bot]')
+        ) ||
+        (
+          github.event_name == 'pull_request_review' &&
+          (contains(github.event.review.body, '@oz-agent') || contains(github.event.review.body, '@warp-agent')) &&
+          github.event.review.user.type != 'Bot' &&
+          !endsWith(github.event.review.user.login, '[bot]')
+        )
+      )
+    runs-on: ubuntu-slim
+    outputs:
+      trusted: ${{ steps.evaluate.outputs.trusted }}
+    steps:
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          owner: ${{ github.repository_owner }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
+      - name: Evaluate commenter trust
+        id: evaluate
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          # ``pull_request_review`` events carry the author under
+          # ``github.event.review``; comment-based events carry it under
+          # ``github.event.comment``. Use GitHub expression fall-through
+          # so either shape resolves to the right identity without
+          # needing parallel branches below.
+          ASSOCIATION: ${{ github.event.comment.author_association || github.event.review.author_association }}
+          ACTOR: ${{ github.event.comment.user.login || github.event.review.user.login }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          case "${ASSOCIATION:-}" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "Treating @${ACTOR} as trusted via author_association=${ASSOCIATION}."
+              echo "trusted=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          if gh api --silent "/orgs/${ORG}/members/${ACTOR}" 2>/dev/null; then
+            echo "Treating @${ACTOR} as trusted via /orgs/${ORG}/members (association=${ASSOCIATION})."
+            echo "trusted=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Ignoring @oz-agent mention from @${ACTOR}; not an org member (association=${ASSOCIATION})."
+            echo "trusted=false" >> "$GITHUB_OUTPUT"
+          fi
+  respond:
+    needs: check_trust
+    if: needs.check_trust.outputs.trusted == 'true'
     name: Respond to PR comment
     runs-on: ubuntu-slim
     env:


### PR DESCRIPTION
## Problem

Three reusable workflows in `oz-for-oss` expose a `workflow_call` surface without embedding the `check_trust` pattern the local adapters already use. Every downstream consumer has had to reimplement that gate, and at least one (`warp-external`) did so with a static-only `author_association` allowlist that drops real org members whenever GitHub's webhook payload reports `CONTRIBUTOR` (private membership, contribution-history ordering, or `pull_request_review_comment` reply payload edge cases).

Concrete instance: warp-external PR #1100 workflow run [24865247970](https://github.com/warpdotdev/warp-external/actions/runs/24865247970) skipped an `@oz-agent` reply on a `pull_request_review_comment` event even though the commenter is an org `MEMBER`, because the webhook payload reported `CONTRIBUTOR`.

## Changes

### Reusable workflows (now own the gate)
- `.github/workflows/respond-to-pr-comment.yml` — new `check_trust` job (mention + event-type + bot guard + `/orgs/{org}/members/{login}` fallback), covering all three event shapes (`issue_comment` on PR, `pull_request_review_comment`, `pull_request_review`). The `respond` job now `needs: check_trust` and gates on `needs.check_trust.outputs.trusted == 'true'`. Only `@oz-agent` mentions trigger the workflow; `@warp-agent` is intentionally dropped.
- `.github/workflows/create-spec-from-issue.yml` — same pattern; only `issue_comment` traffic goes through `check_trust`, `issues` assign/label triggers bypass it (only maintainers can assign/label).
- `.github/workflows/create-implementation-from-issue.yml` — same as spec, keyed on `ready-to-implement`.

### Local adapters (now thin pass-throughs)
- `respond-to-pr-comment-local.yml`, `create-spec-from-issue-local.yml`, `create-implementation-from-issue-local.yml` each reduce to `on:` + `concurrency:` + a single pass-through job with `uses: ./.github/workflows/<sibling>.yml` and `secrets: inherit`.

## Companion PR

`warp-external` has three adapters with the static-only `author_association` allowlist that triggered the original bug report. A companion PR will shrink them to the same thin-pass-through shape. **Merge order matters**: this PR must land first so the reusable workflows have `check_trust` before `warp-external`'s adapters drop their inline gate.

## Validation

- `env PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests` — 390 tests, all pass (Python helpers untouched; call sites unchanged).
- All six workflow files re-parse as valid YAML; job graphs verified (`check_trust` + work job in each reusable; single work job in each local adapter).
- `grep -r 'warp-agent' .github/workflows/` returns nothing after the cleanup.

## Non-goals

- No changes to `respond_to_pr_comment.py`, `create_spec_from_issue.py`, `create_implementation_from_issue.py`, or the Python `is_trusted_commenter()` helper. Python-level trust stays as defense in depth.
- Only `@oz-agent` is accepted; `@warp-agent` support is removed.
- Reusable workflows without an `author_association` allowlist (`respond-to-triaged-issue-comment.yml`, `review-pull-request.yml`, etc.) are untouched; they are not exposed to this bug.

---

Implementation plan: [Move trust + mention checks out of consuming repos into the oz-for-oss reusable workflow](https://staging.warp.dev/drive/notebook/tNvZOhSQDeRMxKbBxqcwfO)
Conversation: [06d06917-433f-4487-b2f1-ce995cbbaec1](https://staging.warp.dev/conversation/06d06917-433f-4487-b2f1-ce995cbbaec1)

Co-Authored-By: Oz <oz-agent@warp.dev>