### PR TITLE
Pass --share public:view in run_docker_agent command

### DIFF
--- a/.github/scripts/oz_workflows/docker_agent.py
+++ b/.github/scripts/oz_workflows/docker_agent.py
@@ -34,8 +34,9 @@ emit sites and the condition that causes each to fire, are:
   emitted when the terminal driver reports a successful share handshake
   (``AgentDriver::handle_terminal_driver_event`` ->
   ``write_session_joined`` in ``driver.rs``). It is only emitted when
-  ``--share`` is passed; ``_build_docker_argv`` always adds ``--share`` so
-  we rely on this event to populate ``session_link``.
+  ``--share`` is passed; ``_build_docker_argv`` always adds
+  ``--share public:view`` so we rely on this event to populate
+  ``session_link``.
 * ``event_type="conversation_started"``, payload ``{conversation_id}`` --
   emitted once per run when the first server conversation token arrives,
   from the ``BlocklistAIHistoryEvent::UpdatedStreamingExchange`` handler
@@ -235,6 +236,7 @@ def _build_docker_argv(
             "--name",
             title,
             "--share",
+            "public:view",
         ]
     )
     if model:


### PR DESCRIPTION
## Summary

- In `_build_docker_argv` within `docker_agent.py`, `--share` was being passed without an argument
- Updated to pass `--share public:view` so agent sessions are correctly shared with public view access
- Updated the module docstring to reflect the new argument

## Test plan

- [ ] Verify that a Docker agent run correctly receives `--share public:view` in its argv
- [ ] Confirm that the `shared_session_established` event is emitted and the session link is populated

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._