### PR TITLE
Replace WORKFLOW_CODE_REF conditional with github.workflow_sha

### DIFF
--- a/.github/workflows/comment-on-unready-assigned-issue.yml
+++ b/.github/workflows/comment-on-unready-assigned-issue.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -104,7 +104,7 @@ jobs:
       pull-requests: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -104,7 +104,7 @@ jobs:
       pull-requests: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-slim
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: read

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-slim
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: write

--- a/.github/workflows/respond-to-triaged-issue-comment.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment.yml
@@ -73,7 +73,7 @@ jobs:
       issues: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
       TRIAGE_IMAGE: oz-for-oss-triage
     steps:

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -46,7 +46,7 @@ jobs:
     env:
       WARP_ENVIRONMENT_ID: ${{ vars.WARP_ENVIRONMENT_ID || '' }}
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     permissions:
       contents: read

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -32,7 +32,7 @@ jobs:
       issues: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
       TRIAGE_IMAGE: oz-for-oss-triage
     steps:

--- a/.github/workflows/trigger-implementation-on-plan-approved.yml
+++ b/.github/workflows/trigger-implementation-on-plan-approved.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token

--- a/.github/workflows/update-dedupe.yml
+++ b/.github/workflows/update-dedupe.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token

--- a/.github/workflows/update-pr-review.yml
+++ b/.github/workflows/update-pr-review.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token

--- a/.github/workflows/update-triage.yml
+++ b/.github/workflows/update-triage.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     env:
       WORKFLOW_CODE_REPOSITORY: warpdotdev/oz-for-oss
-      WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
+      WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
       WORKFLOW_CODE_PATH: __oz_shared
     steps:
       - name: Create GitHub App token


### PR DESCRIPTION
## What and Why

All 12 reusable workflows set `WORKFLOW_CODE_REF` with:

```yaml
WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}
```

This unconditionally falls back to `'main'` for any consuming repo, even when the consumer has pinned a specific version in their `uses:` statement (e.g. `uses: warpdotdev/oz-for-oss/.github/workflows/triage-new-issues.yml@v1.0.0`). The result is that the workflow YAML at the pinned version runs against Python scripts and Docker files from a **different** (potentially newer) version of `main`, which can introduce silent breakage for any consumer not tracking `main` directly.

## Solution

GitHub Actions provides `github.workflow_sha` — the resolved commit SHA of the workflow file being executed, regardless of whether a tag, branch name, or SHA was used in the `uses:` statement. This is exactly the version of the code that belongs with the workflow YAML being run.

```yaml
# Before
WORKFLOW_CODE_REF: ${{ github.repository == 'warpdotdev/oz-for-oss' && github.sha || 'main' }}

# After
WORKFLOW_CODE_REF: ${{ github.workflow_sha }}
```

### Behaviour across contexts

| Context | Before | After |
|---|---|---|
| oz-for-oss self (local `uses: ./.github/workflows/...`) | `github.sha` (correct) | `github.workflow_sha` = same SHA (correct) |
| Consuming repo tracking `@main` | `'main'` (resolves to HEAD of main) | `github.workflow_sha` = HEAD SHA of main (same result) |
| Consuming repo pinned to `@v1.0.0` or `@abc123sha` | `'main'` (**wrong** — runs main's code) | `github.workflow_sha` = exact SHA for that tag/SHA (**correct**) |

## Changes

- Replaced the `WORKFLOW_CODE_REF` expression in all 12 reusable workflow files.
- No change to the `WORKFLOW_CODE_REPOSITORY` or `WORKFLOW_CODE_PATH` env vars, which are unaffected.
- Note: `uses: warpdotdev/oz-for-oss/.github/actions/setup-oz-python@main` references in steps cannot use dynamic expressions (GitHub limitation), but that simple setup action is low-risk for version drift.

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._