### PR TITLE
revert: revert "fix: exempt ready issues from triage (#385)"

### DIFF
--- a/.github/scripts/oz_workflows/triage.py
+++ b/.github/scripts/oz_workflows/triage.py
@@ -85,7 +85,6 @@ def select_recent_untriaged_issues(
     *,
     cutoff: datetime,
     triaged_label: str = "triaged",
-    exempt_labels: tuple[str, ...] = ("ready-to-spec", "ready-to-implement"),
 ) -> list[Any]:
     selected = [
         issue
@@ -97,7 +96,6 @@ def select_recent_untriaged_issues(
             else parse_datetime(get_field(issue, "created_at") or "1970-01-01T00:00:00Z") >= cutoff
         )
         and not issue_has_label(issue, triaged_label)
-        and not any(issue_has_label(issue, label_name) for label_name in exempt_labels)
     ]
     selected.sort(
         key=lambda issue: (

--- a/.github/scripts/tests/test_triage.py
+++ b/.github/scripts/tests/test_triage.py
@@ -194,30 +194,6 @@ class SelectRecentUntriagedIssuesTest(unittest.TestCase):
             [4],
         )
 
-    def test_skips_ready_to_spec_and_ready_to_implement_labels(self) -> None:
-        cutoff = datetime(2026, 3, 24, 1, 0, tzinfo=timezone.utc)
-        issues = [
-            {
-                "number": 4,
-                "created_at": "2026-03-24T01:25:00Z",
-                "labels": [{"name": "bug"}],
-            },
-            {
-                "number": 5,
-                "created_at": "2026-03-24T01:30:00Z",
-                "labels": [{"name": "ready-to-spec"}],
-            },
-            {
-                "number": 6,
-                "created_at": "2026-03-24T01:35:00Z",
-                "labels": [{"name": "ready-to-implement"}],
-            },
-        ]
-        self.assertEqual(
-            [issue["number"] for issue in select_recent_untriaged_issues(issues, cutoff=cutoff)],
-            [4],
-        )
-
 
 class DiscoverIssueTemplatesTest(unittest.TestCase):
     def test_discovers_config_template_and_legacy_template(self) -> None:

--- a/.github/workflows/triage-new-issues-local.yml
+++ b/.github/workflows/triage-new-issues-local.yml
@@ -27,9 +27,7 @@ jobs:
     if: |
       (
         github.event_name != 'issue_comment' &&
-        !contains(github.event.issue.labels.*.name, 'triaged') &&
-        !contains(github.event.issue.labels.*.name, 'ready-to-spec') &&
-        !contains(github.event.issue.labels.*.name, 'ready-to-implement')
+        !contains(github.event.issue.labels.*.name, 'triaged')
       ) || (
         github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&


### PR DESCRIPTION
Reverts commit [59aee06](https://github.com/warpdotdev/oz-for-oss/commit/59aee06a2fccc5b8b12b0f7972ef16d7bb9261e5) — "fix: exempt ready issues from triage (#385)".

_Conversation: https://staging.warp.dev/conversation/a497edee-da73-40dc-8fb2-8f402a2b895f_
_Run: https://oz.staging.warp.dev/runs/019dd497-f635-7843-80b9-177159f5fadb_
_This PR was generated with [Oz](https://warp.dev/oz)._
