### PR TITLE
Fix triage comment formatting: duplicate @mentions, user-facing statements, issue link ticks

### DIFF
--- a/.github/scripts/tests/test_triage.py
+++ b/.github/scripts/tests/test_triage.py
@@ -682,14 +682,14 @@ class FormatTriageSessionLinkTest(unittest.TestCase):
 
 
 class BuildFollowUpSectionTest(unittest.TestCase):
-    def test_includes_reporter_mention_and_questions(self) -> None:
+    def test_includes_questions_without_reporter_mention(self) -> None:
         issue = {"number": 42, "user": {"login": "alice"}}
         questions = [
             {"question": "What OS?", "reasoning": "Platform-sensitive"},
             {"question": "What version?", "reasoning": ""},
         ]
         section = build_follow_up_section(issue, questions)
-        self.assertIn("@alice", section)
+        self.assertNotIn("@alice", section)
         self.assertIn("1. What OS?", section)
         self.assertIn("2. What version?", section)
         self.assertIn("follow-up questions", section)
@@ -697,7 +697,7 @@ class BuildFollowUpSectionTest(unittest.TestCase):
         # Reasoning should NOT be in the above-the-fold section
         self.assertNotIn("Platform-sensitive", section)
 
-    def test_omits_reporter_when_missing(self) -> None:
+    def test_no_at_mention_regardless_of_login(self) -> None:
         issue = {"number": 42, "user": {"login": ""}}
         questions = [{"question": "What OS?", "reasoning": ""}]
         section = build_follow_up_section(issue, questions)
@@ -706,7 +706,7 @@ class BuildFollowUpSectionTest(unittest.TestCase):
 
 
 class BuildStatementsSectionTest(unittest.TestCase):
-    def test_includes_reporter_mention_and_preserves_markdown(self) -> None:
+    def test_preserves_markdown_without_reporter_mention(self) -> None:
         issue = {"number": 42, "user": {"login": "alice"}}
         statements = (
             "This may already be fixed in newer Warp releases.\n\n"
@@ -714,13 +714,13 @@ class BuildStatementsSectionTest(unittest.TestCase):
             "- The current code suggests this is limited to SSH-backed sessions."
         )
         section = build_statements_section(issue, statements)
-        self.assertIn("@alice", section)
-        self.assertIn("here's what I found while triaging this issue", section)
+        self.assertNotIn("@alice", section)
+        self.assertIn("Here's what I found while triaging this issue", section)
         self.assertIn("This may already be fixed in newer Warp releases.", section)
         self.assertIn("`feature.flag`", section)
         self.assertIn("SSH-backed sessions", section)
 
-    def test_omits_reporter_when_missing(self) -> None:
+    def test_no_at_mention_regardless_of_login(self) -> None:
         issue = {"number": 42, "user": {"login": ""}}
         section = build_statements_section(issue, "Check the `feature.flag` setting.")
         self.assertNotIn("@", section)
@@ -729,14 +729,14 @@ class BuildStatementsSectionTest(unittest.TestCase):
 
 
 class BuildDuplicateSectionTest(unittest.TestCase):
-    def test_includes_issue_links(self) -> None:
+    def test_includes_issue_links_without_reporter_mention(self) -> None:
         issue = {"number": 42, "user": {"login": "alice"}}
         duplicates = [
             {"issue_number": 10, "title": "Original bug", "similarity_reason": "Same error"},
             {"issue_number": 20, "title": "Another", "similarity_reason": ""},
         ]
         section = build_duplicate_section(issue, duplicates)
-        self.assertIn("@alice", section)
+        self.assertNotIn("@alice", section)
         self.assertIn("#10", section)
         self.assertIn("Original bug", section)
         self.assertIn("#20", section)
@@ -745,7 +745,7 @@ class BuildDuplicateSectionTest(unittest.TestCase):
         self.assertNotIn("Why it looks similar", section)
         self.assertIn("close it as a duplicate after review", section)
 
-    def test_omits_reporter_when_missing(self) -> None:
+    def test_no_at_mention_regardless_of_login(self) -> None:
         issue = {"number": 42, "user": {"login": ""}}
         duplicates = [
             {"issue_number": 5, "title": "Dupe", "similarity_reason": ""},
@@ -1042,11 +1042,11 @@ class MutualExclusivityTest(unittest.TestCase):
         }
         body = self._build_comment_parts(result, issue)
 
-        self.assertIn("here's what I found while triaging this issue", body)
+        self.assertIn("Here's what I found while triaging this issue", body)
         self.assertIn("follow-up questions", body)
         self.assertIn("This may already be fixed in newer Warp releases.", body)
         self.assertLess(
-            body.index("here's what I found while triaging this issue"),
+            body.index("Here's what I found while triaging this issue"),
             body.index("follow-up questions"),
         )
         self.assertNotIn("I've completed the triage of this issue.", body)
@@ -1064,7 +1064,7 @@ class MutualExclusivityTest(unittest.TestCase):
         }
         body = self._build_comment_parts(result, issue)
 
-        self.assertIn("here's what I found while triaging this issue", body)
+        self.assertIn("Here's what I found while triaging this issue", body)
         self.assertIn("This may already be fixed in newer Warp releases.", body)
         self.assertNotIn("follow-up questions", body)
         self.assertNotIn("overlap with existing issues", body)
@@ -1087,7 +1087,7 @@ class MutualExclusivityTest(unittest.TestCase):
         body = self._build_comment_parts(result, issue)
 
         self.assertIn("overlap with existing issues", body)
-        self.assertNotIn("here's what I found while triaging this issue", body)
+        self.assertNotIn("Here's what I found while triaging this issue", body)
         self.assertNotIn("This may already be fixed in newer Warp releases.", body)
         self.assertNotIn("follow-up questions", body)
 
@@ -1122,7 +1122,7 @@ class MutualExclusivityTest(unittest.TestCase):
 
         self.assertNotIn("follow-up questions", body)
         self.assertNotIn("overlap with existing issues", body)
-        self.assertNotIn("here's what I found while triaging this issue", body)
+        self.assertNotIn("Here's what I found while triaging this issue", body)
         # issue_body should be in the maintainer details
         self.assertIn("## Triage summary", body)
         self.assertIn("<details>", body)

--- a/.github/scripts/triage_new_issues.py
+++ b/.github/scripts/triage_new_issues.py
@@ -448,6 +448,8 @@ def build_triage_prompt(
         - If the report is underspecified, say so directly and use `needs-info` plus `repro:unknown` when justified.
         - When ambiguity remains, include a `follow_up_questions` array with up to 5 short, issue-specific questions for the original reporter. Before including any question, first attempt to answer it yourself through code inspection, documentation lookup, or web search. Only ask questions that you genuinely cannot resolve and that only the reporter would know — subjective intent, environment details personal to the reporter, or decisions requiring human judgment. Do not ask about externally verifiable technical facts. Do not ask for information that is already present, and do not use generic placeholders.
         - When the triage surfaces concise, reporter-facing findings worth sharing immediately — for example that the behavior appears fixed in a newer release, that a specific setting or workaround may help, or that the issue looks limited to a particular environment based on the current code — include them in the `statements` string. Keep it to 1-3 short sentences or markdown bullet items, and leave it empty when there are no high-confidence findings worth surfacing above the fold.
+        - `statements` must be written for the reporter, not for maintainers. Do not include internal file paths, source code references, function names, or implementation details in `statements` — those belong exclusively in `issue_body`. `statements` should be understandable to someone who has no access to the codebase.
+        - When referencing other issues in `statements` or `follow_up_questions`, use plain `#NNN` (e.g. `#1261`) without surrounding backticks so GitHub can linkify them correctly.
         - Use `statements` for agent conclusions that inform the reporter. Use `follow_up_questions` only for information the reporter alone can provide. Do not duplicate the same content across both.
         - If `duplicate_of` is non-empty, leave `statements` empty so the duplicate section remains the only above-the-fold guidance.
         - `statements` does not replace `issue_body`. Continue using `issue_body` for the full maintainer-facing markdown summary.
@@ -699,12 +701,8 @@ def build_question_reasoning_section(questions: list[dict[str, str]]) -> str:
 
 def build_statements_section(issue: Any, statements: str) -> str:
     """Build the reporter-facing statements section for the progress comment."""
-    reporter_login = get_login(get_field(issue, "user")).strip()
     lines: list[str] = []
-    if reporter_login:
-        lines.append(f"@{reporter_login} — here's what I found while triaging this issue:")
-    else:
-        lines.append("Here's what I found while triaging this issue:")
+    lines.append("Here's what I found while triaging this issue:")
     lines.append("")
     lines.append(statements)
     return "\n".join(lines)
@@ -717,12 +715,8 @@ def build_follow_up_section(issue: Any, questions: list[dict[str, str]]) -> str:
     Only the question text is rendered here; reasoning is handled
     separately by ``build_question_reasoning_section`` for the maintainer section.
     """
-    reporter_login = get_login(get_field(issue, "user")).strip()
     lines: list[str] = []
-    if reporter_login:
-        lines.append(f"@{reporter_login} — I have a few follow-up questions before I can narrow this down:")
-    else:
-        lines.append("I have a few follow-up questions before I can narrow this down:")
+    lines.append("I have a few follow-up questions before I can narrow this down:")
     lines.append("")
     lines.extend(f"{i}. {q['question']}" for i, q in enumerate(questions, start=1))
     lines.append("")
@@ -736,12 +730,8 @@ def build_follow_up_section(issue: Any, questions: list[dict[str, str]]) -> str:
 
 def build_duplicate_section(issue: Any, duplicates: list[dict[str, Any]]) -> str:
     """Build the duplicate detection section for embedding in the progress comment."""
-    reporter_login = get_login(get_field(issue, "user")).strip()
     lines: list[str] = []
-    if reporter_login:
-        lines.append(f"@{reporter_login} — this issue appears to overlap with existing issues:")
-    else:
-        lines.append("This issue appears to overlap with existing issues:")
+    lines.append("This issue appears to overlap with existing issues:")
     lines.append("")
     for dup in duplicates:
         num = dup["issue_number"]


### PR DESCRIPTION
Fixes #378.

## Summary

- **Duplicate @mentions**: `build_statements_section`, `build_follow_up_section`, and `build_duplicate_section` each prepended `@{reporter_login}` to their output. But `WorkflowProgressComment.replace_body` already adds a single `@{requester}` at the very top of the full comment body, so the reporter was @mentioned three times per triage comment. Removed the per-section mentions so only the one from `replace_body` remains.

- **User-facing statements**: Added explicit prompt guidance that `statements` must be readable by the reporter — no file paths, function names, or internal implementation details. Those belong in `issue_body` (the maintainer-only `<details>` section).

- **Code-ticked issue references**: Added prompt guidance to write issue references as plain `#NNN` rather than `` `#NNN` `` so GitHub auto-links them correctly.

## Test plan

- [ ] All 67 existing tests pass (`pytest tests/test_triage.py`)
- [ ] Test names for `build_statements_section`, `build_follow_up_section`, and `build_duplicate_section` updated to reflect new no-@mention behavior
- [ ] Checked that `WorkflowProgressComment.replace_body` still handles the single @mention (no changes needed there)

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._