### PR TITLE
feat: allow respond-to-pr-comment flow on fork PRs for org members

### DIFF
--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -21,6 +21,11 @@ from core.routing import (
 from core.state import RunState
 from core.workflow_adapters import reconstruct_progress
 
+# Author associations treated as trusted org members.  Mirrors
+# ``oz.helpers.ORG_MEMBER_ASSOCIATIONS`` but duplicated here to avoid
+# a top-level import of ``oz.helpers`` which the test harness stubs.
+_ORG_MEMBER_ASSOCIATIONS: set[str] = {"COLLABORATOR", "MEMBER", "OWNER"}
+
 
 def _resolve_owner_repo(payload: Mapping[str, Any]) -> tuple[str, str, str]:
     repo_obj = payload.get("repository") or {}
@@ -105,6 +110,26 @@ def _resolve_trigger_kind(payload: Mapping[str, Any]) -> str:
     if isinstance(payload.get("review"), dict):
         return "review_body"
     return "conversation"
+
+
+def _resolve_requester_author_association(payload: Mapping[str, Any]) -> str:
+    """Extract the ``author_association`` for the requester from the payload.
+
+    GitHub includes ``author_association`` on comment and review objects
+    in webhook payloads.  The value reflects the commenter's relationship
+    with the repository (e.g. ``MEMBER``, ``COLLABORATOR``, ``OWNER``).
+    """
+    comment = payload.get("comment")
+    if isinstance(comment, dict):
+        assoc = comment.get("author_association")
+        if isinstance(assoc, str) and assoc.strip():
+            return assoc.strip()
+    review = payload.get("review")
+    if isinstance(review, dict):
+        assoc = review.get("author_association")
+        if isinstance(assoc, str) and assoc.strip():
+            return assoc.strip()
+    return ""
 
 
 def _resolve_trigger_comment_id(payload: Mapping[str, Any]) -> int:
@@ -211,6 +236,8 @@ class RespondWorkflow(BaseWorkflow):
         repo_handle = github_client.get_repo(full_name)
         pr = repo_handle.get_pull(pr_number)
         review_reply_target = _resolve_review_reply_target(payload, pr)
+        author_association = _resolve_requester_author_association(payload)
+        requester_is_org_member = author_association.upper() in _ORG_MEMBER_ASSOCIATIONS
         context = gather_pr_comment_context(
             repo_handle,
             owner=owner,
@@ -224,8 +251,9 @@ class RespondWorkflow(BaseWorkflow):
             workspace_path=workspace_path or Path("/tmp"),
             client=github_client,
             pr=pr,
+            requester_is_org_member=requester_is_org_member,
         )
-        if context.get("can_push_to_head_branch") is False:
+        if context.get("can_push_to_head_branch") is False and not requester_is_org_member:
             return None
         return WorkflowDispatch(
             workflow=self.workflow,

--- a/core/workflows/respond_to_pr_comment.py
+++ b/core/workflows/respond_to_pr_comment.py
@@ -54,6 +54,7 @@ class PrCommentContext(TypedDict):
     has_spec_context: bool
     spec_context_text: str
     coauthor_line: str
+    requester_is_org_member: bool
     coauthor_directives: str
     progress_start_line: str
 
@@ -72,6 +73,7 @@ def gather_pr_comment_context(
     workspace_path: Any = None,
     client: Github | None = None,
     pr: PullRequest | None = None,
+    requester_is_org_member: bool = False,
 ) -> PrCommentContext:
     """Gather PR + spec context for a respond-to-pr-comment dispatch.
 
@@ -157,6 +159,7 @@ def gather_pr_comment_context(
         review_reply_target_id=review_reply_target_id,
         has_spec_context=has_spec_context,
         spec_context_text=spec_context_text,
+        requester_is_org_member=requester_is_org_member,
         coauthor_line=coauthor_line,
         coauthor_directives=coauthor_directives,
         progress_start_line=progress_start_line,
@@ -269,6 +272,7 @@ def apply_pr_comment_result(
     pr_number = int(context["pr_number"])
     head_branch = str(context["head_branch"])
     can_push_to_head_branch = bool(context.get("can_push_to_head_branch", True))
+    requester_is_org_member = bool(context.get("requester_is_org_member", False))
     requester = str(context.get("requester") or "")
     trigger_kind = str(context.get("trigger_kind") or "conversation")
     review_reply_target_id = int(context.get("review_reply_target_id") or 0)
@@ -296,7 +300,7 @@ def apply_pr_comment_result(
     created_at = getattr(run, "created_at", None)
     if not isinstance(created_at, datetime):
         created_at = datetime.now(timezone.utc)
-    if not can_push_to_head_branch:
+    if not can_push_to_head_branch and not requester_is_org_member:
         progress.complete(
             "I analyzed the request but did not push changes because this PR head "
             "is not allowed to publish back to the base repository."

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -381,6 +381,63 @@ class BuildRespondRequestTest(_BuilderTestBase):
         self.assertIsNone(request)
         respond_module.build_pr_comment_prompt.assert_not_called()  # type: ignore[attr-defined]
 
+    def test_allows_dispatch_for_fork_pr_when_requester_is_org_member(self) -> None:
+        from core.builders import build_respond_request
+        from core.routing import WORKFLOW_RESPOND_TO_PR_COMMENT
+
+        respond_module = sys.modules["workflows.respond_to_pr_comment"]
+        respond_module.gather_pr_comment_context.return_value = {  # type: ignore[attr-defined]
+            "owner": "acme",
+            "repo": "widgets",
+            "pr_number": 7,
+            "head_branch": "harsh_poc",
+            "head_repo_full_name": "contributor/widgets",
+            "base_branch": "main",
+            "base_repo_full_name": "acme/widgets",
+            "is_cross_repository": True,
+            "head_branch_exists_in_base": False,
+            "can_push_to_head_branch": False,
+            "pr_title": "feat: add",
+            "requester": "alice",
+            "trigger_kind": "review",
+            "trigger_comment_id": 999,
+            "review_reply_target_id": 999,
+            "has_spec_context": False,
+            "spec_context_text": "No spec context.",
+            "requester_is_org_member": True,
+            "coauthor_line": "",
+            "coauthor_directives": "- foo",
+            "progress_start_line": "I'm starting",
+        }
+        github_client = MagicMock()
+        repo = MagicMock(name="repo")
+        github_client.get_repo.return_value = repo
+        repo.get_pull.return_value = MagicMock(name="pr")
+
+        payload = {
+            "repository": {"full_name": "acme/widgets"},
+            "installation": {"id": 1},
+            "pull_request": {"number": 7},
+            "comment": {
+                "id": 999,
+                "user": {"login": "alice"},
+                "author_association": "MEMBER",
+            },
+        }
+
+        request = build_respond_request(
+            payload,
+            github_client=github_client,
+            workspace_path=Path("/tmp/ws"),
+        )
+
+        self.assertIsNotNone(request)
+        self.assertEqual(request.workflow, WORKFLOW_RESPOND_TO_PR_COMMENT)
+        respond_module.build_pr_comment_prompt.assert_called_once()  # type: ignore[attr-defined]
+        # Verify requester_is_org_member was passed to gather_pr_comment_context
+        kwargs = respond_module.gather_pr_comment_context.call_args.kwargs  # type: ignore[attr-defined]
+        self.assertTrue(kwargs["requester_is_org_member"])
+
 
 class BuildVerifyRequestTest(_BuilderTestBase):
     def setUp(self) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -132,6 +132,55 @@ class PrCommentContextBranchSafetyTest(unittest.TestCase):
         self.assertTrue(context["head_branch_exists_in_base"])
         self.assertFalse(context["can_push_to_head_branch"])
 
+    def test_context_carries_requester_is_org_member(self) -> None:
+        github = MagicMock()
+        github.get_git_ref.return_value = object()
+        pr = self._pr(head_repo="contributor/widgets", base_repo="acme/widgets")
+
+        with patch(
+            "workflows.respond_to_pr_comment.resolve_spec_context_for_pr_via_api",
+            return_value={"spec_entries": []},
+        ):
+            context = gather_pr_comment_context(
+                github,
+                owner="acme",
+                repo="widgets",
+                pr_number=12,
+                trigger_kind="conversation",
+                trigger_comment_id=99,
+                requester="alice",
+                event={},
+                pr=pr,
+                requester_is_org_member=True,
+            )
+
+        self.assertTrue(context["is_cross_repository"])
+        self.assertFalse(context["can_push_to_head_branch"])
+        self.assertTrue(context["requester_is_org_member"])
+
+    def test_context_defaults_requester_is_org_member_to_false(self) -> None:
+        github = MagicMock()
+        github.get_git_ref.return_value = object()
+        pr = self._pr(head_repo="acme/widgets", base_repo="acme/widgets")
+
+        with patch(
+            "workflows.respond_to_pr_comment.resolve_spec_context_for_pr_via_api",
+            return_value={"spec_entries": []},
+        ):
+            context = gather_pr_comment_context(
+                github,
+                owner="acme",
+                repo="widgets",
+                pr_number=12,
+                trigger_kind="conversation",
+                trigger_comment_id=99,
+                requester="alice",
+                event={},
+                pr=pr,
+            )
+
+        self.assertFalse(context["requester_is_org_member"])
+
     def test_context_blocks_push_when_branch_would_be_created(self) -> None:
         github = MagicMock()
         github.get_git_ref.side_effect = UnknownObjectException(404, {}, {})


### PR DESCRIPTION
## Summary

Allow the `respond-to-pr-comment` workflow to trigger on PRs from forks when the requester is a member of the repository's org (COLLABORATOR, MEMBER, or OWNER `author_association`).

Previously, the workflow was unconditionally skipped for fork PRs because `can_push_to_head_branch` was `False`. Now, the webhook handler extracts the requester's `author_association` from the comment/review object in the payload and allows the dispatch to proceed for trusted org members.

## Changes

### `core/workflows/__init__.py`
- Added `_resolve_requester_author_association()` helper to extract `author_association` from the webhook payload
- Added `_ORG_MEMBER_ASSOCIATIONS` constant (mirrors `oz.helpers.ORG_MEMBER_ASSOCIATIONS`)
- Modified `RespondWorkflow.build_dispatch()`: only returns `None` for fork PRs when the requester is NOT an org member

### `core/workflows/respond_to_pr_comment.py`
- Added `requester_is_org_member` field to the `PrCommentContext` TypedDict
- Updated `gather_pr_comment_context()` to accept and pass through the flag
- Updated `apply_pr_comment_result()` to skip the early return for org members, allowing the agent to analyze and push changes

### Tests
- Added test for org member on fork PR being allowed through dispatch (`test_allows_dispatch_for_fork_pr_when_requester_is_org_member`)
- Added tests for `requester_is_org_member` context handling (`test_context_carries_requester_is_org_member`, `test_context_defaults_requester_is_org_member_to_false`)
- Existing test `test_skips_dispatch_when_head_branch_is_not_safe_to_push` continues to verify non-org-member fork PRs are skipped

_Conversation: https://staging.warp.dev/conversation/db278a0a-7b60-45a8-9f68-4f975c7710a8_
_Run: https://oz.staging.warp.dev/runs/019deece-03df-79ae-903d-1f6d3eb222ec_

_This PR was generated with [Oz](https://warp.dev/oz)._
