### PR TITLE
fix(review): validate review artifact locations

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -25,17 +25,9 @@ Review the current pull request and write the output to `review.json`.
 - Include style or nit comments only when you can provide a concrete suggestion block.
 - If a concern involves untouched code, mention it in top-level `body` instead of an inline comment.
 
-## Repository-specific overrides
+## Repository-specific guidance
 
-The consuming repository may ship a companion skill at `.agents/skills/review-pr-local/SKILL.md`. When the prompt includes a fenced "Repository-specific guidance" section referencing that companion, read the referenced file and apply its guidance **only** to the categories listed below. Guidance in the companion may never change the output JSON schema, the severity labels, the safety rules, the evidence rules, the suggestion-block constraints, or the diff-line-annotation contract described elsewhere in this skill.
-
-Overridable categories:
-
-- user-facing-string norms
-- graceful-degradation preferences for rendering optional dynamic data and error messages
-- debugging and observability preferences for error paths
-- repo-specific style nits and recurring "what we always flag" patterns
-- allowlists of paths to skip
+The consuming repository may ship a companion skill at `.agents/skills/review-pr-local/SKILL.md`. When the prompt includes a fenced "Repository-specific guidance" section referencing that companion, read the referenced file and apply its guidance as part of this review. Guidance in the companion may never change the output JSON schema, the severity labels, the safety rules, the evidence rules, the suggestion-block constraints, or the diff-line-annotation contract described elsewhere in this skill.
 
 If a companion file is not referenced in the prompt, rely on the core contract alone.
 

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -47,6 +47,8 @@ The diff file uses these prefixes:
 - `[NEW:n]` for added lines on the new side. Use `"RIGHT"`.
 - `[OLD:n,NEW:m]` for unchanged context. Use `"RIGHT"` with line `m`.
 
+Treat these annotations as the only source of truth for inline comment locations. For every inline comment you emit, first identify the exact annotated line in `pr_diff.txt` (or the inlined PR diff) and copy its path, side, and line number into `review.json`. Do not infer line numbers from prose, rendered GitHub views, file lengths, surrounding spec text, or unannotated snippets. If you cannot point to a specific `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` line in the annotated diff, put the feedback in `summary` instead of `comments`.
+
 ## Comment Requirements
 
 Every comment body must start with one of these labels:
@@ -62,9 +64,10 @@ Write comments with these constraints:
 - Do not add compliments or hedging.
 - Prefer single-line comments.
 - Keep ranges to at most 10 lines.
-- Restrict inline comments to valid changed lines in this PR.
+- Restrict inline comments to lines that appear explicitly in the annotated PR diff.
 - Only create file-level or inline comments for files that exist in this PR's diff.
 - If the relevant file or line is not part of the diff, put the feedback in `summary` instead of `comments`.
+- Before adding each comment object, verify that its `path`, `side`, `line`, and optional `start_line` correspond to real annotations in the same file's diff section.
 
 ## Suggestion Blocks
 
@@ -126,9 +129,13 @@ The `summary` must include:
 
 Before finishing:
 
-- Validate `review.json` with `jq`.
 - Fix invalid JSON if validation fails.
 - Confirm line numbers match the annotated diff.
+- Run the bundled validator against the exact annotated diff you reviewed:
+    ```
+    python3 .agents/skills/review-pr/scripts/validate_review_json.py --review-json review.json --diff pr_diff.txt
+    ```
+  If the script reports any invalid comments, fix `review.json` and rerun it. Do not upload `review.json` until this validator passes. If the script path is not present at that exact location, locate `validate_review_json.py` under the loaded `review-pr` skill directory and run that copy with the same arguments.
 - Do not run `gh pr review`, `gh pr comment`, `gh api`, or any other command that posts to GitHub.
 
 Your only output is the final `review.json`.
@@ -153,6 +160,7 @@ If the prompt says you are in a cloud-environment workflow and the expected loca
 - If the prompt provides a `resolve_spec_context.py` command, run it only when spec validation is needed and write any returned spec content to `spec_context.md` before running review.
 - Still produce `review.json` and validate it with `jq`.
 - When the host already populated `pr_description.txt`, `pr_diff.txt`, or `spec_context.md` in the workflow checkout, use those files as-is and do not try to re-fetch GitHub context yourself.
+- When the prompt inlines the annotated PR diff instead of providing `pr_diff.txt`, write the inlined diff to `pr_diff.txt` exactly before validating `review.json`.
 - The cloud run does not receive `GH_TOKEN`. If the host did not pre-materialize the needed context, follow only the prompt's explicit fallback instructions.
-- After validation, upload the result via `oz artifact upload review.json` (or `oz-preview artifact upload review.json` if the `oz` CLI is not available). Either CLI is acceptable — use whichever one is installed in the environment. Do not write `review.json` to a `/mnt/...` mount path — the cloud agent has no such mount, and the host workflow only reads what you upload through the artifact CLI.
+- After `validate_review_json.py` passes, upload the result via `oz artifact upload review.json` (or `oz-preview artifact upload review.json` if the `oz` CLI is not available). Either CLI is acceptable — use whichever one is installed in the environment. Do not write `review.json` to a `/mnt/...` mount path — the cloud agent has no such mount, and the host workflow only reads what you upload through the artifact CLI.
 - IMPORTANT: the upload subcommand is `artifact` (singular) on both `oz` and `oz-preview`. Do not use `artifacts` (plural) — that is not a valid subcommand and will fail.

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -23,7 +23,7 @@ Review the current pull request and write the output to `review.json`.
 - Always apply the repository's local `security-review-pr` skill as a supplemental security pass on code PRs. Fold any security findings into the same `review.json` produced by this review rather than emitting a separate output.
 - When `spec_context.md` exists, use the repository's local `check-impl-against-spec` skill and treat material spec drift as a review concern.
 - Include style or nit comments only when you can provide a concrete suggestion block.
-- If a concern involves untouched code, mention it in the summary instead of an inline comment.
+- If a concern involves untouched code, mention it in top-level `body` instead of an inline comment.
 
 ## Repository-specific overrides
 
@@ -47,7 +47,7 @@ The diff file uses these prefixes:
 - `[NEW:n]` for added lines on the new side. Use `"RIGHT"`.
 - `[OLD:n,NEW:m]` for unchanged context. Use `"RIGHT"` with line `m`.
 
-Treat these annotations as the only source of truth for inline comment locations. For every inline comment you emit, first identify the exact annotated line in `pr_diff.txt` (or the inlined PR diff) and copy its path, side, and line number into `review.json`. Do not infer line numbers from prose, rendered GitHub views, file lengths, surrounding spec text, or unannotated snippets. If you cannot point to a specific `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` line in the annotated diff, put the feedback in `summary` instead of `comments`.
+Treat these annotations as the only source of truth for inline comment locations. For every inline comment you emit, first identify the exact annotated line in `pr_diff.txt` (or the inlined PR diff) and copy its path, side, and line number into `review.json`. Do not infer line numbers from prose, rendered GitHub views, file lengths, surrounding spec text, or unannotated snippets. If you cannot point to a specific `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` line in the annotated diff, put the feedback in top-level `body` instead of `comments`.
 
 ## Comment Requirements
 
@@ -66,8 +66,8 @@ Write comments with these constraints:
 - Keep ranges to at most 10 lines.
 - Restrict inline comments to lines that appear explicitly in the annotated PR diff.
 - Only create file-level or inline comments for files that exist in this PR's diff.
-- If the relevant file or line is not part of the diff, put the feedback in `summary` instead of `comments`.
-- Before adding each comment object, verify that its `path`, `side`, `line`, and optional `start_line` correspond to real annotations in the same file's diff section.
+- If the relevant file or line is not part of the diff, put the feedback in top-level `body` instead of `comments`.
+- Before adding each comment object, verify that its `path`, `side`, `line`, and optional `start_line`/`start_side` correspond to real annotations in the same file's diff section.
 
 ## Suggestion Blocks
 
@@ -86,7 +86,7 @@ Rules:
 - Never open the block with a line that already appears immediately above `start_line`, and never close the block with a line that already appears immediately below `line`. If you need those lines as anchors, widen `start_line` or `line` so they are actually part of the replaced range.
 - Count brace, bracket, paren, and block-delimiter depth (`{`, `[`, `(`, `end`, etc.) across the original replaced lines and ensure the replacement ends at the same depth. Do not emit phantom closing tokens, and do not drop required ones.
 - When unsure of the surrounding context, widen `start_line`/`line` to include enough real lines from the diff rather than guessing at surrounding tokens.
-- For multi-line suggestions, set `start_line` to the first line and `line` to the last line.
+- For multi-line suggestions, set `start_line` and `start_side` to the first line, and `line` and `side` to the last line.
 
 ## Output Format
 
@@ -95,13 +95,14 @@ Create `review.json` with this shape:
 ```json
 {
   "verdict": "REJECT",
-  "summary": "## Overview\n...\n\n## Concerns\n- ...\n\n## Verdict\nFound: 1 critical, 2 important, 3 suggestions\n\n**Request changes**",
+  "body": "## Overview\n...\n\n## Concerns\n- ...\n\n## Verdict\nFound: 1 critical, 2 important, 3 suggestions\n\n**Request changes**",
   "comments": [
     {
       "path": "path/to/file",
       "line": 42,
       "side": "RIGHT",
       "start_line": 40,
+      "start_side": "RIGHT",
       "body": "⚠️ [IMPORTANT] Short explanation\n\n```suggestion\nreplacement\n```"
     }
   ]
@@ -110,15 +111,16 @@ Create `review.json` with this shape:
 
 Field rules:
 
-- `verdict` is required and must be exactly the string `"APPROVE"` or `"REJECT"` (uppercase). Map your final recommendation as: `Approve` or `Approve with nits` → `"APPROVE"`; `Request changes` → `"REJECT"`. The `verdict` and the human-readable recommendation in `summary` must agree.
+- `verdict` is required and must be exactly the string `"APPROVE"` or `"REJECT"` (uppercase). Map your final recommendation as: `Approve` or `Approve with nits` → `"APPROVE"`; `Request changes` → `"REJECT"`. The `verdict` and the human-readable recommendation in top-level `body` must agree.
+- top-level `body` is the GitHub review body and is required. Use `body`, not `summary`, for the review overview and final recommendation.
 - `path` must be relative to the repository root.
 - `line` is required and must target the correct side.
-- `start_line` is optional and only for multi-line ranges.
+- `start_line` is optional and only for multi-line ranges. When `start_line` is present, `start_side` is required and must be `"LEFT"` or `"RIGHT"`.
 - `side` must be `"LEFT"` or `"RIGHT"`.
 
-## Summary Requirements
+## Body Requirements
 
-The `summary` must include:
+The top-level `body` must include:
 
 - A high-level overview of the PR.
 - Important concerns and any untouched-code concerns that could not be commented inline.

--- a/.agents/skills/review-pr/scripts/validate_review_json.py
+++ b/.agents/skills/review-pr/scripts/validate_review_json.py
@@ -1,36 +1,288 @@
 #!/usr/bin/env python3
 """Validate a review.json artifact against an annotated PR diff.
 
-This script is intended to run inside the review-pr skill before uploading
-``review.json``. It imports the same validation helpers the control plane uses
-before calling GitHub's ``create_review`` API so malformed inline locations are
-caught while the agent can still fix the artifact.
+This script is packaged with the review-pr skill and must work when the skill
+is copied into a consuming repository without the full oz-for-oss source tree.
+Keep it self-contained: do not import helpers from the repository package.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 
-def _bootstrap_repo_imports() -> None:
-    """Make the workflow repo importable when running this bundled script."""
-    script_path = Path(__file__).resolve()
-    for parent in script_path.parents:
-        if (parent / "oz" / "review_validation.py").is_file():
-            sys.path.insert(0, str(parent))
-            return
+class ReviewComment(TypedDict, total=False):
+    """Normalized review comment accepted by GitHub's create-review API."""
+
+    path: str
+    line: int
+    side: str
+    body: str
+    start_line: int
+    start_side: str
 
 
-_bootstrap_repo_imports()
+@dataclass(frozen=True)
+class ReviewValidationResult:
+    """Validated review fields plus any comment-location errors."""
 
-from oz.review_validation import (  # noqa: E402
-    build_diff_maps_from_annotated_diff,
-    validate_review_payload,
+    body: str
+    comments: list[ReviewComment]
+    errors: list[str]
+
+
+SUGGESTION_BLOCK_PATTERN = re.compile(
+    r"```suggestion[^\n]*\r?\n(?P<content>.*?)\r?\n```",
+    re.DOTALL,
 )
+ANNOTATED_OLD_PATTERN = re.compile(r"^\[OLD:(?P<old>\d+)\] ?(?P<text>.*)$")
+ANNOTATED_NEW_PATTERN = re.compile(r"^\[NEW:(?P<new>\d+)\] ?(?P<text>.*)$")
+ANNOTATED_CONTEXT_PATTERN = re.compile(
+    r"^\[OLD:(?P<old>\d+),NEW:(?P<new>\d+)\] ?(?P<text>.*)$"
+)
+
+
+def normalize_review_path(value: Any) -> str:
+    path = str(value or "").strip()
+    path = re.sub(r"^(a/|b/|\./)", "", path)
+    return path
+
+
+def build_diff_maps_from_annotated_diff(
+    diff_text: str,
+) -> tuple[dict[str, dict[str, set[int]]], dict[str, dict[str, dict[int, str]]]]:
+    """Build validation maps from the annotated diff shown to review agents."""
+    diff_line_map: dict[str, dict[str, set[int]]] = {}
+    diff_content_map: dict[str, dict[str, dict[int, str]]] = {}
+    current_path = ""
+    old_path = ""
+
+    def ensure_path(path: str) -> None:
+        diff_line_map.setdefault(path, {"LEFT": set(), "RIGHT": set()})
+        diff_content_map.setdefault(path, {"LEFT": {}, "RIGHT": {}})
+
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("diff --git "):
+            current_path = ""
+            old_path = ""
+            continue
+        if raw_line.startswith("--- "):
+            candidate = raw_line[4:].strip()
+            old_path = (
+                "" if candidate == "/dev/null" else normalize_review_path(candidate)
+            )
+            continue
+        if raw_line.startswith("+++ "):
+            candidate = raw_line[4:].strip()
+            if candidate == "/dev/null":
+                current_path = old_path
+            else:
+                current_path = normalize_review_path(candidate)
+            if current_path:
+                ensure_path(current_path)
+            continue
+        if not current_path:
+            continue
+        old_match = ANNOTATED_OLD_PATTERN.match(raw_line)
+        if old_match:
+            line = int(old_match.group("old"))
+            text = old_match.group("text")
+            diff_line_map[current_path]["LEFT"].add(line)
+            diff_content_map[current_path]["LEFT"][line] = text
+            continue
+        new_match = ANNOTATED_NEW_PATTERN.match(raw_line)
+        if new_match:
+            line = int(new_match.group("new"))
+            text = new_match.group("text")
+            diff_line_map[current_path]["RIGHT"].add(line)
+            diff_content_map[current_path]["RIGHT"][line] = text
+            continue
+        context_match = ANNOTATED_CONTEXT_PATTERN.match(raw_line)
+        if context_match:
+            old_line = int(context_match.group("old"))
+            new_line = int(context_match.group("new"))
+            text = context_match.group("text")
+            diff_line_map[current_path]["LEFT"].add(old_line)
+            diff_line_map[current_path]["RIGHT"].add(new_line)
+            diff_content_map[current_path]["LEFT"][old_line] = text
+            diff_content_map[current_path]["RIGHT"][new_line] = text
+
+    return diff_line_map, diff_content_map
+
+
+def _extract_suggestion_blocks(body: str | None) -> list[list[str]]:
+    blocks: list[list[str]] = []
+    for match in SUGGESTION_BLOCK_PATTERN.finditer(body or ""):
+        content = match.group("content")
+        lines = [line.rstrip("\r") for line in content.split("\n")]
+        blocks.append(lines)
+    return blocks
+
+
+def _validate_suggestion_blocks(
+    comment: dict[str, Any],
+    diff_content_map: dict[str, dict[str, dict[int, str]]],
+) -> list[str]:
+    errors: list[str] = []
+    body = comment.get("body") or ""
+    blocks = _extract_suggestion_blocks(body)
+    if not blocks:
+        return errors
+
+    path = comment.get("path") or ""
+    side = comment.get("side") or "RIGHT"
+    start_side = comment.get("start_side") or side
+    line_no = comment.get("line")
+    if not isinstance(line_no, int):
+        return errors
+    start_line = comment.get("start_line") or line_no
+    content_for_start_side = diff_content_map.get(path, {}).get(start_side, {})
+    content_for_end_side = diff_content_map.get(path, {}).get(side, {})
+
+    for block_index, block_lines in enumerate(blocks):
+        if not block_lines or block_lines == [""]:
+            continue
+        prev_context = content_for_start_side.get(start_line - 1)
+        next_context = content_for_end_side.get(line_no + 1)
+        first_line = block_lines[0]
+        last_line = block_lines[-1]
+        if prev_context is not None and first_line == prev_context:
+            errors.append(
+                f"suggestion block {block_index} duplicates the context line immediately above "
+                f"`start_line` ({start_line - 1}); that line is not replaced and will appear twice after the suggestion is applied"
+            )
+        if next_context is not None and last_line == next_context:
+            errors.append(
+                f"suggestion block {block_index} duplicates the context line immediately below "
+                f"`line` ({line_no + 1}); that line is not replaced and will appear twice after the suggestion is applied"
+            )
+    return errors
+
+
+def validate_review_payload(
+    review: Any,
+    diff_line_map: dict[str, dict[str, set[int]]],
+    diff_content_map: dict[str, dict[str, dict[int, str]]] | None = None,
+) -> ReviewValidationResult:
+    """Validate a review.json payload against the annotated PR diff."""
+    if not isinstance(review, dict):
+        raise ValueError("Review payload must be a JSON object.")
+
+    raw_body = review.get("body")
+    if raw_body is None:
+        raw_body = review.get("summary") or ""
+    if not isinstance(raw_body, str):
+        raise ValueError("Review payload `body` must be a string.")
+
+    raw_comments = review.get("comments") or []
+    if not isinstance(raw_comments, list):
+        raise ValueError("Review payload `comments` must be a list.")
+
+    normalized_comments: list[ReviewComment] = []
+    errors: list[str] = []
+
+    for index, raw_comment in enumerate(raw_comments):
+        if not isinstance(raw_comment, dict):
+            errors.append(f"`comments[{index}]` must be an object.")
+            continue
+
+        path = normalize_review_path(raw_comment.get("path"))
+        line = raw_comment.get("line")
+        body_value = raw_comment.get("body")
+        body = body_value.strip() if isinstance(body_value, str) else ""
+        side = raw_comment.get("side")
+
+        if not path:
+            errors.append(f"`comments[{index}]` is missing `path`.")
+            continue
+        if path not in diff_line_map:
+            errors.append(
+                f"`comments[{index}]` references `{path}`, which is not part of the PR diff. Move that feedback to top-level `body` instead."
+            )
+            continue
+        if not isinstance(line, int) or line <= 0:
+            errors.append(
+                f"`comments[{index}]` for `{path}` must include a positive integer `line`."
+            )
+            continue
+        if side not in {"LEFT", "RIGHT"}:
+            errors.append(
+                f"`comments[{index}]` for `{path}:{line}` must include `side` set to `LEFT` or `RIGHT`."
+            )
+            continue
+        if not body:
+            errors.append(f"`comments[{index}]` for `{path}` is missing `body`.")
+            continue
+
+        allowed_lines = diff_line_map[path][side]
+        if line not in allowed_lines:
+            errors.append(
+                f"`comments[{index}]` references `{path}:{line}` on `{side}`, which is not commentable in the PR diff."
+            )
+            continue
+
+        normalized_comment: ReviewComment = {
+            "path": path,
+            "line": line,
+            "side": side,
+            "body": body,
+        }
+
+        if "start_line" in raw_comment and raw_comment.get("start_line") is not None:
+            start_line = raw_comment.get("start_line")
+            if not isinstance(start_line, int) or start_line <= 0:
+                errors.append(
+                    f"`comments[{index}]` for `{path}` has invalid `start_line`; it must be a positive integer."
+                )
+                continue
+            start_side = raw_comment.get("start_side")
+            if start_side not in {"LEFT", "RIGHT"}:
+                errors.append(
+                    f"`comments[{index}]` for `{path}` has `start_line` but is missing `start_side`; set `start_side` to `LEFT` or `RIGHT`."
+                )
+                continue
+            if start_side == side and start_line >= line:
+                errors.append(
+                    f"`comments[{index}]` for `{path}` has invalid `start_line`; when `start_side` matches `side`, it must be smaller than `line`."
+                )
+                continue
+            if start_line not in diff_line_map[path][start_side]:
+                errors.append(
+                    f"`comments[{index}]` references `{path}:{start_line}` on `{start_side}` as `start_line`, which is not commentable in the PR diff."
+                )
+                continue
+            normalized_comment["start_line"] = start_line
+            normalized_comment["start_side"] = start_side
+        elif raw_comment.get("start_side") is not None:
+            errors.append(
+                f"`comments[{index}]` for `{path}:{line}` has `start_side` without `start_line`."
+            )
+            continue
+
+        if diff_content_map is not None:
+            suggestion_errors = _validate_suggestion_blocks(
+                normalized_comment, diff_content_map
+            )
+            if suggestion_errors:
+                for err in suggestion_errors:
+                    errors.append(
+                        f"`comments[{index}]` for `{path}:{line}` on `{side}` has an invalid suggestion block: {err}."
+                    )
+                continue
+
+        normalized_comments.append(normalized_comment)
+
+    return ReviewValidationResult(
+        body=raw_body.strip(),
+        comments=normalized_comments,
+        errors=errors,
+    )
 
 
 def _load_json(path: Path) -> Any:

--- a/.agents/skills/review-pr/scripts/validate_review_json.py
+++ b/.agents/skills/review-pr/scripts/validate_review_json.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Validate a review.json artifact against an annotated PR diff.
+
+This script is intended to run inside the review-pr skill before uploading
+``review.json``. It imports the same validation helpers the control plane uses
+before calling GitHub's ``create_review`` API so malformed inline locations are
+caught while the agent can still fix the artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _bootstrap_repo_imports() -> None:
+    """Make the workflow repo importable when running this bundled script."""
+    script_path = Path(__file__).resolve()
+    for parent in script_path.parents:
+        if (parent / "oz" / "review_validation.py").is_file():
+            sys.path.insert(0, str(parent))
+            return
+
+
+_bootstrap_repo_imports()
+
+from oz.review_validation import (  # noqa: E402
+    build_diff_maps_from_annotated_diff,
+    validate_review_payload,
+)
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"review validation failed: {path} does not exist")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"review validation failed: {path} is invalid JSON: {exc}")
+
+
+def _validate_verdict(payload: Any) -> list[str]:
+    if not isinstance(payload, dict):
+        return ["review.json must decode to a JSON object."]
+    verdict = payload.get("verdict")
+    if verdict not in {"APPROVE", "REJECT"}:
+        return ['`verdict` must be exactly "APPROVE" or "REJECT".']
+    return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate review.json comments against annotated pr_diff.txt."
+    )
+    parser.add_argument(
+        "--review-json",
+        default="review.json",
+        type=Path,
+        help="Path to the review.json artifact to validate.",
+    )
+    parser.add_argument(
+        "--diff",
+        default="pr_diff.txt",
+        type=Path,
+        help="Path to the annotated PR diff consumed during review.",
+    )
+    args = parser.parse_args()
+
+    payload = _load_json(args.review_json)
+    try:
+        diff_text = args.diff.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"review validation failed: {args.diff} does not exist", file=sys.stderr)
+        return 1
+
+    diff_line_map, diff_content_map = build_diff_maps_from_annotated_diff(diff_text)
+    result = validate_review_payload(payload, diff_line_map, diff_content_map)
+    errors = _validate_verdict(payload) + result.errors
+    if errors:
+        print("review validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "review validation passed: "
+        f"{len(result.comments)} inline comment(s), {len(diff_line_map)} diff file(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/review-spec/SKILL.md
+++ b/.agents/skills/review-spec/SKILL.md
@@ -47,7 +47,7 @@ The diff file uses these prefixes:
 - `[NEW:n]` for added lines on the new side. Use `"RIGHT"`.
 - `[OLD:n,NEW:m]` for unchanged context. Use `"RIGHT"` with line `m`.
 
-Treat these annotations as the only source of truth for inline comment locations. For every inline comment you emit, first identify the exact annotated line in `pr_diff.txt` (or the inlined PR diff) and copy its path, side, and line number into `review.json`. Do not infer line numbers from prose, rendered GitHub views, file lengths, surrounding spec text, or unannotated snippets. If you cannot point to a specific `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` line in the annotated diff, put the feedback in `summary` instead of `comments`.
+Treat these annotations as the only source of truth for inline comment locations. For every inline comment you emit, first identify the exact annotated line in `pr_diff.txt` (or the inlined PR diff) and copy its path, side, and line number into `review.json`. Do not infer line numbers from prose, rendered GitHub views, file lengths, surrounding spec text, or unannotated snippets. If you cannot point to a specific `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` line in the annotated diff, put the feedback in top-level `body` instead of `comments`.
 
 ## Comment Requirements
 
@@ -66,8 +66,8 @@ Write comments with these constraints:
 - Keep ranges to at most 10 lines.
 - Restrict inline comments to lines that appear explicitly in the annotated PR diff.
 - Only create file-level or inline comments for files that exist in this PR's diff.
-- If the relevant file or line is not part of the diff, put the feedback in `summary` instead of `comments`.
-- Before adding each comment object, verify that its `path`, `side`, `line`, and optional `start_line` correspond to real annotations in the same file's diff section.
+- If the relevant file or line is not part of the diff, put the feedback in top-level `body` instead of `comments`.
+- Before adding each comment object, verify that its `path`, `side`, `line`, and optional `start_line`/`start_side` correspond to real annotations in the same file's diff section.
 
 ## Suggestion Blocks
 
@@ -81,7 +81,7 @@ Rules:
 
 - Match the exact indentation of the original file.
 - Include only replacement text.
-- For multi-line suggestions, set `start_line` to the first line and `line` to the last line.
+- For multi-line suggestions, set `start_line` and `start_side` to the first line, and `line` and `side` to the last line.
 
 ## Output Format
 
@@ -90,13 +90,14 @@ Create `review.json` with this shape:
 ```json
 {
   "verdict": "REJECT",
-  "summary": "## Overview\n...\n\n## Concerns\n- ...\n\n## Verdict\nFound: 1 critical, 2 important, 3 suggestions\n\n**Request changes**",
+  "body": "## Overview\n...\n\n## Concerns\n- ...\n\n## Verdict\nFound: 1 critical, 2 important, 3 suggestions\n\n**Request changes**",
   "comments": [
     {
       "path": "path/to/file",
       "line": 42,
       "side": "RIGHT",
       "start_line": 40,
+      "start_side": "RIGHT",
       "body": "⚠️ [IMPORTANT] Short explanation\n\n```suggestion\nreplacement\n```"
     }
   ]
@@ -105,15 +106,16 @@ Create `review.json` with this shape:
 
 Field rules:
 
-- `verdict` is required and must be exactly the string `"APPROVE"` or `"REJECT"` (uppercase). Map your final recommendation as: `Approve` or `Approve with nits` → `"APPROVE"`; `Request changes` → `"REJECT"`. The `verdict` and the human-readable recommendation in `summary` must agree.
+- `verdict` is required and must be exactly the string `"APPROVE"` or `"REJECT"` (uppercase). Map your final recommendation as: `Approve` or `Approve with nits` → `"APPROVE"`; `Request changes` → `"REJECT"`. The `verdict` and the human-readable recommendation in top-level `body` must agree.
+- top-level `body` is the GitHub review body and is required. Use `body`, not `summary`, for the review overview and final recommendation.
 - `path` must be relative to the repository root.
 - `line` is required and must target the correct side.
-- `start_line` is optional and only for multi-line ranges.
+- `start_line` is optional and only for multi-line ranges. When `start_line` is present, `start_side` is required and must be `"LEFT"` or `"RIGHT"`.
 - `side` must be `"LEFT"` or `"RIGHT"`.
 
-## Summary Requirements
+## Body Requirements
 
-The `summary` must include:
+The top-level `body` must include:
 
 - A high-level overview of the spec PR.
 - Concerns about completeness, clarity, feasibility, or issue alignment.

--- a/.agents/skills/review-spec/SKILL.md
+++ b/.agents/skills/review-spec/SKILL.md
@@ -47,6 +47,8 @@ The diff file uses these prefixes:
 - `[NEW:n]` for added lines on the new side. Use `"RIGHT"`.
 - `[OLD:n,NEW:m]` for unchanged context. Use `"RIGHT"` with line `m`.
 
+Treat these annotations as the only source of truth for inline comment locations. For every inline comment you emit, first identify the exact annotated line in `pr_diff.txt` (or the inlined PR diff) and copy its path, side, and line number into `review.json`. Do not infer line numbers from prose, rendered GitHub views, file lengths, surrounding spec text, or unannotated snippets. If you cannot point to a specific `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` line in the annotated diff, put the feedback in `summary` instead of `comments`.
+
 ## Comment Requirements
 
 Every comment body must start with one of these labels:
@@ -62,9 +64,10 @@ Write comments with these constraints:
 - Do not add compliments or hedging.
 - Prefer single-line comments.
 - Keep ranges to at most 10 lines.
-- Restrict inline comments to valid changed lines in this PR.
+- Restrict inline comments to lines that appear explicitly in the annotated PR diff.
 - Only create file-level or inline comments for files that exist in this PR's diff.
 - If the relevant file or line is not part of the diff, put the feedback in `summary` instead of `comments`.
+- Before adding each comment object, verify that its `path`, `side`, `line`, and optional `start_line` correspond to real annotations in the same file's diff section.
 
 ## Suggestion Blocks
 
@@ -121,9 +124,13 @@ The `summary` must include:
 
 Before finishing:
 
-- Validate `review.json` with `jq`.
 - Fix invalid JSON if validation fails.
 - Confirm line numbers match the annotated diff.
+- Run the bundled validator against the exact annotated diff you reviewed:
+    ```
+    python3 .agents/skills/review-pr/scripts/validate_review_json.py --review-json review.json --diff pr_diff.txt
+    ```
+  If the script reports any invalid comments, fix `review.json` and rerun it. Do not upload `review.json` until this validator passes. If the script path is not present at that exact location, locate `validate_review_json.py` under the packaged sibling `review-pr` skill directory and run that copy with the same arguments.
 - Do not run `gh pr review`, `gh pr comment`, `gh api`, or any other command that posts to GitHub.
 
 Your only output is the final `review.json`.
@@ -147,6 +154,7 @@ If the prompt says you are in a cloud-environment workflow and the expected loca
 - Convert the raw diff into `pr_diff.txt` using the annotated format above before reviewing.
 - Still produce `review.json` and validate it with `jq`.
 - When the host already populated `pr_description.txt`, `pr_diff.txt`, or `spec_context.md` in the workflow checkout, use those files as-is and do not try to re-fetch GitHub context yourself.
+- When the prompt inlines the annotated PR diff instead of providing `pr_diff.txt`, write the inlined diff to `pr_diff.txt` exactly before validating `review.json`.
 - The cloud run does not receive `GH_TOKEN`. If the host did not pre-materialize the needed context, follow only the prompt's explicit fallback instructions.
-- After validation, upload the result via `oz artifact upload review.json` (or `oz-preview artifact upload review.json` if the `oz` CLI is not available). Either CLI is acceptable — use whichever one is installed in the environment. Do not write `review.json` to a `/mnt/...` mount path — the cloud agent has no such mount, and the host workflow only reads what you upload through the artifact CLI.
+- After `validate_review_json.py` passes, upload the result via `oz artifact upload review.json` (or `oz-preview artifact upload review.json` if the `oz` CLI is not available). Either CLI is acceptable — use whichever one is installed in the environment. Do not write `review.json` to a `/mnt/...` mount path — the cloud agent has no such mount, and the host workflow only reads what you upload through the artifact CLI.
 - IMPORTANT: the upload subcommand is `artifact` (singular) on both `oz` and `oz-preview`. Do not use `artifacts` (plural) — that is not a valid subcommand and will fail.

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -383,7 +383,7 @@ def _format_non_member_review_section(
         Non-Member Reviewer Selection:
         - The PR author (@{pr_author_login or 'unknown'}) is not a repository member or collaborator, so the workflow should request exactly one human reviewer when your `verdict` is `"APPROVE"`.
         - If your `verdict` is `"REJECT"`, the workflow will post a GitHub `REQUEST_CHANGES` review and will not request a human reviewer.
-        - Return a `recommended_reviewers` field alongside `verdict`, `summary`, and `comments`.
+        - Return a `recommended_reviewers` field alongside `verdict`, `body`, and `comments`.
         - `recommended_reviewers` must be a JSON list with exactly one bare GitHub login string, for example: {{"recommended_reviewers": ["octocat"]}}.
         - Choose that single reviewer from `.github/STAKEHOLDERS` by matching the changed file paths against the STAKEHOLDERS rules. Later rules override earlier rules, and more specific matching rules should be preferred over catch-all rules.
         - Strip any leading `@` from the login and exclude the PR author (@{pr_author_login or 'unknown'}); GitHub rejects self-review requests.
@@ -729,7 +729,7 @@ def build_review_prompt_for_dispatch(context: Mapping[str, Any]) -> str:
         - {context['supplemental_skill_line']}
         - You are running in a cloud environment dispatched by the Vercel control plane. The PR description, annotated diff, and (when available) spec context are inlined below — read them directly instead of fetching anything from GitHub or running the spec-context helper.
         - Do not run `git fetch`, `git checkout`, `gh`, ad-hoc GitHub API calls, or the spec-context helper from this run. The control plane already gathered the GitHub-backed context and this run does not receive `GH_TOKEN`.
-        - Only include comments for files and lines that exist in the inlined PR diff. Every inline comment must map to an explicit `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` annotation from the inlined diff. If feedback does not map to a diff file or commentable diff line, put it in `summary` instead of `comments`.
+        - Only include comments for files and lines that exist in the inlined PR diff. Every inline comment must map to an explicit `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` annotation from the inlined diff. If feedback does not map to a diff file or commentable diff line, put it in top-level `body` instead of `comments`.
         - Before validating, write the inlined PR diff exactly to `pr_diff.txt` so the bundled `validate_review_json.py` script can compare `review.json` against the same annotated diff you reviewed.
         - Run `python3 .agents/skills/review-pr/scripts/validate_review_json.py --review-json review.json --diff pr_diff.txt` after creating `review.json`, or locate the bundled `validate_review_json.py` under the packaged `review-pr` skill directory and run that copy. Fix every reported error before upload.
         - Do not post the final review directly.
@@ -815,7 +815,7 @@ def apply_review_result(
             requester_login=requester,
         )
     pr = github.get_pull(pr_number)
-    summary, comments = _normalize_review_payload(
+    body, comments = _normalize_review_payload(
         result, diff_line_map, diff_content_map
     )
     verdict = _parse_verdict(result)
@@ -846,10 +846,10 @@ def apply_review_result(
     # The empty-feedback short-circuit applies when there is no feedback
     # and no reviewer to ping.
     # A non-member REJECT must still post a ``REQUEST_CHANGES`` review
-    # even when the agent did not produce a summary or inline comments so
+    # even when the agent did not produce a body or inline comments so
     # the rejection action lands on GitHub.
     if (
-        not summary
+        not body
         and not comments
         and event != "REQUEST_CHANGES"
         and not recommended_reviewers
@@ -860,9 +860,9 @@ def apply_review_result(
             )
         )
         return
-    if summary or comments or event == "REQUEST_CHANGES":
+    if body or comments or event == "REQUEST_CHANGES":
         review_body = (
-            f"{summary or 'Automated review'}\n\n{RETRIGGER_HINT}\n\n{POWERED_BY_SUFFIX}"
+            f"{body or 'Automated review'}\n\n{RETRIGGER_HINT}\n\n{POWERED_BY_SUFFIX}"
         )
         if comments:
             pr.create_review(body=review_body, event=event, comments=comments)

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import fnmatch
 import logging
-import re
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Mapping, TypedDict
@@ -20,6 +19,17 @@ from oz.helpers import (
 from oz.repo_local import (
     format_repo_local_prompt_section,
     repo_local_skill_path_for_dispatch,
+)
+from oz.review_validation import (
+    HUNK_HEADER_PATTERN,
+    ReviewComment,
+    build_diff_maps_from_files as _build_diff_maps,
+    deserialize_diff_content_map as _deserialize_diff_content_map,
+    deserialize_diff_line_map as _deserialize_diff_line_map,
+    normalize_review_path as _normalize_review_path,
+    normalize_review_payload as _normalize_review_payload,
+    serialize_diff_content_map as _serialize_diff_content_map,
+    serialize_diff_line_map as _serialize_diff_line_map,
 )
 from oz.triage import (
     format_stakeholders_for_prompt,
@@ -59,34 +69,6 @@ def _parse_verdict(review: Mapping[str, Any]) -> str:
         _VERDICT_APPROVE,
     )
     return _VERDICT_APPROVE
-
-
-
-class ReviewComment(TypedDict, total=False):
-    """Normalized review comment accepted by ``PullRequest.create_review``."""
-
-    path: str
-    line: int
-    side: str
-    body: str
-    start_line: int
-    start_side: str
-
-
-HUNK_HEADER_PATTERN = re.compile(
-    r"^@@ -(?P<old_start>\d+)(?:,(?P<old_count>\d+))? \+(?P<new_start>\d+)(?:,(?P<new_count>\d+))? @@"
-)
-
-SUGGESTION_BLOCK_PATTERN = re.compile(
-    r"```suggestion[^\n]*\r?\n(?P<content>.*?)\r?\n```",
-    re.DOTALL,
-)
-
-
-def _normalize_review_path(value: Any) -> str:
-    path = str(value or "").strip()
-    path = re.sub(r"^(a/|b/|\./)", "", path)
-    return path
 
 
 def _is_non_member_pr(pr: Any) -> bool:
@@ -294,241 +276,6 @@ def _resolve_recommended_reviewers(
         )
     return fallback
 
-
-def _commentable_lines_for_patch(patch: str | None) -> dict[str, set[int]]:
-    commentable_lines = {"LEFT": set(), "RIGHT": set()}
-    if not patch:
-        return commentable_lines
-
-    old_line: int | None = None
-    new_line: int | None = None
-
-    for raw_line in patch.splitlines():
-        header_match = HUNK_HEADER_PATTERN.match(raw_line)
-        if header_match:
-            old_line = int(header_match.group("old_start"))
-            new_line = int(header_match.group("new_start"))
-            continue
-        if old_line is None or new_line is None or raw_line.startswith("\\"):
-            continue
-        marker = raw_line[:1]
-        if marker == "-":
-            commentable_lines["LEFT"].add(old_line)
-            old_line += 1
-        elif marker == "+":
-            commentable_lines["RIGHT"].add(new_line)
-            new_line += 1
-        elif marker == " ":
-            commentable_lines["LEFT"].add(old_line)
-            commentable_lines["RIGHT"].add(new_line)
-            old_line += 1
-            new_line += 1
-
-    return commentable_lines
-
-
-def _line_content_for_patch(patch: str | None) -> dict[str, dict[int, str]]:
-    """Return file content known from the patch, keyed by side and line number."""
-    line_content: dict[str, dict[int, str]] = {"LEFT": {}, "RIGHT": {}}
-    if not patch:
-        return line_content
-
-    old_line: int | None = None
-    new_line: int | None = None
-
-    for raw_line in patch.splitlines():
-        header_match = HUNK_HEADER_PATTERN.match(raw_line)
-        if header_match:
-            old_line = int(header_match.group("old_start"))
-            new_line = int(header_match.group("new_start"))
-            continue
-        if old_line is None or new_line is None or raw_line.startswith("\\"):
-            continue
-        marker = raw_line[:1]
-        text = raw_line[1:]
-        if marker == "-":
-            line_content["LEFT"][old_line] = text
-            old_line += 1
-        elif marker == "+":
-            line_content["RIGHT"][new_line] = text
-            new_line += 1
-        elif marker == " ":
-            line_content["LEFT"][old_line] = text
-            line_content["RIGHT"][new_line] = text
-            old_line += 1
-            new_line += 1
-
-    return line_content
-
-
-def _build_diff_maps(
-    files: list[File],
-) -> tuple[dict[str, dict[str, set[int]]], dict[str, dict[str, dict[int, str]]]]:
-    diff_line_map: dict[str, dict[str, set[int]]] = {}
-    diff_content_map: dict[str, dict[str, dict[int, str]]] = {}
-    for file in files:
-        path = _normalize_review_path(file.filename)
-        patch = file.patch
-        diff_line_map[path] = _commentable_lines_for_patch(patch)
-        diff_content_map[path] = _line_content_for_patch(patch)
-    return diff_line_map, diff_content_map
-
-
-def _build_diff_line_map(files: list[File]) -> dict[str, dict[str, set[int]]]:
-    diff_line_map, _ = _build_diff_maps(files)
-    return diff_line_map
-
-
-def _extract_suggestion_blocks(body: str | None) -> list[list[str]]:
-    """Extract the line content of each ```suggestion fenced block in the body."""
-    blocks: list[list[str]] = []
-    for match in SUGGESTION_BLOCK_PATTERN.finditer(body or ""):
-        content = match.group("content")
-        # Strip the trailing newline introduced by the closing fence, but keep
-        # any internal blank lines intact. Also strip a trailing CR so that
-        # CRLF-encoded bodies compare equal to patch content, which has CR
-        # stripped by str.splitlines().
-        lines = [line.rstrip("\r") for line in content.split("\n")]
-        blocks.append(lines)
-    return blocks
-
-
-def _validate_suggestion_blocks(
-    comment: dict[str, Any],
-    diff_content_map: dict[str, dict[str, dict[int, str]]],
-) -> list[str]:
-    """Return a list of validation errors for the suggestion blocks in a comment.
-
-    Checks that the suggestion block does not duplicate context lines that
-    sit immediately outside the replaced `start_line`–`line` range on the
-    given side of the diff.
-    """
-    errors: list[str] = []
-    body = comment.get("body") or ""
-    blocks = _extract_suggestion_blocks(body)
-    if not blocks:
-        return errors
-
-    path = comment.get("path") or ""
-    side = comment.get("side") or "RIGHT"
-    line_no = comment.get("line")
-    if not isinstance(line_no, int):
-        return errors
-    start_line = comment.get("start_line") or line_no
-    content_for_side = diff_content_map.get(path, {}).get(side, {})
-
-    for block_index, block_lines in enumerate(blocks):
-        if not block_lines or block_lines == [""]:
-            continue
-        prev_context = content_for_side.get(start_line - 1)
-        next_context = content_for_side.get(line_no + 1)
-        first_line = block_lines[0]
-        last_line = block_lines[-1]
-        if prev_context is not None and first_line == prev_context:
-            errors.append(
-                f"suggestion block {block_index} duplicates the context line immediately above "
-                f"`start_line` ({start_line - 1}); that line is not replaced and will appear twice after the suggestion is applied"
-            )
-        if next_context is not None and last_line == next_context:
-            errors.append(
-                f"suggestion block {block_index} duplicates the context line immediately below "
-                f"`line` ({line_no + 1}); that line is not replaced and will appear twice after the suggestion is applied"
-            )
-    return errors
-
-
-def _normalize_review_payload(
-    review: dict[str, Any],
-    diff_line_map: dict[str, dict[str, set[int]]],
-    diff_content_map: dict[str, dict[str, dict[int, str]]] | None = None,
-) -> tuple[str, list[ReviewComment]]:
-    if not isinstance(review, dict):
-        raise ValueError("Review payload must be a JSON object.")
-
-    summary = review.get("summary") or ""
-    if not isinstance(summary, str):
-        raise ValueError("Review payload `summary` must be a string.")
-
-    raw_comments = review.get("comments") or []
-    if not isinstance(raw_comments, list):
-        raise ValueError("Review payload `comments` must be a list.")
-
-    normalized_comments: list[ReviewComment] = []
-    errors: list[str] = []
-
-    for index, raw_comment in enumerate(raw_comments):
-        if not isinstance(raw_comment, dict):
-            errors.append(f"`comments[{index}]` must be an object.")
-            continue
-
-        path = _normalize_review_path(raw_comment.get("path"))
-        line = raw_comment.get("line")
-        body = str(raw_comment.get("body") or "").strip()
-        side = raw_comment.get("side") if raw_comment.get("side") in {"LEFT", "RIGHT"} else "RIGHT"
-
-        if not path:
-            errors.append(f"`comments[{index}]` is missing `path`.")
-            continue
-        if path not in diff_line_map:
-            errors.append(
-                f"`comments[{index}]` references `{path}`, which is not part of the PR diff. Move that feedback to `summary` instead."
-            )
-            continue
-        if not isinstance(line, int) or line <= 0:
-            errors.append(
-                f"`comments[{index}]` for `{path}` must include a positive integer `line`."
-            )
-            continue
-        if not body:
-            errors.append(f"`comments[{index}]` for `{path}` is missing `body`.")
-            continue
-
-        allowed_lines = diff_line_map[path][side]
-        if line not in allowed_lines:
-            errors.append(
-                f"`comments[{index}]` references `{path}:{line}` on `{side}`, which is not commentable in the PR diff."
-            )
-            continue
-
-        normalized_comment: ReviewComment = {
-            "path": path,
-            "line": line,
-            "side": side,
-            "body": body,
-        }
-
-        if "start_line" in raw_comment and raw_comment.get("start_line") is not None:
-            start_line = raw_comment.get("start_line")
-            if not isinstance(start_line, int) or start_line <= 0 or start_line >= line:
-                errors.append(
-                    f"`comments[{index}]` for `{path}` has invalid `start_line`; it must be a positive integer smaller than `line`."
-                )
-                continue
-            if start_line not in allowed_lines:
-                errors.append(
-                    f"`comments[{index}]` references `{path}:{start_line}` on `{side}` as `start_line`, which is not commentable in the PR diff."
-                )
-                continue
-            normalized_comment["start_line"] = start_line
-            normalized_comment["start_side"] = side
-
-        if diff_content_map is not None:
-            suggestion_errors = _validate_suggestion_blocks(
-                normalized_comment, diff_content_map
-            )
-            if suggestion_errors:
-                for err in suggestion_errors:
-                    errors.append(
-                        f"`comments[{index}]` for `{path}:{line}` on `{side}` has an invalid suggestion block: {err}."
-                    )
-                continue
-
-        normalized_comments.append(normalized_comment)
-
-    for err in errors:
-        print(f"[review-validation] Dropped comment: {err}")
-
-    return summary.strip(), normalized_comments
 
 
 # Hint appended to review-related comments so reviewers know they can
@@ -807,46 +554,6 @@ def _format_spec_context_text(spec_context: Mapping[str, Any]) -> str:
     return "\n\n".join(sections).strip()
 
 
-
-def _serialize_diff_line_map(
-    diff_line_map: dict[str, dict[str, set[int]]],
-) -> dict[str, dict[str, list[int]]]:
-    return {
-        path: {side: sorted(lines) for side, lines in sides.items()}
-        for path, sides in diff_line_map.items()
-    }
-
-
-def _deserialize_diff_line_map(
-    serialized: Mapping[str, Mapping[str, list[int]]],
-) -> dict[str, dict[str, set[int]]]:
-    return {
-        str(path): {str(side): set(lines or []) for side, lines in sides.items()}
-        for path, sides in serialized.items()
-    }
-
-
-def _serialize_diff_content_map(
-    diff_content_map: dict[str, dict[str, dict[int, str]]],
-) -> dict[str, dict[str, dict[str, str]]]:
-    return {
-        path: {side: {str(line): text for line, text in lines.items()} for side, lines in sides.items()}
-        for path, sides in diff_content_map.items()
-    }
-
-
-def _deserialize_diff_content_map(
-    serialized: Mapping[str, Mapping[str, Mapping[str, str]]],
-) -> dict[str, dict[str, dict[int, str]]]:
-    return {
-        str(path): {
-            str(side): {int(line): str(text) for line, text in lines.items()}
-            for side, lines in sides.items()
-        }
-        for path, sides in serialized.items()
-    }
-
-
 def gather_review_context(
     github: Repository,
     *,
@@ -1022,7 +729,9 @@ def build_review_prompt_for_dispatch(context: Mapping[str, Any]) -> str:
         - {context['supplemental_skill_line']}
         - You are running in a cloud environment dispatched by the Vercel control plane. The PR description, annotated diff, and (when available) spec context are inlined below — read them directly instead of fetching anything from GitHub or running the spec-context helper.
         - Do not run `git fetch`, `git checkout`, `gh`, ad-hoc GitHub API calls, or the spec-context helper from this run. The control plane already gathered the GitHub-backed context and this run does not receive `GH_TOKEN`.
-        - Only include comments for files and lines that exist in the inlined PR diff. If feedback does not map to a diff file or commentable diff line, put it in `summary` instead of `comments`.
+        - Only include comments for files and lines that exist in the inlined PR diff. Every inline comment must map to an explicit `[NEW:n]`, `[OLD:n]`, or `[OLD:n,NEW:m]` annotation from the inlined diff. If feedback does not map to a diff file or commentable diff line, put it in `summary` instead of `comments`.
+        - Before validating, write the inlined PR diff exactly to `pr_diff.txt` so the bundled `validate_review_json.py` script can compare `review.json` against the same annotated diff you reviewed.
+        - Run `python3 .agents/skills/review-pr/scripts/validate_review_json.py --review-json review.json --diff pr_diff.txt` after creating `review.json`, or locate the bundled `validate_review_json.py` under the packaged `review-pr` skill directory and run that copy. Fix every reported error before upload.
         - Do not post the final review directly.
         - After you create and validate `review.json`, upload it as an artifact via `oz artifact upload {_REVIEW_OUTPUT_FILENAME}` (or `oz-preview artifact upload {_REVIEW_OUTPUT_FILENAME}` if the `oz` CLI is not available). Either CLI is acceptable — use whichever one is installed in the environment. The subcommand is `artifact` (singular) on both CLIs; do not use `artifacts`.
 

--- a/oz/review_validation.py
+++ b/oz/review_validation.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, TypedDict
+
+
+class ReviewComment(TypedDict, total=False):
+    """Normalized review comment accepted by ``PullRequest.create_review``."""
+
+    path: str
+    line: int
+    side: str
+    body: str
+    start_line: int
+    start_side: str
+
+
+@dataclass(frozen=True)
+class ReviewValidationResult:
+    """Validated ``review.json`` fields plus any dropped-comment errors."""
+
+    summary: str
+    comments: list[ReviewComment]
+    errors: list[str]
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.errors
+
+
+HUNK_HEADER_PATTERN = re.compile(
+    r"^@@ -(?P<old_start>\d+)(?:,(?P<old_count>\d+))? \+(?P<new_start>\d+)(?:,(?P<new_count>\d+))? @@"
+)
+
+SUGGESTION_BLOCK_PATTERN = re.compile(
+    r"```suggestion[^\n]*\r?\n(?P<content>.*?)\r?\n```",
+    re.DOTALL,
+)
+
+ANNOTATED_OLD_PATTERN = re.compile(r"^\[OLD:(?P<old>\d+)\] ?(?P<text>.*)$")
+ANNOTATED_NEW_PATTERN = re.compile(r"^\[NEW:(?P<new>\d+)\] ?(?P<text>.*)$")
+ANNOTATED_CONTEXT_PATTERN = re.compile(
+    r"^\[OLD:(?P<old>\d+),NEW:(?P<new>\d+)\] ?(?P<text>.*)$"
+)
+
+
+def normalize_review_path(value: Any) -> str:
+    path = str(value or "").strip()
+    path = re.sub(r"^(a/|b/|\./)", "", path)
+    return path
+
+
+def commentable_lines_for_patch(patch: str | None) -> dict[str, set[int]]:
+    commentable_lines = {"LEFT": set(), "RIGHT": set()}
+    if not patch:
+        return commentable_lines
+
+    old_line: int | None = None
+    new_line: int | None = None
+
+    for raw_line in patch.splitlines():
+        header_match = HUNK_HEADER_PATTERN.match(raw_line)
+        if header_match:
+            old_line = int(header_match.group("old_start"))
+            new_line = int(header_match.group("new_start"))
+            continue
+        if old_line is None or new_line is None or raw_line.startswith("\\"):
+            continue
+        marker = raw_line[:1]
+        if marker == "-":
+            commentable_lines["LEFT"].add(old_line)
+            old_line += 1
+        elif marker == "+":
+            commentable_lines["RIGHT"].add(new_line)
+            new_line += 1
+        elif marker == " ":
+            commentable_lines["LEFT"].add(old_line)
+            commentable_lines["RIGHT"].add(new_line)
+            old_line += 1
+            new_line += 1
+
+    return commentable_lines
+
+
+def line_content_for_patch(patch: str | None) -> dict[str, dict[int, str]]:
+    """Return file content known from a unified patch, keyed by side and line."""
+    line_content: dict[str, dict[int, str]] = {"LEFT": {}, "RIGHT": {}}
+    if not patch:
+        return line_content
+
+    old_line: int | None = None
+    new_line: int | None = None
+
+    for raw_line in patch.splitlines():
+        header_match = HUNK_HEADER_PATTERN.match(raw_line)
+        if header_match:
+            old_line = int(header_match.group("old_start"))
+            new_line = int(header_match.group("new_start"))
+            continue
+        if old_line is None or new_line is None or raw_line.startswith("\\"):
+            continue
+        marker = raw_line[:1]
+        text = raw_line[1:]
+        if marker == "-":
+            line_content["LEFT"][old_line] = text
+            old_line += 1
+        elif marker == "+":
+            line_content["RIGHT"][new_line] = text
+            new_line += 1
+        elif marker == " ":
+            line_content["LEFT"][old_line] = text
+            line_content["RIGHT"][new_line] = text
+            old_line += 1
+            new_line += 1
+
+    return line_content
+
+
+def build_diff_maps_from_files(
+    files: list[Any],
+) -> tuple[dict[str, dict[str, set[int]]], dict[str, dict[str, dict[int, str]]]]:
+    diff_line_map: dict[str, dict[str, set[int]]] = {}
+    diff_content_map: dict[str, dict[str, dict[int, str]]] = {}
+    for file in files:
+        path = normalize_review_path(file.filename)
+        patch = file.patch
+        diff_line_map[path] = commentable_lines_for_patch(patch)
+        diff_content_map[path] = line_content_for_patch(patch)
+    return diff_line_map, diff_content_map
+
+
+def serialize_diff_line_map(
+    diff_line_map: dict[str, dict[str, set[int]]],
+) -> dict[str, dict[str, list[int]]]:
+    return {
+        path: {side: sorted(lines) for side, lines in sides.items()}
+        for path, sides in diff_line_map.items()
+    }
+
+
+def deserialize_diff_line_map(
+    serialized: Mapping[str, Mapping[str, list[int]]],
+) -> dict[str, dict[str, set[int]]]:
+    return {
+        str(path): {str(side): set(lines or []) for side, lines in sides.items()}
+        for path, sides in serialized.items()
+    }
+
+
+def serialize_diff_content_map(
+    diff_content_map: dict[str, dict[str, dict[int, str]]],
+) -> dict[str, dict[str, dict[str, str]]]:
+    return {
+        path: {
+            side: {str(line): text for line, text in lines.items()}
+            for side, lines in sides.items()
+        }
+        for path, sides in diff_content_map.items()
+    }
+
+
+def deserialize_diff_content_map(
+    serialized: Mapping[str, Mapping[str, Mapping[str, str]]],
+) -> dict[str, dict[str, dict[int, str]]]:
+    return {
+        str(path): {
+            str(side): {int(line): str(text) for line, text in lines.items()}
+            for side, lines in sides.items()
+        }
+        for path, sides in serialized.items()
+    }
+
+
+def build_diff_maps_from_annotated_diff(
+    diff_text: str,
+) -> tuple[dict[str, dict[str, set[int]]], dict[str, dict[str, dict[int, str]]]]:
+    """Build validation maps from the annotated diff shown to review agents."""
+    diff_line_map: dict[str, dict[str, set[int]]] = {}
+    diff_content_map: dict[str, dict[str, dict[int, str]]] = {}
+    current_path = ""
+    old_path = ""
+
+    def ensure_path(path: str) -> None:
+        diff_line_map.setdefault(path, {"LEFT": set(), "RIGHT": set()})
+        diff_content_map.setdefault(path, {"LEFT": {}, "RIGHT": {}})
+
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("diff --git "):
+            current_path = ""
+            old_path = ""
+            continue
+        if raw_line.startswith("--- "):
+            candidate = raw_line[4:].strip()
+            old_path = (
+                "" if candidate == "/dev/null" else normalize_review_path(candidate)
+            )
+            continue
+        if raw_line.startswith("+++ "):
+            candidate = raw_line[4:].strip()
+            if candidate == "/dev/null":
+                current_path = old_path
+            else:
+                current_path = normalize_review_path(candidate)
+            if not current_path:
+                continue
+            ensure_path(current_path)
+            continue
+        if not current_path:
+            continue
+        old_match = ANNOTATED_OLD_PATTERN.match(raw_line)
+        if old_match:
+            line = int(old_match.group("old"))
+            text = old_match.group("text")
+            diff_line_map[current_path]["LEFT"].add(line)
+            diff_content_map[current_path]["LEFT"][line] = text
+            continue
+        new_match = ANNOTATED_NEW_PATTERN.match(raw_line)
+        if new_match:
+            line = int(new_match.group("new"))
+            text = new_match.group("text")
+            diff_line_map[current_path]["RIGHT"].add(line)
+            diff_content_map[current_path]["RIGHT"][line] = text
+            continue
+        context_match = ANNOTATED_CONTEXT_PATTERN.match(raw_line)
+        if context_match:
+            old_line = int(context_match.group("old"))
+            new_line = int(context_match.group("new"))
+            text = context_match.group("text")
+            diff_line_map[current_path]["LEFT"].add(old_line)
+            diff_line_map[current_path]["RIGHT"].add(new_line)
+            diff_content_map[current_path]["LEFT"][old_line] = text
+            diff_content_map[current_path]["RIGHT"][new_line] = text
+
+    return diff_line_map, diff_content_map
+
+
+def _extract_suggestion_blocks(body: str | None) -> list[list[str]]:
+    """Extract the line content of each ```suggestion fenced block."""
+    blocks: list[list[str]] = []
+    for match in SUGGESTION_BLOCK_PATTERN.finditer(body or ""):
+        content = match.group("content")
+        lines = [line.rstrip("\r") for line in content.split("\n")]
+        blocks.append(lines)
+    return blocks
+
+
+def _validate_suggestion_blocks(
+    comment: dict[str, Any],
+    diff_content_map: dict[str, dict[str, dict[int, str]]],
+) -> list[str]:
+    """Return validation errors for suggestion blocks in a comment."""
+    errors: list[str] = []
+    body = comment.get("body") or ""
+    blocks = _extract_suggestion_blocks(body)
+    if not blocks:
+        return errors
+
+    path = comment.get("path") or ""
+    side = comment.get("side") or "RIGHT"
+    line_no = comment.get("line")
+    if not isinstance(line_no, int):
+        return errors
+    start_line = comment.get("start_line") or line_no
+    content_for_side = diff_content_map.get(path, {}).get(side, {})
+
+    for block_index, block_lines in enumerate(blocks):
+        if not block_lines or block_lines == [""]:
+            continue
+        prev_context = content_for_side.get(start_line - 1)
+        next_context = content_for_side.get(line_no + 1)
+        first_line = block_lines[0]
+        last_line = block_lines[-1]
+        if prev_context is not None and first_line == prev_context:
+            errors.append(
+                f"suggestion block {block_index} duplicates the context line immediately above "
+                f"`start_line` ({start_line - 1}); that line is not replaced and will appear twice after the suggestion is applied"
+            )
+        if next_context is not None and last_line == next_context:
+            errors.append(
+                f"suggestion block {block_index} duplicates the context line immediately below "
+                f"`line` ({line_no + 1}); that line is not replaced and will appear twice after the suggestion is applied"
+            )
+    return errors
+
+
+def validate_review_payload(
+    review: Any,
+    diff_line_map: dict[str, dict[str, set[int]]],
+    diff_content_map: dict[str, dict[str, dict[int, str]]] | None = None,
+) -> ReviewValidationResult:
+    """Validate and normalize a ``review.json`` payload against a PR diff."""
+    if not isinstance(review, dict):
+        raise ValueError("Review payload must be a JSON object.")
+
+    summary = review.get("summary") or ""
+    if not isinstance(summary, str):
+        raise ValueError("Review payload `summary` must be a string.")
+
+    raw_comments = review.get("comments") or []
+    if not isinstance(raw_comments, list):
+        raise ValueError("Review payload `comments` must be a list.")
+
+    normalized_comments: list[ReviewComment] = []
+    errors: list[str] = []
+
+    for index, raw_comment in enumerate(raw_comments):
+        if not isinstance(raw_comment, dict):
+            errors.append(f"`comments[{index}]` must be an object.")
+            continue
+
+        path = normalize_review_path(raw_comment.get("path"))
+        line = raw_comment.get("line")
+        body = str(raw_comment.get("body") or "").strip()
+        side = (
+            raw_comment.get("side")
+            if raw_comment.get("side") in {"LEFT", "RIGHT"}
+            else "RIGHT"
+        )
+
+        if not path:
+            errors.append(f"`comments[{index}]` is missing `path`.")
+            continue
+        if path not in diff_line_map:
+            errors.append(
+                f"`comments[{index}]` references `{path}`, which is not part of the PR diff. Move that feedback to `summary` instead."
+            )
+            continue
+        if not isinstance(line, int) or line <= 0:
+            errors.append(
+                f"`comments[{index}]` for `{path}` must include a positive integer `line`."
+            )
+            continue
+        if not body:
+            errors.append(f"`comments[{index}]` for `{path}` is missing `body`.")
+            continue
+
+        allowed_lines = diff_line_map[path][side]
+        if line not in allowed_lines:
+            errors.append(
+                f"`comments[{index}]` references `{path}:{line}` on `{side}`, which is not commentable in the PR diff."
+            )
+            continue
+
+        normalized_comment: ReviewComment = {
+            "path": path,
+            "line": line,
+            "side": side,
+            "body": body,
+        }
+
+        if "start_line" in raw_comment and raw_comment.get("start_line") is not None:
+            start_line = raw_comment.get("start_line")
+            if not isinstance(start_line, int) or start_line <= 0 or start_line >= line:
+                errors.append(
+                    f"`comments[{index}]` for `{path}` has invalid `start_line`; it must be a positive integer smaller than `line`."
+                )
+                continue
+            if start_line not in allowed_lines:
+                errors.append(
+                    f"`comments[{index}]` references `{path}:{start_line}` on `{side}` as `start_line`, which is not commentable in the PR diff."
+                )
+                continue
+            normalized_comment["start_line"] = start_line
+            normalized_comment["start_side"] = side
+
+        if diff_content_map is not None:
+            suggestion_errors = _validate_suggestion_blocks(
+                normalized_comment, diff_content_map
+            )
+            if suggestion_errors:
+                for err in suggestion_errors:
+                    errors.append(
+                        f"`comments[{index}]` for `{path}:{line}` on `{side}` has an invalid suggestion block: {err}."
+                    )
+                continue
+
+        normalized_comments.append(normalized_comment)
+
+    return ReviewValidationResult(
+        summary=summary.strip(),
+        comments=normalized_comments,
+        errors=errors,
+    )
+
+
+def normalize_review_payload(
+    review: Any,
+    diff_line_map: dict[str, dict[str, set[int]]],
+    diff_content_map: dict[str, dict[str, dict[int, str]]] | None = None,
+) -> tuple[str, list[ReviewComment]]:
+    """Compatibility wrapper that logs and drops invalid inline comments."""
+    result = validate_review_payload(review, diff_line_map, diff_content_map)
+    for err in result.errors:
+        print(f"[review-validation] Dropped comment: {err}")
+    return result.summary, result.comments

--- a/oz/review_validation.py
+++ b/oz/review_validation.py
@@ -19,14 +19,18 @@ class ReviewComment(TypedDict, total=False):
 @dataclass(frozen=True)
 class ReviewValidationResult:
     """Validated ``review.json`` fields plus any dropped-comment errors."""
-
-    summary: str
+    body: str
     comments: list[ReviewComment]
     errors: list[str]
 
     @property
     def is_valid(self) -> bool:
         return not self.errors
+
+    @property
+    def summary(self) -> str:
+        """Backward-compatible alias for older callers."""
+        return self.body
 
 
 HUNK_HEADER_PATTERN = re.compile(
@@ -258,17 +262,19 @@ def _validate_suggestion_blocks(
 
     path = comment.get("path") or ""
     side = comment.get("side") or "RIGHT"
+    start_side = comment.get("start_side") or side
     line_no = comment.get("line")
     if not isinstance(line_no, int):
         return errors
     start_line = comment.get("start_line") or line_no
-    content_for_side = diff_content_map.get(path, {}).get(side, {})
+    content_for_start_side = diff_content_map.get(path, {}).get(start_side, {})
+    content_for_end_side = diff_content_map.get(path, {}).get(side, {})
 
     for block_index, block_lines in enumerate(blocks):
         if not block_lines or block_lines == [""]:
             continue
-        prev_context = content_for_side.get(start_line - 1)
-        next_context = content_for_side.get(line_no + 1)
+        prev_context = content_for_start_side.get(start_line - 1)
+        next_context = content_for_end_side.get(line_no + 1)
         first_line = block_lines[0]
         last_line = block_lines[-1]
         if prev_context is not None and first_line == prev_context:
@@ -293,9 +299,11 @@ def validate_review_payload(
     if not isinstance(review, dict):
         raise ValueError("Review payload must be a JSON object.")
 
-    summary = review.get("summary") or ""
-    if not isinstance(summary, str):
-        raise ValueError("Review payload `summary` must be a string.")
+    raw_body = review.get("body")
+    if raw_body is None:
+        raw_body = review.get("summary") or ""
+    if not isinstance(raw_body, str):
+        raise ValueError("Review payload `body` must be a string.")
 
     raw_comments = review.get("comments") or []
     if not isinstance(raw_comments, list):
@@ -311,24 +319,26 @@ def validate_review_payload(
 
         path = normalize_review_path(raw_comment.get("path"))
         line = raw_comment.get("line")
-        body = str(raw_comment.get("body") or "").strip()
-        side = (
-            raw_comment.get("side")
-            if raw_comment.get("side") in {"LEFT", "RIGHT"}
-            else "RIGHT"
-        )
+        body_value = raw_comment.get("body")
+        body = body_value.strip() if isinstance(body_value, str) else ""
+        side = raw_comment.get("side")
 
         if not path:
             errors.append(f"`comments[{index}]` is missing `path`.")
             continue
         if path not in diff_line_map:
             errors.append(
-                f"`comments[{index}]` references `{path}`, which is not part of the PR diff. Move that feedback to `summary` instead."
+                f"`comments[{index}]` references `{path}`, which is not part of the PR diff. Move that feedback to top-level `body` instead."
             )
             continue
         if not isinstance(line, int) or line <= 0:
             errors.append(
                 f"`comments[{index}]` for `{path}` must include a positive integer `line`."
+            )
+            continue
+        if side not in {"LEFT", "RIGHT"}:
+            errors.append(
+                f"`comments[{index}]` for `{path}:{line}` must include `side` set to `LEFT` or `RIGHT`."
             )
             continue
         if not body:
@@ -351,18 +361,34 @@ def validate_review_payload(
 
         if "start_line" in raw_comment and raw_comment.get("start_line") is not None:
             start_line = raw_comment.get("start_line")
-            if not isinstance(start_line, int) or start_line <= 0 or start_line >= line:
+            if not isinstance(start_line, int) or start_line <= 0:
                 errors.append(
-                    f"`comments[{index}]` for `{path}` has invalid `start_line`; it must be a positive integer smaller than `line`."
+                    f"`comments[{index}]` for `{path}` has invalid `start_line`; it must be a positive integer."
                 )
                 continue
-            if start_line not in allowed_lines:
+            start_side = raw_comment.get("start_side")
+            if start_side not in {"LEFT", "RIGHT"}:
                 errors.append(
-                    f"`comments[{index}]` references `{path}:{start_line}` on `{side}` as `start_line`, which is not commentable in the PR diff."
+                    f"`comments[{index}]` for `{path}` has `start_line` but is missing `start_side`; set `start_side` to `LEFT` or `RIGHT`."
+                )
+                continue
+            if start_side == side and start_line >= line:
+                errors.append(
+                    f"`comments[{index}]` for `{path}` has invalid `start_line`; when `start_side` matches `side`, it must be smaller than `line`."
+                )
+                continue
+            if start_line not in diff_line_map[path][start_side]:
+                errors.append(
+                    f"`comments[{index}]` references `{path}:{start_line}` on `{start_side}` as `start_line`, which is not commentable in the PR diff."
                 )
                 continue
             normalized_comment["start_line"] = start_line
-            normalized_comment["start_side"] = side
+            normalized_comment["start_side"] = start_side
+        elif raw_comment.get("start_side") is not None:
+            errors.append(
+                f"`comments[{index}]` for `{path}:{line}` has `start_side` without `start_line`."
+            )
+            continue
 
         if diff_content_map is not None:
             suggestion_errors = _validate_suggestion_blocks(
@@ -378,7 +404,7 @@ def validate_review_payload(
         normalized_comments.append(normalized_comment)
 
     return ReviewValidationResult(
-        summary=summary.strip(),
+        body=raw_body.strip(),
         comments=normalized_comments,
         errors=errors,
     )
@@ -393,4 +419,4 @@ def normalize_review_payload(
     result = validate_review_payload(review, diff_line_map, diff_content_map)
     for err in result.errors:
         print(f"[review-validation] Dropped comment: {err}")
-    return result.summary, result.comments
+    return result.body, result.comments

--- a/tests/test_review_validation.py
+++ b/tests/test_review_validation.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from . import conftest  # noqa: F401
+
+from oz.review_validation import (
+    build_diff_maps_from_annotated_diff,
+    normalize_review_payload,
+    validate_review_payload,
+)
+
+
+ANNOTATED_DIFF = """diff --git a/src/example.py b/src/example.py
+--- a/src/example.py
++++ b/src/example.py
+@@ -1,3 +1,4 @@
+[OLD:1,NEW:1] def greet():
+[OLD:2]     return "hello"
+[NEW:2]     name = "world"
+[NEW:3]     return f"hello {name}"
+[OLD:3,NEW:4] 
+"""
+
+DELETED_FILE_ANNOTATED_DIFF = """diff --git a/src/obsolete.py b/src/obsolete.py
+--- a/src/obsolete.py
++++ /dev/null
+@@ -1,2 +0,0 @@
+[OLD:1] def obsolete():
+[OLD:2]     return True
+"""
+
+
+class ReviewValidationTest(unittest.TestCase):
+    def test_validates_comments_against_annotated_diff(self) -> None:
+        diff_line_map, diff_content_map = build_diff_maps_from_annotated_diff(
+            ANNOTATED_DIFF
+        )
+        result = validate_review_payload(
+            {
+                "summary": "ok",
+                "comments": [
+                    {
+                        "path": "src/example.py",
+                        "line": 2,
+                        "side": "RIGHT",
+                        "body": "⚠️ [IMPORTANT] Use a less generic name.",
+                    }
+                ],
+            },
+            diff_line_map,
+            diff_content_map,
+        )
+        self.assertEqual(result.errors, [])
+        self.assertEqual(len(result.comments), 1)
+
+    def test_rejects_comments_for_lines_not_in_annotated_diff(self) -> None:
+        diff_line_map, diff_content_map = build_diff_maps_from_annotated_diff(
+            ANNOTATED_DIFF
+        )
+        result = validate_review_payload(
+            {
+                "summary": "ok",
+                "comments": [
+                    {
+                        "path": "src/example.py",
+                        "line": 99,
+                        "side": "RIGHT",
+                        "body": "⚠️ [IMPORTANT] This line is not present.",
+                    }
+                ],
+            },
+            diff_line_map,
+            diff_content_map,
+        )
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn("not commentable", result.errors[0])
+
+    def test_normalize_review_payload_drops_invalid_comments(self) -> None:
+        diff_line_map, diff_content_map = build_diff_maps_from_annotated_diff(
+            ANNOTATED_DIFF
+        )
+        _summary, comments = normalize_review_payload(
+            {
+                "summary": "ok",
+                "comments": [
+                    {
+                        "path": "src/example.py",
+                        "line": 2,
+                        "side": "RIGHT",
+                        "body": "⚠️ [IMPORTANT] Valid.",
+                    },
+                    {
+                        "path": "src/example.py",
+                        "line": 99,
+                        "side": "RIGHT",
+                        "body": "⚠️ [IMPORTANT] Invalid.",
+                    },
+                ],
+            },
+            diff_line_map,
+            diff_content_map,
+        )
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(comments[0]["line"], 2)
+
+    def test_validates_left_comments_on_deleted_files(self) -> None:
+        diff_line_map, diff_content_map = build_diff_maps_from_annotated_diff(
+            DELETED_FILE_ANNOTATED_DIFF
+        )
+        result = validate_review_payload(
+            {
+                "summary": "ok",
+                "comments": [
+                    {
+                        "path": "src/obsolete.py",
+                        "line": 2,
+                        "side": "LEFT",
+                        "body": "⚠️ [IMPORTANT] Keep this behavior elsewhere.",
+                    }
+                ],
+            },
+            diff_line_map,
+            diff_content_map,
+        )
+        self.assertEqual(result.errors, [])
+        self.assertEqual(len(result.comments), 1)
+
+    def test_cli_validator_fails_for_invalid_inline_location(self) -> None:
+        script = (
+            Path(__file__).resolve().parent.parent
+            / ".agents"
+            / "skills"
+            / "review-pr"
+            / "scripts"
+            / "validate_review_json.py"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            diff_path = tmp_path / "pr_diff.txt"
+            review_path = tmp_path / "review.json"
+            diff_path.write_text(ANNOTATED_DIFF, encoding="utf-8")
+            review_path.write_text(
+                json.dumps(
+                    {
+                        "verdict": "REJECT",
+                        "summary": "bad",
+                        "comments": [
+                            {
+                                "path": "src/example.py",
+                                "line": 99,
+                                "side": "RIGHT",
+                                "body": "⚠️ [IMPORTANT] Invalid.",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--review-json",
+                    str(review_path),
+                    "--diff",
+                    str(diff_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("not commentable", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_review_validation.py
+++ b/tests/test_review_validation.py
@@ -43,7 +43,7 @@ class ReviewValidationTest(unittest.TestCase):
         )
         result = validate_review_payload(
             {
-                "summary": "ok",
+                "body": "ok",
                 "comments": [
                     {
                         "path": "src/example.py",
@@ -58,6 +58,64 @@ class ReviewValidationTest(unittest.TestCase):
         )
         self.assertEqual(result.errors, [])
         self.assertEqual(len(result.comments), 1)
+        self.assertEqual(result.body, "ok")
+
+    def test_accepts_github_shaped_multiline_comments_with_start_side(self) -> None:
+        diff_line_map, diff_content_map = build_diff_maps_from_annotated_diff(
+            ANNOTATED_DIFF
+        )
+        result = validate_review_payload(
+            {
+                "body": "ok",
+                "comments": [
+                    {
+                        "path": "src/example.py",
+                        "start_line": 2,
+                        "start_side": "RIGHT",
+                        "line": 3,
+                        "side": "RIGHT",
+                        "body": "💡 [SUGGESTION] Combine these lines.",
+                    }
+                ],
+            },
+            diff_line_map,
+            diff_content_map,
+        )
+        self.assertEqual(result.errors, [])
+        self.assertEqual(
+            result.comments[0],
+            {
+                "path": "src/example.py",
+                "start_line": 2,
+                "start_side": "RIGHT",
+                "line": 3,
+                "side": "RIGHT",
+                "body": "💡 [SUGGESTION] Combine these lines.",
+            },
+        )
+
+    def test_requires_start_side_for_multiline_comments(self) -> None:
+        diff_line_map, diff_content_map = build_diff_maps_from_annotated_diff(
+            ANNOTATED_DIFF
+        )
+        result = validate_review_payload(
+            {
+                "body": "ok",
+                "comments": [
+                    {
+                        "path": "src/example.py",
+                        "start_line": 2,
+                        "line": 3,
+                        "side": "RIGHT",
+                        "body": "💡 [SUGGESTION] Combine these lines.",
+                    }
+                ],
+            },
+            diff_line_map,
+            diff_content_map,
+        )
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn("missing `start_side`", result.errors[0])
 
     def test_rejects_comments_for_lines_not_in_annotated_diff(self) -> None:
         diff_line_map, diff_content_map = build_diff_maps_from_annotated_diff(
@@ -149,7 +207,7 @@ class ReviewValidationTest(unittest.TestCase):
                 json.dumps(
                     {
                         "verdict": "REJECT",
-                        "summary": "bad",
+                        "body": "bad",
                         "comments": [
                             {
                                 "path": "src/example.py",


### PR DESCRIPTION
## Summary
- Harden review-pr and review-spec instructions so inline comments must target explicit annotated diff lines.
- Add a shared review validation module used by both the workflow apply path and the bundled validator CLI.
- Package a single validator script under the review-pr skill and have review-spec/cloud prompts reuse that script.

## Context
This follows the investigation into warpdotdev/warp#9746, where a review artifact targeted a non-commentable line and caused GitHub to reject the entire review with `Line could not be resolved`.

## Validation
- `python3 -m unittest tests.test_review_validation`
- `python3 -m unittest tests.test_handlers tests.test_poll_runs`

Oz conversation: https://staging.warp.dev/conversation/9aa732f8-4356-49c7-b3d2-d467e5572f01

Co-Authored-By: Oz <oz-agent@warp.dev>
