### PR TITLE
feat: enforce PR issue readiness on open and /oz-review only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,13 @@ Other labels, such as automated triage labels for area or reproducibility, are i
 
 ## When to open a spec PR
 
-Spec-only PRs (markdown-only changes) are accepted without requiring a matching `ready-to-spec` issue. Spec discussion is free-form and can start directly from a PR when that is the most useful place for the conversation.
+Spec-only PRs (markdown-only changes) are accepted when they are tied to an issue that is marked `ready-to-spec`. Spec discussion should start from an issue so maintainers can confirm the problem is ready for product and technical due diligence before a PR enters review.
 
 In practice, that means:
 
-- use the issue for product discussion first when a shared baseline is helpful
-- the `ready-to-spec` label still signals that the Warp team wants product and technical due diligence on an issue before code starts, but it does not gate opening a spec PR
-- open a PR with the product spec and tech spec whenever the spec material is ready to review
+- use the issue for product discussion first so a shared baseline is clear
+- wait until the Warp team marks the issue `ready-to-spec`
+- open a PR with the product spec and tech spec once the issue is in that state
 - use the PR as the place for product and technical discussion and iteration
 
 For larger changes, the specs live in the PR and become the home for the back-and-forth. Once they are in good shape, the Warp team can approve them and the work can move into implementation.

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -71,6 +71,17 @@ def _resolve_issue_number(payload: Mapping[str, Any]) -> int:
     raise ValueError("payload does not include an issue number")
 
 
+def _resolve_linked_issue_numbers(payload: Mapping[str, Any]) -> list[int]:
+    raw = payload.get("linked_issue_number")
+    try:
+        number = int(raw or 0)
+    except (TypeError, ValueError):
+        return []
+    if number <= 0:
+        return []
+    return [number]
+
+
 def _resolve_requester(payload: Mapping[str, Any]) -> str:
     comment = payload.get("comment")
     if isinstance(comment, dict):
@@ -184,17 +195,22 @@ class ReviewWorkflow(BaseWorkflow):
 
     def build_dispatch(self, payload: Mapping[str, Any], *, github_client: Any, workspace_path: Path | None = None) -> WorkflowDispatch | None:
         from oz.helpers import format_review_start_line  # type: ignore[import-not-found]
-        from workflows.review_pr import build_review_prompt_for_dispatch, gather_review_context  # type: ignore[import-not-found]
+        from workflows.review_pr import (  # type: ignore[import-not-found]
+            build_review_prompt_for_dispatch,
+            enforce_pr_issue_state_for_review,
+            gather_review_context,
+        )
 
         owner, repo, full_name = _resolve_owner_repo(payload)
         pr_number = _resolve_pr_number(payload)
         requester = _resolve_requester(payload)
         trigger_source = _resolve_trigger_source(payload)
         repo_handle = github_client.get_repo(full_name)
+        pr = repo_handle.get_pull(pr_number)
         if _is_explicit_review_invocation(payload):
             try:
                 invocation_count = _explicit_review_invocation_count(
-                    repo_handle.get_pull(pr_number)
+                    pr
                 )
             except Exception:
                 # Fail open: if the throttle lookup itself fails for any
@@ -216,6 +232,15 @@ class ReviewWorkflow(BaseWorkflow):
                     MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR,
                 )
                 return None
+        if not enforce_pr_issue_state_for_review(
+            repo_handle,
+            owner=owner,
+            repo=repo,
+            pr=pr,
+            requester=requester,
+            explicit_issue_numbers=_resolve_linked_issue_numbers(payload),
+        ):
+            return None
         context = gather_review_context(
             repo_handle,
             owner=owner,

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import fnmatch
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Mapping, TypedDict
@@ -8,10 +9,15 @@ from github.File import File
 from github.GithubException import GithubException
 from github.Repository import Repository
 from oz.helpers import (
+    build_comment_body,
+    comment_metadata,
+    get_field,
+    get_label_name,
     is_automation_user,
     is_spec_only_pr,
     ORG_MEMBER_ASSOCIATIONS,
     POWERED_BY_SUFFIX,
+    resolve_pr_association,
     resolve_issue_number_for_pr,
     resolve_spec_context_for_pr_via_api,
     WorkflowProgressComment,
@@ -41,6 +47,10 @@ WORKFLOW_NAME = "review-pull-request"
 logger = logging.getLogger(__name__)
 
 _REVIEW_OUTPUT_FILENAME = "review.json"
+_READY_TO_SPEC_LABEL = "ready-to-spec"
+_READY_TO_IMPLEMENT_LABEL = "ready-to-implement"
+_ENFORCEMENT_COMMENT_RUN_ID = "pr-issue-state-enforcement"
+_READY_LABELS = frozenset({_READY_TO_SPEC_LABEL, _READY_TO_IMPLEMENT_LABEL})
 
 # Allowed values for the agent-supplied ``verdict`` field on ``review.json``.
 _VERDICT_APPROVE = "APPROVE"
@@ -93,6 +103,267 @@ def _is_non_member_pr(pr: Any) -> bool:
     if not normalized:
         return False
     return normalized not in ORG_MEMBER_ASSOCIATIONS
+
+
+def _same_repo_issue_numbers_from_refs(
+    owner: str,
+    repo: str,
+    refs: list[dict[str, Any]],
+) -> list[int]:
+    normalized_owner = owner.lower()
+    normalized_repo = repo.lower()
+    numbers: list[int] = []
+    for ref in refs:
+        if str(ref.get("owner") or "").lower() != normalized_owner:
+            continue
+        if str(ref.get("repo") or "").lower() != normalized_repo:
+            continue
+        try:
+            numbers.append(int(ref["number"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+    return list(dict.fromkeys(numbers))
+
+
+def _positive_issue_numbers(values: list[int] | None) -> list[int]:
+    numbers: list[int] = []
+    for value in values or []:
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            continue
+        if number > 0:
+            numbers.append(number)
+    return list(dict.fromkeys(numbers))
+
+
+def _issue_label_names(issue: Any) -> list[str]:
+    return [
+        name
+        for name in (get_label_name(label).strip() for label in get_field(issue, "labels", []) or [])
+        if name
+    ]
+
+
+@dataclass(frozen=True)
+class IssueReadinessStatus:
+    """Structured result from checking a single issue's readiness labels."""
+
+    number: int
+    labels: list[str]
+    readiness_labels: list[str]
+    has_required_label: bool
+    is_pull_request: bool
+
+
+def _issue_readiness_status(
+    github: Repository,
+    issue_number: int,
+    *,
+    required_label: str,
+) -> IssueReadinessStatus | None:
+    try:
+        issue = github.get_issue(issue_number)
+    except Exception:
+        logger.exception(
+            "review-pr: failed to fetch associated issue #%s during issue-state enforcement",
+            issue_number,
+        )
+        return None
+    labels = _issue_label_names(issue)
+    readiness_labels = [label for label in labels if label in _READY_LABELS]
+    is_pull_request = bool(get_field(issue, "pull_request", None))
+    return IssueReadinessStatus(
+        number=issue_number,
+        labels=labels,
+        readiness_labels=readiness_labels,
+        has_required_label=required_label in labels and not is_pull_request,
+        is_pull_request=is_pull_request,
+    )
+
+
+def check_pr_issue_state_for_review(
+    github: Repository,
+    *,
+    owner: str,
+    repo: str,
+    pr: Any,
+    changed_files: list[str],
+    explicit_issue_numbers: list[int] | None = None,
+) -> dict[str, Any]:
+    """Return the deterministic issue-state gate result for a review PR."""
+    spec_only = is_spec_only_pr(changed_files)
+    required_label = _READY_TO_SPEC_LABEL if spec_only else _READY_TO_IMPLEMENT_LABEL
+    association = resolve_pr_association(github, owner, repo, pr, changed_files)
+    github_linked_issue_numbers = _same_repo_issue_numbers_from_refs(
+        owner,
+        repo,
+        association.get("github_linked_issues") or [],
+    )
+    issue_numbers = list(
+        dict.fromkeys(
+            _positive_issue_numbers(explicit_issue_numbers)
+            + github_linked_issue_numbers
+        )
+    )
+    issue_statuses = [
+        status
+        for issue_number in issue_numbers
+        if (
+            status := _issue_readiness_status(
+                github,
+                issue_number,
+                required_label=required_label,
+            )
+        )
+        is not None
+    ]
+    ready_issue_numbers = [
+        status.number
+        for status in issue_statuses
+        if status.has_required_label
+    ]
+    return {
+        "allowed": bool(ready_issue_numbers),
+        "spec_only": spec_only,
+        "required_label": required_label,
+        "association": association,
+        "issue_numbers": issue_numbers,
+        "issue_statuses": issue_statuses,
+        "ready_issue_numbers": ready_issue_numbers,
+    }
+
+
+def _format_issue_numbers(numbers: list[int]) -> str:
+    return ", ".join(f"#{number}" for number in numbers)
+
+
+def _format_issue_status(status: IssueReadinessStatus, *, required_label: str) -> str:
+    readiness_text = (
+        ", ".join(f"`{label}`" for label in status.readiness_labels)
+        if status.readiness_labels
+        else "none"
+    )
+    if status.is_pull_request:
+        state = "is a pull request, not an issue"
+    elif status.has_required_label:
+        state = f"has `{required_label}`"
+    else:
+        state = f"missing `{required_label}`"
+    return f"- #{status.number}: {state}; readiness labels present: {readiness_text}"
+
+
+def _format_pr_issue_state_failure_message(
+    check: Mapping[str, Any],
+    *,
+    requester: str,
+) -> str:
+    required_label = str(check["required_label"])
+    issue_numbers = [int(number) for number in check.get("issue_numbers") or []]
+    associated_text = _format_issue_numbers(issue_numbers) if issue_numbers else "none"
+    opening = (
+        f"This PR is not linked to an issue that is marked with `{required_label}`."
+    )
+    sections: list[str] = []
+    normalized_requester = requester.strip().removeprefix("@")
+    if normalized_requester:
+        sections.append(f"@{normalized_requester}")
+    sections.extend(
+        [
+            opening,
+            "Issue-state enforcement details:",
+            f"- Associated same-repo issues checked: {associated_text}",
+            f"- Required readiness label: `{required_label}`",
+        ]
+    )
+    statuses = check.get("issue_statuses") or []
+    if statuses:
+        sections.append("Readiness check:")
+        sections.extend(
+            _format_issue_status(status, required_label=required_label)
+            for status in statuses
+        )
+    sections.append(
+        f"To continue, link this PR to a same-repo issue such as `Closes #123` "
+        f"in the PR description, and make sure that issue has `{required_label}`."
+    )
+    return "\n\n".join(sections)
+
+
+def _upsert_pr_issue_state_enforcement_comment(
+    github: Repository,
+    *,
+    pr_number: int,
+    body: str,
+) -> None:
+    metadata = comment_metadata(
+        WORKFLOW_NAME,
+        pr_number,
+        run_id=_ENFORCEMENT_COMMENT_RUN_ID,
+    )
+    comment_body = build_comment_body(body, metadata)
+    issue = github.get_issue(pr_number)
+    for comment in issue.get_comments():
+        if metadata in str(get_field(comment, "body", "") or ""):
+            comment.edit(comment_body)
+            return
+    issue.create_comment(comment_body)
+
+
+def enforce_pr_issue_state_for_review(
+    github: Repository,
+    *,
+    owner: str,
+    repo: str,
+    pr: Any,
+    requester: str,
+    explicit_issue_numbers: list[int] | None = None,
+) -> bool:
+    """Post a REQUEST_CHANGES review and return False when review is blocked.
+
+    Enforcement is skipped for org members/collaborators — only external
+    contributors are required to link a ready issue.
+    """
+    if not _is_non_member_pr(pr):
+        return True
+    files = list(pr.get_files())
+    changed_files = [str(file.filename) for file in files]
+    check = check_pr_issue_state_for_review(
+        github,
+        owner=owner,
+        repo=repo,
+        pr=pr,
+        changed_files=changed_files,
+        explicit_issue_numbers=explicit_issue_numbers,
+    )
+    if check["allowed"]:
+        return True
+    pr_number = int(get_field(pr, "number") or 0)
+    if pr_number <= 0:
+        logger.warning(
+            "review-pr: cannot post issue-state enforcement review without a PR number"
+        )
+        return False
+    failure_body = _format_pr_issue_state_failure_message(
+        check,
+        requester=requester,
+    )
+    _upsert_pr_issue_state_enforcement_comment(
+        github,
+        pr_number=pr_number,
+        body=failure_body,
+    )
+    review_body = f"{failure_body}\n\n{POWERED_BY_SUFFIX}"
+    try:
+        pr.create_review(body=review_body, event="REQUEST_CHANGES")
+    except Exception:
+        logger.exception(
+            "review-pr: failed to post REQUEST_CHANGES enforcement review for %s/%s PR #%s",
+            owner,
+            repo,
+            pr_number,
+        )
+    return False
 
 
 def _stakeholder_logins(entries: list[dict[str, Any]]) -> set[str]:

--- a/oz/helpers.py
+++ b/oz/helpers.py
@@ -1967,9 +1967,10 @@ def resolve_issue_number_for_pr(
 
 
 def is_spec_only_pr(changed_files: list[str]) -> bool:
-    """Return True when every changed file lives under ``specs/``."""
+    """Return True when a PR contains only spec/Markdown files."""
     return bool(changed_files) and all(
-        filename.startswith("specs/") for filename in changed_files
+        filename.startswith("specs/") or filename.lower().endswith(".md")
+        for filename in changed_files
     )
 
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -168,6 +168,9 @@ class BuildReviewRequestTest(_BuilderTestBase):
         review_module.build_review_prompt_for_dispatch = MagicMock(  # type: ignore[attr-defined]
             return_value="REVIEW_PROMPT_BODY"
         )
+        review_module.enforce_pr_issue_state_for_review = MagicMock(  # type: ignore[attr-defined]
+            return_value=True
+        )
 
     def _payload(self) -> dict[str, Any]:
         return {
@@ -346,13 +349,34 @@ class BuildReviewRequestTest(_BuilderTestBase):
         review_module = sys.modules["workflows.review_pr"]
         review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
 
+    def test_skips_review_when_issue_state_enforcement_blocks(self) -> None:
+        from core.builders import build_review_request
+
+        github_client, repo, _pr = self._github_client_with_review_comments()
+        review_module = sys.modules["workflows.review_pr"]
+        review_module.enforce_pr_issue_state_for_review.return_value = False  # type: ignore[attr-defined]
+
+        request = build_review_request(
+            self._payload(),
+            github_client=github_client,
+            workspace_path=Path("/tmp/ws"),
+        )
+
+        self.assertIsNone(request)
+        repo.get_pull.assert_called_once_with(42)
+        review_module.enforce_pr_issue_state_for_review.assert_called_once()  # type: ignore[attr-defined]
+        review_module.gather_review_context.assert_not_called()  # type: ignore[attr-defined]
+        review_module.build_review_prompt_for_dispatch.assert_not_called()  # type: ignore[attr-defined]
+
     def test_fails_open_when_explicit_invocation_count_lookup_fails(self) -> None:
         from core.builders import build_review_request
 
         github_client = MagicMock()
         repo = MagicMock(name="repo")
+        pr = MagicMock(name="pr")
         github_client.get_repo.return_value = repo
-        repo.get_pull.side_effect = RuntimeError("GitHub API unavailable")
+        repo.get_pull.return_value = pr
+        pr.get_issue_comments.side_effect = RuntimeError("GitHub API unavailable")
 
         with self.assertLogs("core.workflows", level="ERROR"):
             request = build_review_request(
@@ -364,6 +388,7 @@ class BuildReviewRequestTest(_BuilderTestBase):
         self.assertIsNotNone(request)
         repo.get_pull.assert_called_once_with(42)
         review_module = sys.modules["workflows.review_pr"]
+        review_module.enforce_pr_issue_state_for_review.assert_called_once()  # type: ignore[attr-defined]
         review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
 
 

--- a/tests/test_pr_issue_state_enforcement.py
+++ b/tests/test_pr_issue_state_enforcement.py
@@ -1,0 +1,259 @@
+"""Tests for deterministic PR issue-state enforcement."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from . import conftest  # noqa: F401
+
+from workflows.review_pr import (  # type: ignore[import-not-found]
+    check_pr_issue_state_for_review,
+    enforce_pr_issue_state_for_review,
+)
+
+
+def _file(path: str) -> SimpleNamespace:
+    return SimpleNamespace(filename=path)
+
+
+def _issue(*labels: str, pull_request: object | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        labels=[SimpleNamespace(name=label) for label in labels],
+        pull_request=pull_request,
+    )
+
+
+class _Comment:
+    def __init__(self, body: str = "") -> None:
+        self.body = body
+
+    def edit(self, body: str) -> None:
+        self.body = body
+
+
+class _IssueWithComments:
+    def __init__(self) -> None:
+        self.comments: list[_Comment] = []
+
+    def get_comments(self) -> list[_Comment]:
+        return self.comments
+
+    def create_comment(self, body: str) -> _Comment:
+        comment = _Comment(body)
+        self.comments.append(comment)
+        return comment
+
+
+class _Repo:
+    requester = None
+
+    def __init__(self, issues: dict[int, object]) -> None:
+        self.issues = issues
+
+    def get_issue(self, number: int) -> object:
+        return self.issues[number]
+
+
+class CheckPrIssueStateForReviewTest(unittest.TestCase):
+    def _check(
+        self,
+        *,
+        changed_files: list[str],
+        issue_numbers: list[int],
+        labels_by_issue: dict[int, list[str]],
+        github_linked_issue_numbers: list[int] | None = None,
+        explicit_issue_numbers: list[int] | None = None,
+    ) -> dict:
+        repo = _Repo(
+            {
+                number: _issue(*labels)
+                for number, labels in labels_by_issue.items()
+            }
+        )
+        association = {
+            "same_repo_issue_numbers": issue_numbers,
+            "github_linked_issues": [
+                {
+                    "owner": "acme",
+                    "repo": "widgets",
+                    "number": number,
+                    "source": "closingIssuesReferences",
+                }
+                for number in (github_linked_issue_numbers or [])
+            ],
+            "deterministic_issue_numbers": [],
+            "primary_issue_number": issue_numbers[0] if len(issue_numbers) == 1 else None,
+            "ambiguous": len(issue_numbers) > 1,
+        }
+        with patch("workflows.review_pr.resolve_pr_association", return_value=association):
+            return check_pr_issue_state_for_review(
+                repo,  # type: ignore[arg-type]
+                owner="acme",
+                repo="widgets",
+                pr=SimpleNamespace(number=1, body=""),
+                changed_files=changed_files,
+                explicit_issue_numbers=explicit_issue_numbers,
+            )
+
+    def test_spec_markdown_pr_requires_ready_to_spec(self) -> None:
+        check = self._check(
+            changed_files=["specs/GH10/product.md"],
+            issue_numbers=[10],
+            labels_by_issue={10: ["ready-to-spec"]},
+            github_linked_issue_numbers=[10],
+        )
+
+        self.assertTrue(check["allowed"])
+        self.assertTrue(check["spec_only"])
+        self.assertEqual(check["required_label"], "ready-to-spec")
+        self.assertEqual(check["ready_issue_numbers"], [10])
+
+    def test_code_pr_requires_ready_to_implement(self) -> None:
+        check = self._check(
+            changed_files=["core/routing.py"],
+            issue_numbers=[11],
+            labels_by_issue={11: ["ready-to-implement"]},
+            github_linked_issue_numbers=[11],
+        )
+
+        self.assertTrue(check["allowed"])
+        self.assertFalse(check["spec_only"])
+        self.assertEqual(check["required_label"], "ready-to-implement")
+
+    def test_no_linked_issue_fails(self) -> None:
+        check = self._check(
+            changed_files=["core/routing.py"],
+            issue_numbers=[],
+            labels_by_issue={},
+        )
+
+        self.assertFalse(check["allowed"])
+        self.assertEqual(check["issue_numbers"], [])
+
+    def test_wrong_label_fails_with_issue_status(self) -> None:
+        check = self._check(
+            changed_files=["core/routing.py"],
+            issue_numbers=[12],
+            labels_by_issue={12: ["ready-to-spec"]},
+            github_linked_issue_numbers=[12],
+        )
+
+        self.assertFalse(check["allowed"])
+        self.assertEqual(check["issue_statuses"][0].readiness_labels, ["ready-to-spec"])
+
+    def test_multiple_issues_pass_when_any_issue_is_ready(self) -> None:
+        check = self._check(
+            changed_files=["core/routing.py"],
+            issue_numbers=[13, 14],
+            labels_by_issue={
+                13: ["triaged"],
+                14: ["ready-to-implement"],
+            },
+            github_linked_issue_numbers=[13, 14],
+        )
+
+        self.assertTrue(check["allowed"])
+        self.assertEqual(check["ready_issue_numbers"], [14])
+
+    def test_github_linked_issue_passes(self) -> None:
+        check = self._check(
+            changed_files=["core/routing.py"],
+            issue_numbers=[15],
+            labels_by_issue={15: ["ready-to-implement"]},
+            github_linked_issue_numbers=[15],
+        )
+
+        self.assertTrue(check["allowed"])
+        self.assertEqual(check["issue_numbers"], [15])
+
+    def test_explicit_payload_issue_passes_without_pr_body_reference(self) -> None:
+        check = self._check(
+            changed_files=["core/routing.py"],
+            issue_numbers=[16],
+            labels_by_issue={16: ["ready-to-implement"]},
+            explicit_issue_numbers=[16],
+        )
+
+        self.assertTrue(check["allowed"])
+        self.assertEqual(check["issue_numbers"], [16])
+
+    def test_deterministic_only_issue_does_not_satisfy_linked_issue_gate(self) -> None:
+        check = self._check(
+            changed_files=["core/routing.py"],
+            issue_numbers=[17],
+            labels_by_issue={17: ["ready-to-implement"]},
+        )
+
+        self.assertFalse(check["allowed"])
+        self.assertEqual(check["issue_numbers"], [])
+
+
+class EnforcePrIssueStateForReviewTest(unittest.TestCase):
+    def test_blocked_pr_posts_actionable_comment_and_changes_requested_review(self) -> None:
+        pr_issue = _IssueWithComments()
+        repo = _Repo({7: pr_issue})
+        reviews_created: list[dict] = []
+
+        def _create_review(body: str, event: str) -> None:
+            reviews_created.append({"body": body, "event": event})
+
+        pr = SimpleNamespace(
+            number=7,
+            body="",
+            user=SimpleNamespace(login="external-user", type="User"),
+            author_association="NONE",
+            get_files=lambda: [_file("core/routing.py")],
+            create_review=_create_review,
+        )
+
+        allowed = enforce_pr_issue_state_for_review(
+            repo,  # type: ignore[arg-type]
+            owner="acme",
+            repo="widgets",
+            pr=pr,
+            requester="alice",
+        )
+
+        self.assertFalse(allowed)
+        self.assertEqual(len(pr_issue.comments), 1)
+        body = pr_issue.comments[0].body
+        self.assertIn("@alice", body)
+        self.assertIn("This PR is not linked to an issue that is marked with `ready-to-implement`", body)
+        self.assertIn("Required readiness label: `ready-to-implement`", body)
+        self.assertIn("Closes #123", body)
+        self.assertNotIn("PR description issue reference", body)
+        # Verify REQUEST_CHANGES review was posted
+        self.assertEqual(len(reviews_created), 1)
+        self.assertEqual(reviews_created[0]["event"], "REQUEST_CHANGES")
+        self.assertIn("not linked to an issue", reviews_created[0]["body"])
+
+
+    def test_org_member_pr_skips_enforcement(self) -> None:
+        pr_issue = _IssueWithComments()
+        repo = _Repo({8: pr_issue})
+
+        pr = SimpleNamespace(
+            number=8,
+            body="",
+            user=SimpleNamespace(login="org-member", type="User"),
+            author_association="MEMBER",
+            get_files=lambda: [_file("core/routing.py")],
+            create_review=lambda body, event: None,
+        )
+
+        allowed = enforce_pr_issue_state_for_review(
+            repo,  # type: ignore[arg-type]
+            owner="acme",
+            repo="widgets",
+            pr=pr,
+            requester="org-member",
+        )
+
+        self.assertTrue(allowed)
+        self.assertEqual(len(pr_issue.comments), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Enforce PR issue readiness before review dispatch, but only when the review workflow is actually triggered — not on every push.

**Key changes:**
- Added `enforce_pr_issue_state_for_review` to the review workflow's `build_dispatch` method, which blocks review for non-member PRs that lack a linked issue with the appropriate readiness label
- Spec-only (markdown) PRs require a same-repo `ready-to-spec` issue
- Code PRs require a same-repo `ready-to-implement` issue
- Org members/collaborators bypass enforcement entirely
- When enforcement blocks, an actionable comment and `REQUEST_CHANGES` review are posted

**What this changes vs #441:**
PR #441 added `synchronize` and `edited` to the routing, which caused enforcement to run on every commit push. This PR keeps the existing routing unchanged — enforcement only fires when the review workflow is already triggered:
- PR `opened` / `reopened` / `ready_for_review`
- `/oz-review` comment (explicit review request)
- `review_requested` from `oz-agent`
- `oz-review` label applied

**Other changes:**
- Updated `is_spec_only_pr` to include `.md` files outside `specs/`
- Updated `CONTRIBUTING.md` to document the readiness requirement for spec PRs

## Validation

- `python -m pytest tests` — 366 passed, 56 subtests passed

---

_Conversation: https://staging.warp.dev/conversation/6f8e4189-9960-45e1-be9b-3c53a77c7b8f_
_Run: https://oz.staging.warp.dev/runs/019e042d-c48b-7bb8-9017-af088e091e6f_
_This PR was generated with [Oz](https://warp.dev/oz)._
