### PR TITLE
fix: resolve PR head ref via refs/pull/<n>/head for fork PRs

### DIFF
--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -596,9 +596,7 @@ def _write_text_file(path: Path, content: str) -> None:
     path.write_text(content.rstrip() + "\n", encoding="utf-8")
 
 
-def _checkout_review_head_branch(
-    *, workspace_path: Path, pr_number: int, head_branch: str
-) -> None:
+def _checkout_review_head_branch(*, workspace_path: Path, pr_number: int) -> None:
     """Check out the PR head branch in the host workspace before starting Docker.
 
     Resolves the head ref through ``refs/pull/<pr_number>/head`` rather than
@@ -607,15 +605,20 @@ def _checkout_review_head_branch(
     the head branch never exists on ``origin`` and a plain
     ``git fetch origin <head_branch>`` would fail with
     ``couldn't find remote ref``.
+
+    Check out ``FETCH_HEAD`` in detached mode rather than writing the fetched
+    commit to a local branch named after the PR head ref. Fork authors control
+    the head branch name, and branch names like ``main`` could collide with an
+    existing local branch in the workflow checkout.
     """
     pr_ref = f"refs/pull/{pr_number}/head"
     subprocess.run(
-        ["git", "fetch", "origin", f"+{pr_ref}:refs/heads/{head_branch}"],
+        ["git", "fetch", "origin", pr_ref],
         cwd=str(workspace_path),
         check=True,
     )
     subprocess.run(
-        ["git", "checkout", head_branch],
+        ["git", "checkout", "--detach", "FETCH_HEAD"],
         cwd=str(workspace_path),
         check=True,
     )
@@ -874,7 +877,6 @@ def main() -> None:
         _checkout_review_head_branch(
             workspace_path=workspace_path,
             pr_number=pr_number,
-            head_branch=str(pr.head.ref),
         )
         companion_path = resolve_repo_local_skill_path(workspace_path, skill_name)
         if companion_path is not None:

--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -596,10 +596,21 @@ def _write_text_file(path: Path, content: str) -> None:
     path.write_text(content.rstrip() + "\n", encoding="utf-8")
 
 
-def _checkout_review_head_branch(*, workspace_path: Path, head_branch: str) -> None:
-    """Check out the PR head branch in the host workspace before starting Docker."""
+def _checkout_review_head_branch(
+    *, workspace_path: Path, pr_number: int, head_branch: str
+) -> None:
+    """Check out the PR head branch in the host workspace before starting Docker.
+
+    Resolves the head ref through ``refs/pull/<pr_number>/head`` rather than
+    assuming the branch lives on ``origin``. GitHub maintains that ref on the
+    base repository for every open PR, including PRs opened from forks where
+    the head branch never exists on ``origin`` and a plain
+    ``git fetch origin <head_branch>`` would fail with
+    ``couldn't find remote ref``.
+    """
+    pr_ref = f"refs/pull/{pr_number}/head"
     subprocess.run(
-        ["git", "fetch", "origin", head_branch],
+        ["git", "fetch", "origin", f"+{pr_ref}:refs/heads/{head_branch}"],
         cwd=str(workspace_path),
         check=True,
     )
@@ -862,6 +873,7 @@ def main() -> None:
         )
         _checkout_review_head_branch(
             workspace_path=workspace_path,
+            pr_number=pr_number,
             head_branch=str(pr.head.ref),
         )
         companion_path = resolve_repo_local_skill_path(workspace_path, skill_name)

--- a/.github/scripts/tests/test_review_pr.py
+++ b/.github/scripts/tests/test_review_pr.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from review_pr import (
     RETRIGGER_HINT,
+    _checkout_review_head_branch,
     _container_companion_path,
     _build_diff_line_map,
     _commentable_lines_for_patch,
@@ -129,6 +130,43 @@ class LaunchReviewAgentTest(unittest.TestCase):
             kwargs["forward_env_names"],
             ("WARP_API_KEY", "WARP_API_BASE_URL"),
         )
+
+
+class CheckoutReviewHeadBranchTest(unittest.TestCase):
+    def test_fetches_pr_head_ref_to_support_fork_prs(self) -> None:
+        """PRs from forks have their head branch on the fork, not on origin.
+
+        We must resolve the head ref through ``refs/pull/<n>/head`` (which
+        GitHub maintains on the base repository for every open PR) instead
+        of doing ``git fetch origin <head_branch>``, which fails for fork
+        PRs with ``couldn't find remote ref``.
+        """
+        with patch("review_pr.subprocess.run") as run_mock:
+            run_mock.return_value = SimpleNamespace(returncode=0)
+            _checkout_review_head_branch(
+                workspace_path=Path("/tmp/workspace"),
+                pr_number=9242,
+                head_branch="orbit/remove-fake-file",
+            )
+        self.assertEqual(run_mock.call_count, 2)
+        fetch_args, _ = run_mock.call_args_list[0]
+        checkout_args, _ = run_mock.call_args_list[1]
+        self.assertEqual(
+            fetch_args[0],
+            [
+                "git",
+                "fetch",
+                "origin",
+                "+refs/pull/9242/head:refs/heads/orbit/remove-fake-file",
+            ],
+        )
+        self.assertEqual(
+            checkout_args[0],
+            ["git", "checkout", "orbit/remove-fake-file"],
+        )
+        for call in run_mock.call_args_list:
+            self.assertEqual(call.kwargs["cwd"], "/tmp/workspace")
+            self.assertTrue(call.kwargs["check"])
 
 
 class MaterializeSpecContextTest(unittest.TestCase):

--- a/.github/scripts/tests/test_review_pr.py
+++ b/.github/scripts/tests/test_review_pr.py
@@ -140,13 +140,16 @@ class CheckoutReviewHeadBranchTest(unittest.TestCase):
         GitHub maintains on the base repository for every open PR) instead
         of doing ``git fetch origin <head_branch>``, which fails for fork
         PRs with ``couldn't find remote ref``.
+
+        Checking out ``FETCH_HEAD`` in detached mode avoids writing a
+        user-controlled fork branch name to a local branch in the workflow
+        checkout.
         """
         with patch("review_pr.subprocess.run") as run_mock:
             run_mock.return_value = SimpleNamespace(returncode=0)
             _checkout_review_head_branch(
                 workspace_path=Path("/tmp/workspace"),
                 pr_number=9242,
-                head_branch="orbit/remove-fake-file",
             )
         self.assertEqual(run_mock.call_count, 2)
         fetch_args, _ = run_mock.call_args_list[0]
@@ -157,12 +160,12 @@ class CheckoutReviewHeadBranchTest(unittest.TestCase):
                 "git",
                 "fetch",
                 "origin",
-                "+refs/pull/9242/head:refs/heads/orbit/remove-fake-file",
+                "refs/pull/9242/head",
             ],
         )
         self.assertEqual(
             checkout_args[0],
-            ["git", "checkout", "orbit/remove-fake-file"],
+            ["git", "checkout", "--detach", "FETCH_HEAD"],
         )
         for call in run_mock.call_args_list:
             self.assertEqual(call.kwargs["cwd"], "/tmp/workspace")


### PR DESCRIPTION
## Summary
Fixes the `review_pr` workflow failure surfaced in [warpdotdev/warp#9242 review run](https://github.com/warpdotdev/warp/actions/runs/25063661644/job/73424818998?pr=9242):

```
fatal: couldn't find remote ref orbit/remove-fake-file
subprocess.CalledProcessError: Command '['git', 'fetch', 'origin', 'orbit/remove-fake-file']' returned non-zero exit status 128.
```

`_checkout_review_head_branch` was running `git fetch origin <head_branch>` before mounting the workspace into the review container. For PRs opened from a fork, the head branch only lives on the fork, so that fetch fails and the workflow exits before the agent runs.

## Change
Resolve the head ref through `refs/pull/<pr_number>/head`, which GitHub maintains on the base repository for every open PR (fork or not). The fetch becomes:

```
git fetch origin +refs/pull/<pr_number>/head:refs/heads/<head_branch>
git checkout <head_branch>
```

This works identically for branch PRs and fork PRs, with no separate code path for forks.

## Tests
- Added `CheckoutReviewHeadBranchTest` covering the new fetch refspec and checkout call.
- `python -m unittest tests.test_review_pr` — 62 tests pass.

_Conversation: https://staging.warp.dev/conversation/a4d5171a-07cf-44b5-8c13-0b3205eb034e_
_Run: https://oz.staging.warp.dev/runs/019dd4d6-f713-72dc-a2eb-e39ad955bbb3_

_This PR was generated with [Oz](https://warp.dev/oz)._
