### PR TITLE
fix: wrap recommended_reviewer mentions in backticks to avoid GitHub pings

### DIFF
--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -305,7 +305,7 @@ def _format_review_completion_message(
 ) -> str:
     """Build the progress-comment completion message after review application."""
     if recommended_reviewers:
-        mentions = ", ".join(f"@{login}" for login in recommended_reviewers)
+        mentions = ", ".join(f"`@{login}`" for login in recommended_reviewers)
         base = (
             "I reviewed this pull request and requested human review from: "
             f"{mentions}."


### PR DESCRIPTION
When Oz approves a non-member PR and requests human review, the
completion message previously used bare `@login` mentions (e.g. `@alice`).
This triggered a second GitHub notification even though the reviewer was
already notified via the review request API.

Wrap each login in backticks so the mention renders as `` `@alice` ``
instead — GitHub does not send mention notifications for code-formatted
text.

**Changed:** `_format_review_completion_message` in
`core/workflows/review_pr.py` — `f"@{login}"` → `` f"`@{login}`" ``

_Conversation: https://staging.warp.dev/conversation/8351d6b9-fe61-40fb-b67e-84d0a5a210cc_
_Run: https://oz.staging.warp.dev/runs/019df061-5ec2-707e-9cbd-9df46404bf27_
_This PR was generated with [Oz](https://warp.dev/oz)._
