### PR TITLE
fix: expire stale in-flight cron records

### DIFF
--- a/api/cron.py
+++ b/api/cron.py
@@ -20,7 +20,13 @@ from dataclasses import asdict
 from http.server import BaseHTTPRequestHandler
 from typing import Any, Mapping
 
-from core.poll_runs import DrainOutcome, WorkflowHandlers, drain_in_flight_runs
+from core.poll_runs import (
+    DEFAULT_MAX_IN_FLIGHT_AGE_SECONDS,
+    DEFAULT_MAX_IN_FLIGHT_ATTEMPTS,
+    DrainOutcome,
+    WorkflowHandlers,
+    drain_in_flight_runs,
+)
 from core.state import StateStore
 
 logger = logging.getLogger(__name__)
@@ -147,11 +153,38 @@ def build_workflow_handlers() -> Mapping[str, WorkflowHandlers]:
     return build_handler_registry(github_client_factory=github_client_factory)
 
 
+def _optional_positive_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid %s=%r; using default %s",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if value <= 0:
+        logger.warning(
+            "Ignoring non-positive %s=%r; using default %s",
+            name,
+            raw,
+            default,
+        )
+        return default
+    return value
+
+
 def run_cron_tick(
     *,
     store: StateStore,
     retriever: Any,
     handlers: Mapping[str, WorkflowHandlers] | None = None,
+    max_attempts: int | None = None,
+    max_age_seconds: float | None = None,
 ) -> list[DrainOutcome]:
     """Process a single cron tick.
 
@@ -163,6 +196,16 @@ def run_cron_tick(
         store=store,
         retriever=retriever,
         handlers=handlers or build_workflow_handlers(),
+        max_attempts=(
+            DEFAULT_MAX_IN_FLIGHT_ATTEMPTS
+            if max_attempts is None
+            else max_attempts
+        ),
+        max_age_seconds=(
+            DEFAULT_MAX_IN_FLIGHT_AGE_SECONDS
+            if max_age_seconds is None
+            else max_age_seconds
+        ),
     )
 
 
@@ -204,6 +247,14 @@ class handler(BaseHTTPRequestHandler):  # noqa: N801 - Vercel requires this exac
             outcomes = run_cron_tick(
                 store=store,
                 retriever=client.agent.runs,
+                max_attempts=_optional_positive_int_env(
+                    "OZ_IN_FLIGHT_MAX_ATTEMPTS",
+                    DEFAULT_MAX_IN_FLIGHT_ATTEMPTS,
+                ),
+                max_age_seconds=_optional_positive_int_env(
+                    "OZ_IN_FLIGHT_MAX_AGE_SECONDS",
+                    DEFAULT_MAX_IN_FLIGHT_AGE_SECONDS,
+                ),
             )
         except Exception as exc:
             logger.exception("Cron tick aborted")

--- a/core/poll_runs.py
+++ b/core/poll_runs.py
@@ -20,15 +20,25 @@ processing the rest.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, Callable, Mapping, Protocol
 
-from .state import RunState, StateStore, delete_run_state, list_in_flight_runs, save_run_state
+from .state import (
+    RunState,
+    StateStore,
+    delete_run_state,
+    list_in_flight_runs,
+    save_run_state,
+)
 
 logger = logging.getLogger(__name__)
 
 TERMINAL_STATES = {"SUCCEEDED", "FAILED", "ERROR", "CANCELLED"}
 TERMINAL_FAILURE_STATES = {"FAILED", "ERROR", "CANCELLED"}
+DEFAULT_MAX_IN_FLIGHT_ATTEMPTS = 360
+DEFAULT_MAX_IN_FLIGHT_AGE_SECONDS = 7 * 24 * 60 * 60
 
 
 class RunRetriever(Protocol):
@@ -100,12 +110,69 @@ def _coerce_state(run: Any) -> str:
     return str(getattr(run, "state", "") or "").strip().upper()
 
 
+def _expiration_reason(
+    state: RunState,
+    *,
+    now: float,
+    max_attempts: int | None,
+    max_age_seconds: float | None,
+) -> str:
+    if max_attempts is not None and max_attempts > 0 and state.attempts >= max_attempts:
+        return f"max attempts exceeded ({state.attempts} >= {max_attempts})"
+    if (
+        max_age_seconds is not None
+        and max_age_seconds > 0
+        and state.dispatched_at > 0
+        and now - state.dispatched_at >= max_age_seconds
+    ):
+        age_seconds = int(now - state.dispatched_at)
+        return f"max age exceeded ({age_seconds}s >= {int(max_age_seconds)}s)"
+    return ""
+
+
+def _expire_state(
+    state: RunState,
+    *,
+    handler: WorkflowHandlers,
+    store: StateStore,
+    reason: str,
+) -> DrainOutcome:
+    run = SimpleNamespace(
+        run_id=state.run_id,
+        state="EXPIRED",
+        session_link="",
+        status_message=reason,
+    )
+    error_message = reason
+    if handler.failure_handler is not None:
+        try:
+            handler.failure_handler(state=state, run=run)
+        except Exception as exc:
+            logger.exception(
+                "failure_handler for expired run %s (%s) raised; deleting stale state anyway",
+                state.run_id,
+                state.workflow,
+            )
+            error_message = f"{reason}; failure handler failed: {exc}"
+    delete_run_state(store, state.run_id)
+    return DrainOutcome(
+        run_id=state.run_id,
+        workflow=state.workflow,
+        state="EXPIRED",
+        applied=False,
+        error=error_message,
+    )
+
+
 def _process_one(
     state: RunState,
     *,
     retriever: RunRetriever,
     handlers: Mapping[str, WorkflowHandlers],
     store: StateStore,
+    now: float,
+    max_attempts: int | None,
+    max_age_seconds: float | None,
 ) -> DrainOutcome:
     handler = handlers.get(state.workflow)
     if handler is None:
@@ -119,6 +186,25 @@ def _process_one(
             state="UNKNOWN_WORKFLOW",
             applied=False,
             error=f"no handler registered for workflow {state.workflow!r}",
+        )
+    reason = _expiration_reason(
+        state,
+        now=now,
+        max_attempts=max_attempts,
+        max_age_seconds=max_age_seconds,
+    )
+    if reason:
+        logger.warning(
+            "Expiring Oz run %s for workflow %s: %s",
+            state.run_id,
+            state.workflow,
+            reason,
+        )
+        return _expire_state(
+            state,
+            handler=handler,
+            store=store,
+            reason=reason,
         )
 
     try:
@@ -211,6 +297,9 @@ def drain_in_flight_runs(
     retriever: RunRetriever,
     handlers: Mapping[str, WorkflowHandlers],
     state_iterator: Callable[[StateStore], Any] = list_in_flight_runs,
+    max_attempts: int | None = DEFAULT_MAX_IN_FLIGHT_ATTEMPTS,
+    max_age_seconds: float | None = DEFAULT_MAX_IN_FLIGHT_AGE_SECONDS,
+    now: float | None = None,
 ) -> list[DrainOutcome]:
     """Process every in-flight run currently persisted in *store*.
 
@@ -218,6 +307,7 @@ def drain_in_flight_runs(
     deterministic iteration order without touching the underlying KV
     contract.
     """
+    current_time = time.time() if now is None else now
     outcomes: list[DrainOutcome] = []
     for state in state_iterator(store):
         outcomes.append(
@@ -226,6 +316,9 @@ def drain_in_flight_runs(
                 retriever=retriever,
                 handlers=handlers,
                 store=store,
+                now=current_time,
+                max_attempts=max_attempts,
+                max_age_seconds=max_age_seconds,
             )
         )
     return outcomes
@@ -233,6 +326,8 @@ def drain_in_flight_runs(
 
 __all__ = [
     "ArtifactLoader",
+    "DEFAULT_MAX_IN_FLIGHT_AGE_SECONDS",
+    "DEFAULT_MAX_IN_FLIGHT_ATTEMPTS",
     "DrainOutcome",
     "FailureHandler",
     "NonTerminalHandler",

--- a/tests/test_poll_runs.py
+++ b/tests/test_poll_runs.py
@@ -33,14 +33,24 @@ class _FakeRetriever:
         return self._runs[run_id]
 
 
-def _state(run_id: str = "run-1", workflow: str = "review-pull-request") -> RunState:
-    return RunState(
+def _state(
+    run_id: str = "run-1",
+    workflow: str = "review-pull-request",
+    *,
+    attempts: int = 0,
+    dispatched_at: float | None = None,
+) -> RunState:
+    state = RunState(
         run_id=run_id,
         workflow=workflow,
         repo="acme/widgets",
         installation_id=42,
         payload_subset={"pr_number": 1},
+        attempts=attempts,
     )
+    if dispatched_at is not None:
+        state.dispatched_at = dispatched_at
+    return state
 
 
 def _seed(store: InMemoryStateStore, *states: RunState) -> None:
@@ -218,6 +228,97 @@ class DrainInFlightRunsTest(unittest.TestCase):
         self.assertEqual(outcomes[0].state, "RETRIEVE_FAILED")
         self.assertEqual(outcomes[0].error, "network down")
         # The record stays in KV so the next cron tick can retry.
+        self.assertEqual(len(store.keys(RUN_STATE_KEY_PREFIX)), 1)
+
+    def test_max_attempts_expiration_invokes_failure_handler_and_drains_record(self) -> None:
+        store = InMemoryStateStore()
+        _seed(store, _state(attempts=3))
+        retriever = _FakeRetriever({})
+
+        failures: list[dict[str, Any]] = []
+
+        def failure_handler(*, state: RunState, run: Any) -> None:
+            failures.append({"state": state, "run": run})
+
+        outcomes = drain_in_flight_runs(
+            store=store,
+            retriever=retriever,
+            handlers=_make_handlers(failure_handler=failure_handler),
+            max_attempts=3,
+            max_age_seconds=None,
+        )
+        self.assertEqual(outcomes[0].state, "EXPIRED")
+        self.assertFalse(outcomes[0].applied)
+        self.assertIn("max attempts exceeded", outcomes[0].error)
+        self.assertEqual(retriever.calls, [])
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0]["state"].run_id, "run-1")
+        self.assertEqual(failures[0]["run"].state, "EXPIRED")
+        self.assertIn("max attempts exceeded", failures[0]["run"].status_message)
+        self.assertEqual(store.keys(RUN_STATE_KEY_PREFIX), [])
+
+    def test_max_age_expiration_invokes_failure_handler_and_drains_record(self) -> None:
+        store = InMemoryStateStore()
+        _seed(store, _state(dispatched_at=100.0))
+        retriever = _FakeRetriever({})
+
+        failures: list[dict[str, Any]] = []
+
+        def failure_handler(*, state: RunState, run: Any) -> None:
+            failures.append({"state": state, "run": run})
+
+        outcomes = drain_in_flight_runs(
+            store=store,
+            retriever=retriever,
+            handlers=_make_handlers(failure_handler=failure_handler),
+            max_attempts=None,
+            max_age_seconds=50,
+            now=151.0,
+        )
+        self.assertEqual(outcomes[0].state, "EXPIRED")
+        self.assertIn("max age exceeded", outcomes[0].error)
+        self.assertEqual(retriever.calls, [])
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0]["run"].state, "EXPIRED")
+        self.assertIn("max age exceeded", failures[0]["run"].status_message)
+        self.assertEqual(store.keys(RUN_STATE_KEY_PREFIX), [])
+
+    def test_expiration_deletes_record_when_failure_handler_raises(self) -> None:
+        store = InMemoryStateStore()
+        _seed(store, _state(attempts=3))
+        retriever = _FakeRetriever({})
+
+        def failure_handler(*, state: RunState, run: Any) -> None:
+            raise RuntimeError("github down")
+
+        outcomes = drain_in_flight_runs(
+            store=store,
+            retriever=retriever,
+            handlers=_make_handlers(failure_handler=failure_handler),
+            max_attempts=3,
+            max_age_seconds=None,
+        )
+        self.assertEqual(outcomes[0].state, "EXPIRED")
+        self.assertIn("max attempts exceeded", outcomes[0].error)
+        self.assertIn("failure handler failed: github down", outcomes[0].error)
+        self.assertEqual(retriever.calls, [])
+        self.assertEqual(store.keys(RUN_STATE_KEY_PREFIX), [])
+
+    def test_expiration_limits_can_be_disabled(self) -> None:
+        store = InMemoryStateStore()
+        _seed(store, _state(attempts=999, dispatched_at=1.0))
+        retriever = _FakeRetriever({"run-1": SimpleNamespace(state="RUNNING")})
+
+        outcomes = drain_in_flight_runs(
+            store=store,
+            retriever=retriever,
+            handlers=_make_handlers(),
+            max_attempts=None,
+            max_age_seconds=None,
+            now=10_000.0,
+        )
+        self.assertEqual(outcomes[0].state, "RUNNING")
+        self.assertEqual(retriever.calls, ["run-1"])
         self.assertEqual(len(store.keys(RUN_STATE_KEY_PREFIX)), 1)
 
     def test_apply_failure_keeps_record_for_retry(self) -> None:


### PR DESCRIPTION
## Summary
- expire in-flight Oz run records when they exceed a max-attempt limit or max-age threshold
- route expired records through the workflow failure handler so progress comments are updated before KV cleanup
- add production env overrides for the expiration limits
- add poller tests for attempt expiration, age expiration, failure-handler errors, and disabled limits

## Validation
- `python3 -m unittest tests.test_poll_runs`
- `python3 -m pytest tests` — 344 passed, 1 local urllib3/LibreSSL warning
- Production deploy smoke check confirmed high-attempt stale records were pruned and remaining queue records are below the new thresholds

Refs #437

Conversation: https://staging.warp.dev/conversation/29bdb7c4-b503-41bc-8776-0872d193af48

Co-Authored-By: Oz <oz-agent@warp.dev>
