### PR TITLE
fix(review): support fork PRs in _checkout_review_head_branch

### DIFF
--- a/.github/scripts/review_pr.py
+++ b/.github/scripts/review_pr.py
@@ -596,10 +596,24 @@ def _write_text_file(path: Path, content: str) -> None:
     path.write_text(content.rstrip() + "\n", encoding="utf-8")
 
 
-def _checkout_review_head_branch(*, workspace_path: Path, head_branch: str) -> None:
-    """Check out the PR head branch in the host workspace before starting Docker."""
+def _checkout_review_head_branch(
+    *, workspace_path: Path, head_branch: str, pr_number: int
+) -> None:
+    """Check out the PR head branch in the host workspace before starting Docker.
+
+    Fetches via GitHub's ``refs/pull/<n>/head`` ref so this works for PRs
+    opened from forks too, where ``head_branch`` (for example
+    ``feature/foo``) does not exist as a ref on ``origin``. The ``+`` in
+    the refspec lets us force-update the local branch if a stale copy
+    already exists from a previous run.
+    """
     subprocess.run(
-        ["git", "fetch", "origin", head_branch],
+        [
+            "git",
+            "fetch",
+            "origin",
+            f"+refs/pull/{pr_number}/head:refs/heads/{head_branch}",
+        ],
         cwd=str(workspace_path),
         check=True,
     )
@@ -863,6 +877,7 @@ def main() -> None:
         _checkout_review_head_branch(
             workspace_path=workspace_path,
             head_branch=str(pr.head.ref),
+            pr_number=pr_number,
         )
         companion_path = resolve_repo_local_skill_path(workspace_path, skill_name)
         if companion_path is not None:

--- a/.github/scripts/tests/test_review_pr.py
+++ b/.github/scripts/tests/test_review_pr.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from review_pr import (
     RETRIGGER_HINT,
+    _checkout_review_head_branch,
     _container_companion_path,
     _build_diff_line_map,
     _commentable_lines_for_patch,
@@ -182,6 +183,46 @@ class MaterializeSpecContextTest(unittest.TestCase):
                 )
 
             self.assertFalse((workspace / "spec_context.md").exists())
+
+
+class CheckoutReviewHeadBranchTest(unittest.TestCase):
+    """``_checkout_review_head_branch`` must work for fork PRs too.
+
+    For PRs opened from a fork, the head branch (e.g. ``feature/foo``)
+    does not exist as a ref on ``origin``; only ``refs/pull/<n>/head``
+    does. The function should fetch via that ref so a plain ``git
+    fetch origin <branch>`` failure on fork PRs no longer breaks the
+    review workflow.
+    """
+
+    def test_fetches_via_pull_request_ref_and_checks_out_branch(self) -> None:
+        with patch("review_pr.subprocess.run") as run_mock:
+            run_mock.return_value = SimpleNamespace(returncode=0)
+            _checkout_review_head_branch(
+                workspace_path=Path("/tmp/workspace"),
+                head_branch="feature/foo",
+                pr_number=42,
+            )
+        self.assertEqual(run_mock.call_count, 2)
+        fetch_call, checkout_call = run_mock.call_args_list
+        self.assertEqual(
+            fetch_call.args[0],
+            [
+                "git",
+                "fetch",
+                "origin",
+                "+refs/pull/42/head:refs/heads/feature/foo",
+            ],
+        )
+        self.assertEqual(fetch_call.kwargs["cwd"], "/tmp/workspace")
+        self.assertTrue(fetch_call.kwargs["check"])
+        self.assertEqual(
+            checkout_call.args[0],
+            ["git", "checkout", "feature/foo"],
+        )
+        self.assertEqual(checkout_call.kwargs["cwd"], "/tmp/workspace")
+        self.assertTrue(checkout_call.kwargs["check"])
+
 
 class CommentableLinesForPatchTest(unittest.TestCase):
     def test_commentable_lines_table(self) -> None:


### PR DESCRIPTION
## Problem

The PR review workflow is failing on every pull request opened from a fork. The traceback bottoms out at:

```
File "/home/runner/work/_actions/warpdotdev/oz-for-oss/main/.github/scripts/review_pr.py", line 601, in _checkout_review_head_branch
```

The function does:

```python
subprocess.run(["git", "fetch", "origin", head_branch], cwd=..., check=True)
subprocess.run(["git", "checkout", head_branch], cwd=..., check=True)
```

with `head_branch=str(pr.head.ref)` — just the bare branch name (e.g. `feature/name`).

For a PR from a fork, GitHub shows the head as `username:feature/name`, but the actual branch lives only on the fork's repo, not on `origin`. So `git fetch origin feature/name` errors out with `couldn't find remote ref feature/name`, and the whole review run aborts before the agent ever starts.

## Fix

Fetch via GitHub's `refs/pull/<n>/head` ref instead. That ref always exists on the base repo regardless of whether the PR is from a fork or the same repo, and is the same trick `gh pr checkout` / `actions/checkout` use internally:

```python
subprocess.run(
    ["git", "fetch", "origin",
     f"+refs/pull/{pr_number}/head:refs/heads/{head_branch}"],
    cwd=..., check=True,
)
subprocess.run(["git", "checkout", head_branch], cwd=..., check=True)
```

The `+` allows force-updating the local branch if a stale copy survived from a previous run on the same runner. The local branch keeps the original `head_branch` name, so the subsequent `git checkout head_branch` and the rest of the review pipeline work unchanged.

I plumbed `pr_number` through the single call site (`pr.number`); no other call sites needed updating.

## Tests

- Added `CheckoutReviewHeadBranchTest` in `tests/test_review_pr.py` that pins:
  - the exact `git fetch` argv (including `+refs/pull/<n>/head:refs/heads/<branch>`),
  - the `git checkout <branch>` argv,
  - `cwd` matches the workspace, and `check=True` for both calls.
- Full `tests/test_review_pr.py` suite still passes (62 tests).

## Risk

Low. The function is only used by the PR review workflow, the new refspec is the canonical way to address PR head commits, and the local branch name is unchanged so no downstream behavior should differ.

---

[Oz conversation](https://staging.warp.dev/conversation/ee15dfc5-dfb3-4d00-a5a8-6e5b7d9bd9bc)

Co-Authored-By: Oz <oz-agent@warp.dev>
