### PR TITLE
fix(ci): include lib in PYTHONPATH for legacy run-tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,5 +45,10 @@ jobs:
       - name: Run tests
         if: steps.filter.outputs.has_code_changes == 'true'
         env:
-          PYTHONPATH: .github/scripts
+          # Include `lib` so PRs that have already moved
+          # `oz_workflows` to the new top-level `lib/` location
+          # (per the webhook control-plane migration) can still
+          # import it. Non-existent path entries are ignored, so
+          # this stays safe for PRs that have not migrated yet.
+          PYTHONPATH: lib:.github/scripts
         run: python -m unittest discover -s .github/scripts/tests


### PR DESCRIPTION
## Summary

The webhook control-plane migration in #400 relocates the shared `oz_workflows` package from `.github/scripts/oz_workflows` to a new top-level `lib/oz_workflows`.

While that PR is open, `pr-hooks.yml` on `main` keeps invoking the legacy reusable `run-tests.yml` against every open PR's merge ref. Because that workflow sets `PYTHONPATH=.github/scripts`, the `python -m unittest discover -s .github/scripts/tests` step fails with `ModuleNotFoundError: No module named 'oz_workflows'` once a PR has performed the move (e.g. #400 itself):

```
ERROR: test_verification (unittest.loader._FailedTest.test_verification)
ImportError: Failed to import test module: test_verification
ModuleNotFoundError: No module named 'oz_workflows'
...
Ran 63 tests in 0.063s
FAILED (errors=21)
```

## Change

Add `lib` to the `PYTHONPATH` the legacy reusable workflow exports before `python -m unittest discover -s .github/scripts/tests`. Python silently ignores non-existent entries on `PYTHONPATH`, so PRs that have not migrated yet (where `lib/` does not exist) keep behaving exactly as they do today.

This unblocks PR #400's `run_tests_on_push / Run tests` check without modifying the migration PR. Once #400 lands, `pr-hooks.yml` and the legacy reusable workflow will be retired entirely.

## Validation

- `python -m unittest discover -s .github/scripts/tests` passes against `main` (no `lib/` present, behavior unchanged).
- The migrated tests on PR #400 already pass with `PYTHONPATH=lib:.github/scripts` (verified locally on the merge ref: 110 passed, 14 subtests passed for `tests/`; legacy suite resolves `oz_workflows` from `lib/`).

_Conversation: https://staging.warp.dev/conversation/1b6aa5c7-03cf-46a0-82a5-b9fe805e2fb6_
_Run: https://oz.staging.warp.dev/runs/019dd6af-d7da-7f05-a8c1-4da156024d76_

_This PR was generated with [Oz](https://warp.dev/oz)._
