### PR TITLE
security: filter issue comments to org members only in triage and respond-to-triaged workflows

### DIFF
--- a/.github/scripts/respond_to_triaged_issue_comment.py
+++ b/.github/scripts/respond_to_triaged_issue_comment.py
@@ -15,10 +15,10 @@ from oz_workflows.docker_agent import (
 from oz_workflows.env import load_event, optional_env, repo_parts, repo_slug, require_env, workspace
 from oz_workflows.helpers import (
     WorkflowProgressComment,
-    format_issue_comments_for_prompt,
     format_respond_to_triaged_start_line,
     is_automation_user,
     is_trusted_commenter,
+    org_member_comments_text,
     record_run_session_link,
     triggering_comment_prompt_text,
 )
@@ -26,7 +26,6 @@ from oz_workflows.triage import extract_original_issue_report
 
 
 WORKFLOW_NAME = "respond-to-triaged-issue-comment"
-OZ_AGENT_METADATA_PREFIX = "<!-- oz-agent-metadata:"
 
 
 def format_visible_issue_comments(
@@ -34,12 +33,11 @@ def format_visible_issue_comments(
     *,
     exclude_comment_id: int | None = None,
 ) -> str:
-    """Format visible issue comments while filtering Oz-managed metadata comments."""
-    return format_issue_comments_for_prompt(
+    """Format org-member issue comments, excluding non-org-member content."""
+    return org_member_comments_text(
         comments,
-        metadata_prefix=OZ_AGENT_METADATA_PREFIX,
         exclude_comment_id=exclude_comment_id,
-    )
+    ) or "- None"
 
 
 def extract_analysis_comment(result: dict[str, Any]) -> str:
@@ -95,7 +93,7 @@ def build_respond_prompt(
         Original Issue Report:
         {original_report or "No original issue report provided."}
 
-        Existing Issue Comments:
+        Existing Issue Comments (from organization members only):
         {comments_text}
 
         Explicit Triggering Comment:

--- a/.github/scripts/tests/test_respond_to_triaged_issue_comment.py
+++ b/.github/scripts/tests/test_respond_to_triaged_issue_comment.py
@@ -31,17 +31,17 @@ class FormatVisibleIssueCommentsTest(unittest.TestCase):
             ],
             exclude_comment_id=2,
         )
-        self.assertEqual(rendered, "- @alice [MEMBER] (2026-03-24T00:00:00Z): Earlier context")
+        self.assertEqual(rendered, "- alice (2026-03-24T00:00:00Z): Earlier context")
 
-    def test_skips_managed_oz_comments(self) -> None:
+    def test_excludes_non_org_member_comments(self) -> None:
         rendered = format_visible_issue_comments(
             [
                 {
                     "id": 1,
                     "author_association": "NONE",
                     "created_at": "2026-03-24T00:00:00Z",
-                    "body": "Visible reporter comment",
-                    "user": {"login": "alice"},
+                    "body": "Reporter comment that should be excluded",
+                    "user": {"login": "external-user"},
                 },
                 {
                     "id": 2,
@@ -52,7 +52,28 @@ class FormatVisibleIssueCommentsTest(unittest.TestCase):
                 },
             ]
         )
-        self.assertEqual(rendered, "- @alice [NONE] (2026-03-24T00:00:00Z): Visible reporter comment")
+        self.assertEqual(rendered, "- None")
+
+    def test_includes_org_member_comments(self) -> None:
+        rendered = format_visible_issue_comments(
+            [
+                {
+                    "id": 1,
+                    "author_association": "NONE",
+                    "created_at": "2026-03-24T00:00:00Z",
+                    "body": "Reporter comment that should be excluded",
+                    "user": {"login": "external-user"},
+                },
+                {
+                    "id": 2,
+                    "author_association": "MEMBER",
+                    "created_at": "2026-03-24T01:00:00Z",
+                    "body": "Org member comment",
+                    "user": {"login": "maintainer"},
+                },
+            ]
+        )
+        self.assertEqual(rendered, "- maintainer (2026-03-24T01:00:00Z): Org member comment")
 
 
 class ExtractAnalysisCommentTest(unittest.TestCase):

--- a/.github/scripts/tests/test_triage.py
+++ b/.github/scripts/tests/test_triage.py
@@ -265,17 +265,17 @@ class FormatIssueCommentsTest(unittest.TestCase):
             ],
             exclude_comment_id=2,
         )
-        self.assertEqual(rendered, "- @alice [MEMBER] (2026-03-24T00:00:00Z): Earlier context")
+        self.assertEqual(rendered, "- alice (2026-03-24T00:00:00Z): Earlier context")
 
-    def test_skips_managed_oz_comments(self) -> None:
+    def test_excludes_non_org_member_comments(self) -> None:
         rendered = format_issue_comments(
             [
                 {
                     "id": 1,
                     "author_association": "NONE",
                     "created_at": "2026-03-24T00:00:00Z",
-                    "body": "Visible reporter comment",
-                    "user": {"login": "alice"},
+                    "body": "Reporter comment that should be excluded",
+                    "user": {"login": "external-user"},
                 },
                 {
                     "id": 2,
@@ -286,7 +286,28 @@ class FormatIssueCommentsTest(unittest.TestCase):
                 },
             ]
         )
-        self.assertEqual(rendered, "- @alice [NONE] (2026-03-24T00:00:00Z): Visible reporter comment")
+        self.assertEqual(rendered, "- None")
+
+    def test_includes_org_member_comments(self) -> None:
+        rendered = format_issue_comments(
+            [
+                {
+                    "id": 1,
+                    "author_association": "NONE",
+                    "created_at": "2026-03-24T00:00:00Z",
+                    "body": "Reporter comment that should be excluded",
+                    "user": {"login": "external-user"},
+                },
+                {
+                    "id": 2,
+                    "author_association": "MEMBER",
+                    "created_at": "2026-03-24T01:00:00Z",
+                    "body": "Org member comment",
+                    "user": {"login": "maintainer"},
+                },
+            ]
+        )
+        self.assertEqual(rendered, "- maintainer (2026-03-24T01:00:00Z): Org member comment")
 
 
 class LoadRecentIssuesForDedupeTest(unittest.TestCase):

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -24,9 +24,9 @@ from oz_workflows.helpers import (
     format_triage_start_line,
     get_label_name,
     get_login,
-    format_issue_comments_for_prompt,
     is_automation_user,
     issue_has_prior_triage,
+    org_member_comments_text,
     triggering_comment_prompt_text,
     WorkflowProgressComment,
 )
@@ -49,7 +49,6 @@ WORKFLOW_NAME = "triage-new-issues"
 PRIMARY_TRIAGE_LABELS = {"bug", "duplicate", "enhancement", "documentation", "needs-info", "triaged"}
 REPRO_LABEL_PREFIX = "repro:"
 AGENT_PROHIBITED_LABELS = {"ready-to-implement", "ready-to-spec"}
-OZ_AGENT_METADATA_PREFIX = "<!-- oz-agent-metadata:"
 TRIAGE_DISCLAIMER = "*This is my automated analysis and may be incorrect. A maintainer will verify the details.*"
 
 
@@ -402,7 +401,7 @@ def build_triage_prompt(
         Original Issue Report:
         {original_report or "No original issue report provided."}
 
-        Issue Comments:
+        Issue Comments (from organization members only):
         {comments_text}
 
         Explicit Triggering Comment:
@@ -835,12 +834,11 @@ def format_issue_comments(
     *,
     exclude_comment_id: int | None = None,
 ) -> str:
-    """Format non-managed issue comments for the triage prompt."""
-    return format_issue_comments_for_prompt(
+    """Format org-member issue comments for the triage prompt."""
+    return org_member_comments_text(
         comments,
-        metadata_prefix=OZ_AGENT_METADATA_PREFIX,
         exclude_comment_id=exclude_comment_id,
-    )
+    ) or "- None"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Addresses the comment-filtering gap identified in issue #336. Two workflow scripts were inlining all issue comments (including from untrusted external users) into LLM prompts:

- `triage_new_issues.py`: `format_issue_comments` used `format_issue_comments_for_prompt`, which included every comment regardless of author trust level
- `respond_to_triaged_issue_comment.py`: `format_visible_issue_comments` used the same unfiltered helper

Both are now changed to use `org_member_comments_text`, which restricts the inlined comment context to org members, collaborators, and owners — matching the already-correct behavior in `create_spec_from_issue.py`.

**What was already correct (not changed):**
- `create_spec_from_issue.py` — already used `org_member_comments_text` ✓
- `review_pr.py` — does not inline issue/PR comments into the prompt ✓
- `enforce_pr_issue_state.py` — does not inline issue comments ✓
- `respond_to_triaged_issue_comment.py` already gated the *triggering* comment on `is_trusted_commenter`; this PR fixes the *context* comments that were passed alongside it

**Out of scope for this PR** (other claims in #336):
- Adding `<untrusted-user-content>` wrapper tags around issue bodies/titles in the remaining scripts (`review_pr.py`, `enforce_pr_issue_state.py`)
- Adding security-rules blocks to `review_pr.py`, `create_spec_from_issue.py`, and `enforce_pr_issue_state.py` (the triage scripts already have them)

## Changes

- Replace `format_issue_comments_for_prompt` with `org_member_comments_text` in both scripts
- Update prompt section labels to "Issue Comments (from organization members only)" for LLM clarity
- Remove now-unused `OZ_AGENT_METADATA_PREFIX` constants (bot comments are excluded by association check anyway)
- Update tests: rename `test_skips_managed_oz_comments` → `test_excludes_non_org_member_comments`, fix expected output format, and add `test_includes_org_member_comments`

## Test plan

- [ ] `test_triage.py::FormatIssueCommentsTest::test_can_exclude_triggering_comment` — org member comments are included, triggering comment is excluded
- [ ] `test_triage.py::FormatIssueCommentsTest::test_excludes_non_org_member_comments` — external-user and bot comments (NONE association) are excluded, result is `"- None"`
- [ ] `test_triage.py::FormatIssueCommentsTest::test_includes_org_member_comments` — MEMBER comments are included, NONE comments are filtered
- [ ] `test_respond_to_triaged_issue_comment.py::FormatVisibleIssueCommentsTest` — same three scenarios for the respond-to-triaged script

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._