### PR TITLE
Update MIT license copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Warp
+Copyright (c) 2026 Denver Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update the MIT license copyright holder to match warpdotdev/common-skills.

## Tests
- Not run; license-only change.

Co-Authored-By: Oz <oz-agent@warp.dev>

Oz conversation: https://staging.warp.dev/conversation/d681c7c8-0f6d-41ec-ae04-d684b890c520