### PR TITLE
fix: scope progress comment search to bot-authored comments only

### DIFF
--- a/.github/scripts/oz_workflows/helpers.py
+++ b/.github/scripts/oz_workflows/helpers.py
@@ -637,6 +637,8 @@ class WorkflowProgressComment:
             github_run_id=self.github_run_id,
         )
         self._workflow_prefix = _workflow_metadata_prefix(workflow, issue_number)
+        app_slug = optional_env("GH_APP_SLUG")
+        self._bot_login = f"{app_slug}[bot]" if app_slug else ""
         self.comment_id: int | None = None
         self.session_link: str = ""
         # When set, progress updates are posted/edited as review-comment replies
@@ -843,6 +845,8 @@ class WorkflowProgressComment:
         self.comment_id = int(get_field(existing, "id"))
 
     def _comment_matches_current_run(self, comment: IssueComment | PullRequestComment) -> bool:
+        if self._bot_login and get_login(get_field(comment, "user")).lower() != self._bot_login.lower():
+            return False
         body = str(get_field(comment, "body") or "")
         if self._workflow_prefix not in body:
             return False
@@ -907,6 +911,10 @@ class WorkflowProgressComment:
                 for comment in comments
                 if isinstance(get_field(comment, "body"), str)
                 and self._workflow_prefix in (get_field(comment, "body") or "")
+                and (
+                    not self._bot_login
+                    or get_login(get_field(comment, "user")).lower() == self._bot_login.lower()
+                )
             ),
             None,
         )

--- a/.github/scripts/tests/test_comment_updates.py
+++ b/.github/scripts/tests/test_comment_updates.py
@@ -517,6 +517,119 @@ class ReviewReplyProgressCommentTest(unittest.TestCase):
         self.assertEqual(pr.edit_count, edits_after_first)
 
 
+    def test_bot_author_filter_ignores_comment_from_other_user(self) -> None:
+        # When GH_APP_SLUG is set, a progress comment authored by a different
+        # user (e.g. a human who happened to include the metadata marker) must
+        # NOT be adopted as the bot's own comment.
+        os.environ["GH_APP_SLUG"] = "oz-mgmt"
+        os.environ["GITHUB_RUN_ID"] = "777"
+        try:
+            github = FakeGitHubClient(bot_login="oz-mgmt[bot]")
+            from oz_workflows.helpers import comment_metadata, _workflow_metadata_prefix
+            # Pre-seed a comment that looks like a bot comment but is authored
+            # by a human — simulates a crafted comment or a different bot.
+            metadata = comment_metadata("triage-new-issues", 42, run_id="abc", github_run_id="777")
+            github.comments.append({
+                "id": 1,
+                "body": f"Sneaky comment.\n\n{metadata}",
+                "user": {"login": "malicious-user"},
+            })
+            progress = WorkflowProgressComment(
+                github,
+                "acme",
+                "widgets",
+                42,
+                workflow="triage-new-issues",
+                requester_login="alice",
+            )
+            progress.start("Legitimate bot start.")
+        finally:
+            os.environ.pop("GH_APP_SLUG", None)
+            os.environ.pop("GITHUB_RUN_ID", None)
+
+        # A new comment should be created rather than adopting the crafted one.
+        self.assertEqual(len(github.comments), 2)
+        bot_comments = [c for c in github.comments if (c.get("user") or {}).get("login") == "oz-mgmt[bot]"]
+        self.assertEqual(len(bot_comments), 1)
+        self.assertIn("Legitimate bot start.", str(bot_comments[0]["body"]))
+
+    def test_bot_author_filter_adopts_own_comment_across_instances(self) -> None:
+        # When GH_APP_SLUG is set, a second WorkflowProgressComment instance
+        # in the same run must adopt the first instance's comment (authored by
+        # the same bot) rather than creating a duplicate.
+        os.environ["GH_APP_SLUG"] = "oz-mgmt"
+        os.environ["GITHUB_RUN_ID"] = "888"
+        try:
+            github = FakeGitHubClient(bot_login="oz-mgmt[bot]")
+            run1 = WorkflowProgressComment(
+                github,
+                "acme",
+                "widgets",
+                42,
+                workflow="triage-new-issues",
+                requester_login="alice",
+            )
+            run1.start("First instance start.")
+            run2 = WorkflowProgressComment(
+                github,
+                "acme",
+                "widgets",
+                42,
+                workflow="triage-new-issues",
+                requester_login="alice",
+            )
+            run2.start("Second instance start.")
+        finally:
+            os.environ.pop("GH_APP_SLUG", None)
+            os.environ.pop("GITHUB_RUN_ID", None)
+
+        self.assertEqual(len(github.comments), 1)
+        body = str(github.comments[0]["body"])
+        self.assertIn("First instance start.", body)
+        self.assertIn("Second instance start.", body)
+
+    def test_bot_author_filter_for_review_replies(self) -> None:
+        # When GH_APP_SLUG is set, only review-comment replies authored by
+        # the bot are considered for adoption. A human-authored reply that
+        # contains the metadata marker must not be adopted.
+        os.environ["GH_APP_SLUG"] = "oz-mgmt"
+        os.environ["GITHUB_RUN_ID"] = "999"
+        try:
+            from oz_workflows.helpers import comment_metadata
+            github = FakeGitHubClient(bot_login="oz-mgmt[bot]")
+            pr = FakePullRequest(trigger_comment_id=100, bot_login="oz-mgmt[bot]")
+            # Pre-seed a reply authored by a human with the bot metadata marker.
+            metadata = comment_metadata("respond-to-pr-comment", 42, run_id="xyz", github_run_id="999")
+            pr.review_comments.append({
+                "id": 200,
+                "in_reply_to_id": 100,
+                "body": f"Human reply.\n\n{metadata}",
+                "user": {"login": "human-user"},
+            })
+            progress = WorkflowProgressComment(
+                github,
+                "acme",
+                "widgets",
+                42,
+                workflow="respond-to-pr-comment",
+                requester_login="alice",
+                review_reply_target=(pr, 100),
+            )
+            progress.start("Bot start.")
+        finally:
+            os.environ.pop("GH_APP_SLUG", None)
+            os.environ.pop("GITHUB_RUN_ID", None)
+
+        # A new reply from the bot should be created; the human reply is ignored.
+        bot_replies = [
+            c for c in pr.review_comments
+            if c.get("in_reply_to_id") == 100
+            and (c.get("user") or {}).get("login") == "oz-mgmt[bot]"
+        ]
+        self.assertEqual(len(bot_replies), 1)
+        self.assertIn("Bot start.", str(bot_replies[0]["body"]))
+
+
 class WorkflowRunUrlTest(unittest.TestCase):
     def test_workflow_run_url_variants(self) -> None:
         """``_workflow_run_url`` combines env vars or returns "" if any
@@ -781,6 +894,10 @@ class FakeIssueComment:
     def body(self) -> str:
         return str(self._data.get("body") or "")
 
+    @property
+    def user(self) -> object:
+        return self._data.get("user")
+
     def edit(self, body: str) -> None:
         self._data["body"] = body
 
@@ -801,7 +918,11 @@ class FakeIssue:
         return [FakeIssueComment(self._repo, c) for c in self._repo.comments]
 
     def create_comment(self, body: str) -> FakeIssueComment:
-        data: dict[str, object] = {"id": len(self._repo.comments) + 1, "body": body}
+        data: dict[str, object] = {
+            "id": len(self._repo.comments) + 1,
+            "body": body,
+            "user": {"login": self._repo.bot_login},
+        }
         self._repo.comments.append(data)
         return FakeIssueComment(self._repo, data)
 
@@ -818,8 +939,9 @@ class FakeIssue:
 class FakeGitHubClient:
     """A minimal stand-in for ``github.Repository.Repository``."""
 
-    def __init__(self) -> None:
+    def __init__(self, bot_login: str = "oz-agent[bot]") -> None:
         self.comments: list[dict[str, object]] = []
+        self.bot_login = bot_login
 
     def get_issue(self, issue_number: int) -> FakeIssue:
         return FakeIssue(self, issue_number)
@@ -921,7 +1043,9 @@ class FakePullRequest:
         *,
         trigger_comment_id: int = 100,
         duplicate_reply_count: int = 1,
+        bot_login: str = "oz-agent[bot]",
     ) -> None:
+        self.bot_login = bot_login
         self.review_comments: list[dict[str, object]] = [
             {
                 "id": trigger_comment_id,
@@ -961,7 +1085,7 @@ class FakePullRequest:
                 "id": new_id,
                 "in_reply_to_id": comment_id,
                 "body": body,
-                "user": {"login": "oz-agent"},
+                "user": {"login": self.bot_login},
             }
             self.review_comments.append(data)
             last = FakeReviewComment(self, data)

--- a/.github/workflows/comment-on-unready-assigned-issue.yml
+++ b/.github/workflows/comment-on-unready-assigned-issue.yml
@@ -40,4 +40,5 @@ jobs:
         env:
           PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
         run: python "${{ env.WORKFLOW_CODE_PATH }}/.github/scripts/comment_on_unready_assigned_issue.py"

--- a/.github/workflows/create-implementation-from-issue.yml
+++ b/.github/workflows/create-implementation-from-issue.yml
@@ -134,6 +134,7 @@ jobs:
           ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
           PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}

--- a/.github/workflows/create-spec-from-issue.yml
+++ b/.github/workflows/create-spec-from-issue.yml
@@ -134,6 +134,7 @@ jobs:
           ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
           PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -62,6 +62,7 @@ jobs:
         env:
           PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
           PR_NUMBER: ${{ inputs.pr_number }}
           REQUESTER: ${{ inputs.requester }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}

--- a/.github/workflows/respond-to-pr-comment.yml
+++ b/.github/workflows/respond-to-pr-comment.yml
@@ -123,6 +123,7 @@ jobs:
         env:
           PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_AGENT_MCP: ${{ vars.WARP_AGENT_MCP || '' }}

--- a/.github/workflows/respond-to-triaged-issue-comment.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment.yml
@@ -109,6 +109,7 @@ jobs:
         env:
           PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
           WARP_AGENT_MODEL: ${{ vars.WARP_AGENT_MODEL || '' }}
           WARP_API_BASE_URL: https://app.warp.dev/api/v1

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -137,6 +137,7 @@ jobs:
         env:
           PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           TRIGGER_SOURCE: ${{ steps.resolve.outputs.trigger_source }}
           REQUESTER: ${{ steps.resolve.outputs.requester }}

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           PYTHONPATH: ${{ env.WORKFLOW_CODE_PATH }}/.github/scripts
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_APP_SLUG: ${{ steps.app_token.outputs.app-slug }}
           LOOKBACK_MINUTES: ${{ inputs.lookback_minutes || '60' }}
           TRIAGE_ISSUE_NUMBER: ${{ inputs.issue_number || '' }}
           WARP_API_KEY: ${{ secrets.WARP_API_KEY }}


### PR DESCRIPTION
## Summary

Audit of PR #356 found that `_comment_matches_current_run` and `_find_any_workflow_comment` only match comments by workflow prefix and `github_run_id`, without checking the comment **author**. This means a crafted comment from any user (or a different bot) containing the metadata marker could be adopted as the bot's own progress comment.

- Filter progress-comment search by the bot author in `_comment_matches_current_run` and `_find_any_workflow_comment`
- Derive `_bot_login` as `<slug>[bot]` from the new `GH_APP_SLUG` env var (absent → filter skipped for backward compatibility)
- Pass `GH_APP_SLUG: ${{ steps.app_token.outputs.app-slug }}` to every workflow step that runs a Python script using `WorkflowProgressComment`
- Add `user` property to `FakeIssueComment` and configurable `bot_login` to `FakeGitHubClient`/`FakePullRequest`
- Add three regression tests covering: ignoring a crafted non-bot comment, adopting the bot's own same-run comment, and filtering review-thread replies

## Test plan

- [ ] `python -m py_compile .github/scripts/oz_workflows/helpers.py .github/scripts/tests/test_comment_updates.py`
- [ ] `env PYTHONPATH=.github/scripts python -m unittest discover -s .github/scripts/tests -p 'test_comment_updates.py'` — all 60 tests pass
- [ ] Full test suite: `env PYTHONPATH=.github/scripts python -m unittest discover -s .github/scripts/tests` — all 446 tests pass

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._