### PR TITLE
fix: restore oz review invocation cap

### DIFF
--- a/core/routing.py
+++ b/core/routing.py
@@ -99,7 +99,7 @@ OZ_REVIEW_COMMAND = "/oz-review"
 OZ_VERIFY_COMMAND = "/oz-verify"
 MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR = 3
 OZ_REVIEW_COMMAND_PATTERN = re.compile(
-    r"(?:^|\s)(?:/oz-review|@oz-agent\s+/review)\b", re.IGNORECASE
+    r"(?:^|\s)(?:/oz-review|@oz-agent\s+/review)(?![-\w])", re.IGNORECASE
 )
 
 

--- a/core/routing.py
+++ b/core/routing.py
@@ -69,6 +69,7 @@ Webhook coverage today:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -96,6 +97,15 @@ READY_TO_IMPLEMENT_LABEL = "ready-to-implement"
 OZ_AGENT_MENTION = "@oz-agent"
 OZ_REVIEW_COMMAND = "/oz-review"
 OZ_VERIFY_COMMAND = "/oz-verify"
+MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR = 3
+OZ_REVIEW_COMMAND_PATTERN = re.compile(
+    r"(?:^|\s)(?:/oz-review|@oz-agent\s+/review)\b", re.IGNORECASE
+)
+
+
+def has_oz_review_command(body: str) -> bool:
+    """Return whether *body* carries an explicit Oz review invocation."""
+    return bool(OZ_REVIEW_COMMAND_PATTERN.search(body or ""))
 
 
 @dataclass(frozen=True)
@@ -172,7 +182,7 @@ def _route_issue_comment(payload: dict[str, Any]) -> RouteDecision:
         return _route_plain_issue_comment(issue=issue, comment=comment, body=body)
     if OZ_VERIFY_COMMAND in body:
         return RouteDecision(WORKFLOW_VERIFY_PR_COMMENT, "/oz-verify on PR comment")
-    if OZ_REVIEW_COMMAND in body:
+    if has_oz_review_command(body):
         return RouteDecision(WORKFLOW_REVIEW_PR, "/oz-review on PR comment")
     if OZ_AGENT_MENTION in body:
         return RouteDecision(WORKFLOW_RESPOND_TO_PR_COMMENT, "@oz-agent mention on PR")
@@ -403,7 +413,7 @@ def _route_pull_request_review_comment(payload: dict[str, Any]) -> RouteDecision
     if _is_bot(comment.get("user")):
         return RouteDecision(None, "review comment authored by automation user")
     body = str(comment.get("body") or "")
-    if OZ_REVIEW_COMMAND in body:
+    if has_oz_review_command(body):
         return RouteDecision(WORKFLOW_REVIEW_PR, "/oz-review on review comment")
     if OZ_VERIFY_COMMAND in body:
         return RouteDecision(WORKFLOW_VERIFY_PR_COMMENT, "/oz-verify on review comment")
@@ -459,8 +469,10 @@ __all__ = [
     "OZ_AGENT_LOGIN",
     "OZ_AGENT_MENTION",
     "OZ_REVIEW_COMMAND",
+    "OZ_REVIEW_COMMAND_PATTERN",
     "OZ_VERIFY_COMMAND",
     "OZ_REVIEW_LABEL",
+    "MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR",
     "PLAN_APPROVED_LABEL",
     "READY_TO_IMPLEMENT_LABEL",
     "READY_TO_SPEC_LABEL",
@@ -474,5 +486,6 @@ __all__ = [
     "WORKFLOW_REVIEW_PR",
     "WORKFLOW_TRIAGE_NEW_ISSUES",
     "WORKFLOW_VERIFY_PR_COMMENT",
+    "has_oz_review_command",
     "route_event",
 ]

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -10,6 +11,7 @@ from oz.agent_workflow import (
 )
 
 from core.routing import (
+    MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR,
     WORKFLOW_CREATE_IMPLEMENTATION_FROM_ISSUE,
     WORKFLOW_CREATE_SPEC_FROM_ISSUE,
     WORKFLOW_PLAN_APPROVED,
@@ -17,9 +19,12 @@ from core.routing import (
     WORKFLOW_REVIEW_PR,
     WORKFLOW_TRIAGE_NEW_ISSUES,
     WORKFLOW_VERIFY_PR_COMMENT,
+    has_oz_review_command,
 )
 from core.state import RunState
 from core.workflow_adapters import reconstruct_progress
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_owner_repo(payload: Mapping[str, Any]) -> tuple[str, str, str]:
@@ -125,6 +130,40 @@ def _resolve_review_reply_target(payload: Mapping[str, Any], pr: Any) -> tuple[A
     return None
 
 
+def _get_field(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _is_automation_user(user: Any) -> bool:
+    user_type = str(_get_field(user, "type", "") or "").strip().lower()
+    if user_type == "bot":
+        return True
+    login = str(_get_field(user, "login", "") or "").strip().lower()
+    return bool(login) and login.endswith("[bot]")
+
+
+def _explicit_review_invocation_count(pr: Any) -> int:
+    """Count non-bot explicit review invocations already persisted on *pr*."""
+    count = 0
+    for comment in list(pr.get_issue_comments()) + list(pr.get_review_comments()):
+        body = str(_get_field(comment, "body", "") or "")
+        if not has_oz_review_command(body):
+            continue
+        if _is_automation_user(_get_field(comment, "user")):
+            continue
+        count += 1
+    return count
+
+
+def _is_explicit_review_invocation(payload: Mapping[str, Any]) -> bool:
+    comment = payload.get("comment")
+    if not isinstance(comment, dict):
+        return False
+    return has_oz_review_command(str(comment.get("body") or ""))
+
+
 class BaseWorkflow:
     workflow: str
     config_name: str
@@ -152,6 +191,31 @@ class ReviewWorkflow(BaseWorkflow):
         requester = _resolve_requester(payload)
         trigger_source = _resolve_trigger_source(payload)
         repo_handle = github_client.get_repo(full_name)
+        if _is_explicit_review_invocation(payload):
+            try:
+                invocation_count = _explicit_review_invocation_count(
+                    repo_handle.get_pull(pr_number)
+                )
+            except Exception:
+                # Fail open: if the throttle lookup itself fails for any
+                # reason (transient API error, permissions issue, etc.) we
+                # still honor the request rather than silently dropping a
+                # legitimate review trigger.
+                logger.exception(
+                    "Failed to count explicit /oz-review invocations for %s PR #%s; allowing review",
+                    full_name,
+                    pr_number,
+                )
+                invocation_count = 0
+            if invocation_count > MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR:
+                logger.info(
+                    "Skipping /oz-review for %s PR #%s: invocation count %s exceeds limit %s",
+                    full_name,
+                    pr_number,
+                    invocation_count,
+                    MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR,
+                )
+                return None
         context = gather_review_context(
             repo_handle,
             owner=owner,

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -90,6 +90,7 @@ class _BuilderTestBase(unittest.TestCase):
         helpers.triggering_comment_prompt_text = MagicMock(  # type: ignore[attr-defined]
             return_value=""
         )
+
     def assert_deferred_progress(
         self,
         request: Any,
@@ -176,6 +177,50 @@ class BuildReviewRequestTest(_BuilderTestBase):
             "sender": {"login": "alice"},
         }
 
+    def _explicit_review_payload(self, body: str = "/oz-review") -> dict[str, Any]:
+        return {
+            "action": "created",
+            "repository": {"full_name": "acme/widgets"},
+            "installation": {"id": 1234},
+            "issue": {
+                "number": 42,
+                "pull_request": {"url": "https://example.test/pr/42"},
+            },
+            "comment": {
+                "id": 1001,
+                "body": body,
+                "user": {"login": "alice", "type": "User"},
+            },
+            "sender": {"login": "alice"},
+        }
+
+    def _review_comment(
+        self,
+        body: str,
+        *,
+        login: str = "alice",
+        user_type: str = "User",
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            body=body,
+            user=SimpleNamespace(login=login, type=user_type),
+        )
+
+    def _github_client_with_review_comments(
+        self,
+        *,
+        issue_comments: list[Any] | None = None,
+        review_comments: list[Any] | None = None,
+    ) -> tuple[MagicMock, MagicMock, MagicMock]:
+        github_client = MagicMock()
+        repo = MagicMock(name="repo")
+        pr = MagicMock(name="pr")
+        github_client.get_repo.return_value = repo
+        repo.get_pull.return_value = pr
+        pr.get_issue_comments.return_value = issue_comments or []
+        pr.get_review_comments.return_value = review_comments or []
+        return github_client, repo, pr
+
     def test_returns_dispatch_request_with_inlined_prompt(self) -> None:
         from core.builders import build_review_request
         from core.routing import WORKFLOW_REVIEW_PR
@@ -213,6 +258,113 @@ class BuildReviewRequestTest(_BuilderTestBase):
                 github_client=MagicMock(),
                 workspace_path=Path("/tmp/ws"),
             )
+
+    def test_allows_third_explicit_review_invocation(self) -> None:
+        from core.builders import build_review_request
+
+        github_client, repo, pr = self._github_client_with_review_comments(
+            issue_comments=[
+                self._review_comment("/oz-review"),
+                self._review_comment("please @oz-agent /review"),
+                self._review_comment("/oz-review again"),
+            ],
+        )
+
+        request = build_review_request(
+            self._explicit_review_payload(),
+            github_client=github_client,
+            workspace_path=Path("/tmp/ws"),
+        )
+
+        self.assertIsNotNone(request)
+        repo.get_pull.assert_called_once_with(42)
+        pr.get_issue_comments.assert_called_once_with()
+        pr.get_review_comments.assert_called_once_with()
+        review_module = sys.modules["workflows.review_pr"]
+        review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
+
+    def test_skips_fourth_explicit_review_invocation(self) -> None:
+        from core.builders import build_review_request
+
+        github_client, repo, pr = self._github_client_with_review_comments(
+            issue_comments=[
+                self._review_comment("/oz-review"),
+                self._review_comment("/oz-review again"),
+                self._review_comment("please @oz-agent /review"),
+            ],
+            review_comments=[self._review_comment("/oz-review inline")],
+        )
+
+        request = build_review_request(
+            self._explicit_review_payload(),
+            github_client=github_client,
+            workspace_path=Path("/tmp/ws"),
+        )
+
+        self.assertIsNone(request)
+        repo.get_pull.assert_called_once_with(42)
+        pr.get_issue_comments.assert_called_once_with()
+        pr.get_review_comments.assert_called_once_with()
+        review_module = sys.modules["workflows.review_pr"]
+        review_module.gather_review_context.assert_not_called()  # type: ignore[attr-defined]
+        review_module.build_review_prompt_for_dispatch.assert_not_called()  # type: ignore[attr-defined]
+        self.assertEqual(len(self.progress_instances), 0)
+
+    def test_ignores_bot_comments_when_counting_explicit_invocations(self) -> None:
+        from core.builders import build_review_request
+
+        github_client, repo, pr = self._github_client_with_review_comments(
+            issue_comments=[
+                self._review_comment("/oz-review"),
+                self._review_comment("/oz-review again"),
+                self._review_comment("please @oz-agent /review"),
+                self._review_comment(
+                    "/oz-review from automation",
+                    login="oz-for-oss[bot]",
+                    user_type="Bot",
+                ),
+            ],
+            review_comments=[
+                self._review_comment(
+                    "/oz-review bot suffix",
+                    login="dependabot[bot]",
+                    user_type="User",
+                )
+            ],
+        )
+
+        request = build_review_request(
+            self._explicit_review_payload(),
+            github_client=github_client,
+            workspace_path=Path("/tmp/ws"),
+        )
+
+        self.assertIsNotNone(request)
+        repo.get_pull.assert_called_once_with(42)
+        pr.get_issue_comments.assert_called_once_with()
+        pr.get_review_comments.assert_called_once_with()
+        review_module = sys.modules["workflows.review_pr"]
+        review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
+
+    def test_fails_open_when_explicit_invocation_count_lookup_fails(self) -> None:
+        from core.builders import build_review_request
+
+        github_client = MagicMock()
+        repo = MagicMock(name="repo")
+        github_client.get_repo.return_value = repo
+        repo.get_pull.side_effect = RuntimeError("GitHub API unavailable")
+
+        with self.assertLogs("core.workflows", level="ERROR"):
+            request = build_review_request(
+                self._explicit_review_payload(),
+                github_client=github_client,
+                workspace_path=Path("/tmp/ws"),
+            )
+
+        self.assertIsNotNone(request)
+        repo.get_pull.assert_called_once_with(42)
+        review_module = sys.modules["workflows.review_pr"]
+        review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
 
 
 class BuildRespondRequestTest(_BuilderTestBase):
@@ -430,7 +582,6 @@ class BuildVerifyRequestTest(_BuilderTestBase):
         self.assertEqual(request.payload_subset["pr_number"], 11)
         self.assertEqual(len(self.progress_instances), 0)
         self.assert_deferred_progress(request)
-
 
 
 class BuildTriageRequestTest(_BuilderTestBase):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -356,6 +356,28 @@ class IssueCommentEventTest(unittest.TestCase):
         )
         self.assertEqual(decision.workflow, WORKFLOW_REVIEW_PR)
 
+    def test_oz_agent_review_alias_on_pr_routes_to_review(self) -> None:
+        decision = route_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": _issue(pull_request={"url": "..."}),
+                "comment": _comment(body="please @oz-agent /review"),
+            },
+        )
+        self.assertEqual(decision.workflow, WORKFLOW_REVIEW_PR)
+
+    def test_oz_review_prefix_without_word_boundary_is_dropped(self) -> None:
+        decision = route_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": _issue(pull_request={"url": "..."}),
+                "comment": _comment(body="/oz-reviewed this already"),
+            },
+        )
+        self.assertIsNone(decision.workflow)
+
     def test_oz_verify_command_takes_precedence_over_review(self) -> None:
         decision = route_event(
             "issue_comment",
@@ -696,6 +718,16 @@ class PullRequestReviewCommentTest(unittest.TestCase):
             {
                 "action": "created",
                 "comment": _comment(body="/oz-review"),
+            },
+        )
+        self.assertEqual(decision.workflow, WORKFLOW_REVIEW_PR)
+
+    def test_oz_agent_review_alias_on_review_comment_routes_to_review(self) -> None:
+        decision = route_event(
+            "pull_request_review_comment",
+            {
+                "action": "created",
+                "comment": _comment(body="please @oz-agent /review"),
             },
         )
         self.assertEqual(decision.workflow, WORKFLOW_REVIEW_PR)


### PR DESCRIPTION
## Summary
- Restore the 3-per-PR cap for explicit `/oz-review` and `@oz-agent /review` requests in the webhook dispatch path.
- Count persisted non-bot explicit review invocations across PR conversation comments and inline review comments before building review context.
- Keep automatic PR review triggers unaffected and fail open if the GitHub lookup for invocation counting fails.

## Validation
- `python3 -m unittest tests.test_routing tests.test_builders tests.test_webhook_dispatch`
- `python3 -m py_compile core/routing.py core/workflows/__init__.py tests/test_routing.py tests/test_builders.py`
- `git --no-pager diff --check`

## Artifacts
- Conversation: https://staging.warp.dev/conversation/776c43b3-6b46-433b-bc53-311ffc5fa897

Co-Authored-By: Oz <oz-agent@warp.dev>
