### PR TITLE
fix: route team slugs to team_reviewers API parameter and reflect failures in progress comment

### DIFF
--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -131,6 +131,46 @@ def _stakeholder_logins(entries: list[dict[str, Any]]) -> set[str]:
     return logins
 
 
+def _is_team_slug(login: str) -> bool:
+    """Return True when *login* looks like an ``org/team`` team slug.
+
+    GitHub user logins never contain ``/``, so any entry of the form
+    ``warpdotdev/oss-maintainers`` (with or without a leading ``@``)
+    is a team reference that must be routed through the
+    ``team_reviewers`` API parameter instead of ``reviewers``.
+    """
+    return "/" in login
+
+
+def _team_slug_only(team_ref: str) -> str:
+    """Strip the ``org/`` prefix from a team reference.
+
+    GitHub's review-request API expects plain team slugs (e.g.
+    ``oss-maintainers``) in ``team_reviewers``, not the full
+    ``org/slug`` form used in CODEOWNERS / STAKEHOLDERS files.
+    """
+    return team_ref.split("/", 1)[-1]
+
+
+def _split_reviewers(
+    reviewers: list[str],
+) -> tuple[list[str], list[str]]:
+    """Partition *reviewers* into ``(user_logins, team_slugs)``.
+
+    Team entries are identified by the presence of ``/`` in the string
+    and returned with the ``org/`` prefix stripped so they can be passed
+    directly to GitHub's ``team_reviewers`` parameter.
+    """
+    users: list[str] = []
+    teams: list[str] = []
+    for reviewer in reviewers:
+        if _is_team_slug(reviewer):
+            teams.append(_team_slug_only(reviewer))
+        else:
+            users.append(reviewer)
+    return users, teams
+
+
 def _normalize_reviewer_login(
     candidate: Any,
     *,
@@ -1116,15 +1156,24 @@ def apply_review_result(
             pr.create_review(body=review_body, event=event, comments=comments)
         else:
             pr.create_review(body=review_body, event=event)
+    actually_requested: list[str] = []
     if recommended_reviewers:
-        try:
-            pr.create_review_request(reviewers=recommended_reviewers)
-        except GithubException:
-            logger.exception(
-                "Failed to request reviewers %s for PR #%s in %s/%s",
-                recommended_reviewers,
-                pr_number,
-                owner,
-                repo,
-            )
-    progress.complete(_format_review_completion_message(event, recommended_reviewers))
+        user_reviewers, team_reviewers = _split_reviewers(recommended_reviewers)
+        request_kwargs: dict[str, list[str]] = {}
+        if user_reviewers:
+            request_kwargs["reviewers"] = user_reviewers
+        if team_reviewers:
+            request_kwargs["team_reviewers"] = team_reviewers
+        if request_kwargs:
+            try:
+                pr.create_review_request(**request_kwargs)
+                actually_requested = recommended_reviewers
+            except GithubException:
+                logger.exception(
+                    "Failed to request reviewers %s for PR #%s in %s/%s",
+                    recommended_reviewers,
+                    pr_number,
+                    owner,
+                    repo,
+                )
+    progress.complete(_format_review_completion_message(event, actually_requested))

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -554,9 +554,9 @@ def _with_retrigger_hint(message: str) -> str:
 
 def _format_review_completion_message(
     event: str,
-    recommended_reviewers: list[str],
+    recommended_reviewers: list[str] | None,
 ) -> str:
-    """Build the progress-comment completion message for a posted review."""
+    """Build the progress-comment completion message after review application."""
     if recommended_reviewers:
         mentions = ", ".join(f"@{login}" for login in recommended_reviewers)
         base = (
@@ -564,7 +564,10 @@ def _format_review_completion_message(
             f"{mentions}."
         )
     else:
-        base = "I completed the review and posted feedback on this pull request."
+        base = (
+            "I completed the review and no human review was requested for "
+            "this pull request."
+        )
     return _with_retrigger_hint(base)
 
 

--- a/tests/test_review_pr_reviewer_sampling.py
+++ b/tests/test_review_pr_reviewer_sampling.py
@@ -176,6 +176,15 @@ class FormatReviewCompletionMessageTest(unittest.TestCase):
     def test_plain_comment_no_reviewers(self) -> None:
         message = _format_review_completion_message("COMMENT", [])
         self.assertIn("completed the review", message)
+        self.assertIn("no human review was requested", message)
+        self.assertNotIn("posted feedback", message)
+        self.assertNotIn("approved", message.lower())
+
+    def test_plain_comment_null_reviewers(self) -> None:
+        message = _format_review_completion_message("COMMENT", None)
+        self.assertIn("completed the review", message)
+        self.assertIn("no human review was requested", message)
+        self.assertNotIn("posted feedback", message)
         self.assertNotIn("approved", message.lower())
 
 
@@ -573,6 +582,8 @@ class ApplyReviewResultTeamReviewerTest(unittest.TestCase):
         message = progress.complete.call_args[0][0]
         self.assertNotIn("oss-maintainers", message)
         self.assertIn("completed the review", message)
+        self.assertIn("no human review was requested", message)
+        self.assertNotIn("posted feedback", message)
 
     def test_progress_comment_mentions_reviewers_on_success(self) -> None:
         pr = MagicMock()

--- a/tests/test_review_pr_reviewer_sampling.py
+++ b/tests/test_review_pr_reviewer_sampling.py
@@ -7,13 +7,18 @@ from unittest.mock import MagicMock
 
 from . import conftest  # noqa: F401
 
+from github.GithubException import GithubException
+
 from workflows.review_pr import (  # type: ignore[import-not-found]
     _deterministic_reviewer_from_stakeholders,
     _format_non_member_review_section,
     _format_review_completion_message,
+    _is_team_slug,
     _parse_verdict,
     _resolve_recommended_reviewers,
+    _split_reviewers,
     _stakeholder_pattern_matches,
+    _team_slug_only,
     apply_review_result,
     RETRIGGER_HINT,
 )
@@ -25,6 +30,11 @@ STAKEHOLDERS = [
     {"pattern": "/docs/", "owners": ["docs-owner"]},
     {"pattern": "/docs/api/", "owners": ["api-owner"]},
     {"pattern": "/src/*.py", "owners": ["python-owner"]},
+]
+
+STAKEHOLDERS_WITH_TEAM = [
+    {"pattern": "/", "owners": ["warpdotdev/oss-maintainers"]},
+    {"pattern": "/docs/", "owners": ["docs-owner"]},
 ]
 
 
@@ -432,6 +442,158 @@ class ApplyReviewResultVerdictTest(unittest.TestCase):
             approve_pr.create_review.call_args.kwargs["body"],
             reject_pr.create_review.call_args.kwargs["body"],
         )
+
+
+class TeamSlugDetectionTest(unittest.TestCase):
+    def test_user_login_is_not_team(self) -> None:
+        self.assertFalse(_is_team_slug("alice"))
+        self.assertFalse(_is_team_slug("docs-owner"))
+
+    def test_org_team_slug_is_team(self) -> None:
+        self.assertTrue(_is_team_slug("warpdotdev/oss-maintainers"))
+        self.assertTrue(_is_team_slug("acme/reviewers"))
+
+    def test_team_slug_only_strips_org_prefix(self) -> None:
+        self.assertEqual(_team_slug_only("warpdotdev/oss-maintainers"), "oss-maintainers")
+        self.assertEqual(_team_slug_only("acme/reviewers"), "reviewers")
+
+    def test_team_slug_only_on_plain_login_returns_login(self) -> None:
+        self.assertEqual(_team_slug_only("alice"), "alice")
+
+
+class SplitReviewersTest(unittest.TestCase):
+    def test_all_users(self) -> None:
+        users, teams = _split_reviewers(["alice", "bob"])
+        self.assertEqual(users, ["alice", "bob"])
+        self.assertEqual(teams, [])
+
+    def test_all_teams(self) -> None:
+        users, teams = _split_reviewers(["warpdotdev/oss-maintainers"])
+        self.assertEqual(users, [])
+        self.assertEqual(teams, ["oss-maintainers"])
+
+    def test_mixed(self) -> None:
+        users, teams = _split_reviewers(["alice", "warpdotdev/reviewers"])
+        self.assertEqual(users, ["alice"])
+        self.assertEqual(teams, ["reviewers"])
+
+    def test_empty(self) -> None:
+        users, teams = _split_reviewers([])
+        self.assertEqual(users, [])
+        self.assertEqual(teams, [])
+
+
+class ApplyReviewResultTeamReviewerTest(unittest.TestCase):
+    """Verify ``apply_review_result`` routes team slugs to ``team_reviewers``."""
+
+    def _make_context(self, *, stakeholder_entries: list | None = None) -> dict:
+        return {
+            "owner": "acme",
+            "repo": "widgets",
+            "pr_number": 7,
+            "requester": "alice",
+            "is_non_member": True,
+            "pr_author_login": "contributor",
+            "stakeholder_entries": stakeholder_entries or STAKEHOLDERS_WITH_TEAM,
+            "stakeholder_logins": [],
+            "diff_line_map": {},
+            "diff_content_map": {},
+        }
+
+    def _make_github(self, pr: MagicMock) -> MagicMock:
+        github = MagicMock()
+        github.get_pull.return_value = pr
+        return github
+
+    def test_team_slug_routed_to_team_reviewers_param(self) -> None:
+        pr = MagicMock()
+        github = self._make_github(pr)
+        progress = MagicMock()
+        apply_review_result(
+            github,
+            context=self._make_context(),
+            run=MagicMock(),
+            result={
+                "verdict": "APPROVE",
+                "summary": "Looks good",
+                "comments": [],
+                "recommended_reviewers": ["warpdotdev/oss-maintainers"],
+            },
+            progress=progress,
+        )
+        pr.create_review_request.assert_called_once_with(
+            team_reviewers=["oss-maintainers"]
+        )
+
+    def test_user_login_routed_to_reviewers_param(self) -> None:
+        pr = MagicMock()
+        github = self._make_github(pr)
+        progress = MagicMock()
+        apply_review_result(
+            github,
+            context=self._make_context(
+                stakeholder_entries=[
+                    {"pattern": "/docs/", "owners": ["docs-owner"]},
+                ],
+            ),
+            run=MagicMock(),
+            result={
+                "verdict": "APPROVE",
+                "summary": "Looks good",
+                "comments": [],
+                "recommended_reviewers": ["docs-owner"],
+            },
+            progress=progress,
+        )
+        pr.create_review_request.assert_called_once_with(
+            reviewers=["docs-owner"]
+        )
+
+    def test_progress_comment_omits_reviewers_on_api_failure(self) -> None:
+        pr = MagicMock()
+        pr.create_review_request.side_effect = GithubException(
+            422, {"message": "Reviews may only be requested from collaborators"},
+            headers={},
+        )
+        github = self._make_github(pr)
+        progress = MagicMock()
+        apply_review_result(
+            github,
+            context=self._make_context(),
+            run=MagicMock(),
+            result={
+                "verdict": "APPROVE",
+                "summary": "Looks good",
+                "comments": [],
+                "recommended_reviewers": ["warpdotdev/oss-maintainers"],
+            },
+            progress=progress,
+        )
+        progress.complete.assert_called_once()
+        message = progress.complete.call_args[0][0]
+        self.assertNotIn("oss-maintainers", message)
+        self.assertIn("completed the review", message)
+
+    def test_progress_comment_mentions_reviewers_on_success(self) -> None:
+        pr = MagicMock()
+        github = self._make_github(pr)
+        progress = MagicMock()
+        apply_review_result(
+            github,
+            context=self._make_context(),
+            run=MagicMock(),
+            result={
+                "verdict": "APPROVE",
+                "summary": "Looks good",
+                "comments": [],
+                "recommended_reviewers": ["warpdotdev/oss-maintainers"],
+            },
+            progress=progress,
+        )
+        progress.complete.assert_called_once()
+        message = progress.complete.call_args[0][0]
+        self.assertIn("oss-maintainers", message)
+        self.assertIn("requested human review", message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The review workflow in oz-for-oss fails to actually request team reviews when a `.github/STAKEHOLDERS` entry references a GitHub team (e.g. `@warpdotdev/oss-maintainers`). The bot's progress comment claims the review was requested, but the GitHub API call silently fails because:

1. Team slugs (containing `/`) are passed to the `reviewers` parameter, which only accepts individual user logins. Teams must go through `team_reviewers`.
2. The `GithubException` is caught and logged, but the progress comment is updated unconditionally — always claiming success.

Observed on [warpdotdev/warp#9691](https://github.com/warpdotdev/warp/pull/9691#issuecomment-4356939548).

## Changes

**`core/workflows/review_pr.py`**
- Add `_is_team_slug()` — detects `org/team` format (presence of `/`)
- Add `_team_slug_only()` — strips the `org/` prefix for the GitHub API
- Add `_split_reviewers()` — partitions a reviewer list into `(user_logins, team_slugs)`
- Update `apply_review_result` to:
  - Split recommended reviewers into users and teams
  - Pass them to the correct API parameters (`reviewers` vs `team_reviewers`)
  - Only report successfully requested reviewers in the progress comment

**`tests/test_review_pr_reviewer_sampling.py`**
- 12 new tests: team slug detection, slug stripping, reviewer splitting, API routing for team vs user, progress comment accuracy on success and on API failure

## Testing

All 328 tests pass (including 12 new ones).

---

_Conversation: https://staging.warp.dev/conversation/ef40de82-ea29-4fa3-aeab-b5ec896017d9_
_Run: https://oz.staging.warp.dev/runs/019de41d-84ed-77b8-930a-88afee1cc598_

_This PR was generated with [Oz](https://warp.dev/oz)._
