### PR TITLE
fix: ignore oz self-assignment events

### DIFF
--- a/core/routing.py
+++ b/core/routing.py
@@ -290,6 +290,13 @@ def _route_issues(payload: dict[str, Any]) -> RouteDecision:
                 None,
                 f"issues.assigned for non-oz-agent assignee {assignee_login!r}",
             )
+        sender = payload.get("sender")
+        sender_login = _login(sender)
+        if sender_login == OZ_AGENT_LOGIN or _is_bot(sender):
+            return RouteDecision(
+                None,
+                "oz-agent self-assignment event from automation user",
+            )
         labels = _label_names(issue.get("labels"))
         if READY_TO_IMPLEMENT_LABEL in labels:
             return RouteDecision(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -128,6 +128,46 @@ class IssuesEventTest(unittest.TestCase):
         )
         self.assertEqual(decision.workflow, WORKFLOW_CREATE_SPEC_FROM_ISSUE)
 
+    def test_oz_agent_self_assignment_from_app_bot_is_dropped(self) -> None:
+        # The implementation workflow may best-effort assign
+        # ``oz-agent`` while handling an issue-comment mention. GitHub
+        # then emits a separate ``issues.assigned`` webhook authored by
+        # the GitHub App bot; routing that event would start a second
+        # implementation run for the same issue.
+        decision = route_event(
+            "issues",
+            {
+                "action": "assigned",
+                "assignee": {"login": OZ_AGENT_LOGIN},
+                "sender": {"login": "oz-for-oss[bot]", "type": "Bot"},
+                "issue": _issue(
+                    labels=["triaged", "ready-to-implement"],
+                    assignees=[OZ_AGENT_LOGIN],
+                ),
+            },
+        )
+        self.assertIsNone(decision.workflow)
+        self.assertIn("self-assignment", decision.reason)
+
+    def test_oz_agent_self_assignment_from_oz_agent_sender_is_dropped(self) -> None:
+        # GitHub issue timelines can surface the actor for the same
+        # app-driven assignment as ``oz-agent``. Treat that as the same
+        # self-assignment loop while preserving maintainer senders.
+        decision = route_event(
+            "issues",
+            {
+                "action": "assigned",
+                "assignee": {"login": OZ_AGENT_LOGIN},
+                "sender": {"login": OZ_AGENT_LOGIN, "type": "User"},
+                "issue": _issue(
+                    labels=["triaged", "ready-to-implement"],
+                    assignees=[OZ_AGENT_LOGIN],
+                ),
+            },
+        )
+        self.assertIsNone(decision.workflow)
+        self.assertIn("self-assignment", decision.reason)
+
     def test_assigned_ready_to_implement_takes_precedence_over_ready_to_spec(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- Ignore `issues.assigned` events where `oz-agent` is assigned by `oz-agent` or an automation sender.
- Preserve maintainer-driven `oz-agent` assignment routing for create-spec/create-implementation workflows.
- Add regression coverage for both `oz-for-oss[bot]` and `oz-agent` sender variants.

## Validation
- `python3 -m pytest tests/test_routing.py`
- `python3 -m pytest`

Oz conversation: https://staging.warp.dev/conversation/efa209f7-8a3d-435b-8fed-c6e7ba1bf44e

Co-Authored-By: Oz <oz-agent@warp.dev>