### PR TITLE
feat: skip triage for issues filed with auto-implement label

### DIFF
--- a/core/routing.py
+++ b/core/routing.py
@@ -44,6 +44,17 @@ Webhook coverage today:
   - ``opened`` routes to ``triage-new-issues`` regardless of the
     issue's existing labels (``ready-to-spec`` /
     ``ready-to-implement`` issues still get a triage pass).
+    The one exception is the ``auto-implement`` label: when an
+    issue is filed with it pre-applied, routing skips triage and
+    goes straight to ``create-implementation-from-issue``. Only
+    repository collaborators (or trusted bot identities they
+    grant label permissions to) can apply labels, so the label
+    is trusted as an authoritative skip-triage signal — and is
+    honored even when the issue author itself is an automation
+    user (e.g. a verified social-media intake bot filing on
+    behalf of a real user). Adding ``auto-implement`` to an
+    existing issue after the fact is intentionally a no-op:
+    only ``issues.opened`` honors the label.
   - ``assigned`` routes to ``create-spec-from-issue`` or
     ``create-implementation-from-issue`` when the assignee being
     added is ``oz-agent`` and the issue carries the matching
@@ -93,6 +104,7 @@ TRIAGED_LABEL = "triaged"
 NEEDS_INFO_LABEL = "needs-info"
 READY_TO_SPEC_LABEL = "ready-to-spec"
 READY_TO_IMPLEMENT_LABEL = "ready-to-implement"
+AUTO_IMPLEMENT_LABEL = "auto-implement"
 
 OZ_AGENT_MENTION = "@oz-agent"
 OZ_REVIEW_COMMAND = "/oz-review"
@@ -287,6 +299,19 @@ def _route_issues(payload: dict[str, Any]) -> RouteDecision:
             None, f"issues.{action} delivered for a pull request"
         )
     if action == "opened":
+        labels = _label_names(issue.get("labels"))
+        if AUTO_IMPLEMENT_LABEL in labels:
+            # Trust-safe: GitHub restricts label application to
+            # collaborators (or bot identities granted that
+            # permission), so an ``auto-implement`` label present
+            # at issue-open time is an authoritative skip-triage
+            # signal. Honor it even when the issue author itself
+            # is an automation user (e.g. a verified social-media
+            # intake bot filing on behalf of a real user).
+            return RouteDecision(
+                WORKFLOW_CREATE_IMPLEMENTATION_FROM_ISSUE,
+                "issues.opened with auto-implement label skips triage",
+            )
         if _is_bot(issue.get("user")):
             return RouteDecision(None, "issue authored by automation user")
         return RouteDecision(
@@ -465,6 +490,7 @@ def route_event(event: str, payload: dict[str, Any]) -> RouteDecision:
 
 
 __all__ = [
+    "AUTO_IMPLEMENT_LABEL",
     "NEEDS_INFO_LABEL",
     "OZ_AGENT_LOGIN",
     "OZ_AGENT_MENTION",

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -92,6 +92,60 @@ class IssuesEventTest(unittest.TestCase):
         )
         self.assertIsNone(decision.workflow)
 
+    def test_issues_opened_with_auto_implement_label_skips_triage(self) -> None:
+        # The auto-implement label is a trusted skip-triage signal:
+        # only repository collaborators can apply labels, so the bot
+        # dispatches the implementation workflow directly when an
+        # issue is filed with the label pre-applied.
+        decision = route_event(
+            "issues",
+            {
+                "action": "opened",
+                "issue": _issue(labels=["auto-implement"]),
+            },
+        )
+        self.assertEqual(
+            decision.workflow, WORKFLOW_CREATE_IMPLEMENTATION_FROM_ISSUE
+        )
+
+    def test_issues_opened_with_auto_implement_label_routes_even_for_bot_author(
+        self,
+    ) -> None:
+        # Trusted intake bots (e.g. a social-media bot filing on
+        # behalf of a real user) may author issues with the
+        # auto-implement label pre-applied. The label is the
+        # trust signal — the author being a bot does not block
+        # dispatch when the label is present.
+        decision = route_event(
+            "issues",
+            {
+                "action": "opened",
+                "issue": _issue(
+                    labels=["auto-implement"],
+                    user={"login": "warp-intake[bot]", "type": "Bot"},
+                ),
+            },
+        )
+        self.assertEqual(
+            decision.workflow, WORKFLOW_CREATE_IMPLEMENTATION_FROM_ISSUE
+        )
+
+    def test_auto_implement_label_added_post_open_is_dropped(self) -> None:
+        # Adding ``auto-implement`` to an existing issue after the
+        # fact is intentionally a no-op — only ``issues.opened``
+        # honors the label. The labeled-branch unhandled-label
+        # drop catches this since auto-implement is not in the
+        # recognized lifecycle-label set.
+        decision = route_event(
+            "issues",
+            {
+                "action": "labeled",
+                "label": {"name": "auto-implement"},
+                "issue": _issue(labels=["auto-implement"]),
+            },
+        )
+        self.assertIsNone(decision.workflow)
+
     def test_oz_agent_assigned_to_ready_to_implement_routes_to_create_implementation(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- Add `auto-implement` label that routes `issues.opened` straight to `create-implementation-from-issue`, skipping triage entirely. The existing implementation workflow already opens a draft PR, auto-assigns `oz-agent`, posts a progress comment, and surfaces the session link via the cron poller — so no workflow changes are needed.
- Honor the label even when the issue author is a bot, so trusted intake pipelines (e.g. a verified social-media bot filing on behalf of a real user) can dispatch implementation in one step. Trust boundary is GitHub's label-write permission, which is already restricted to repository collaborators.
- Label is `issues.opened`-only. Adding `auto-implement` to an existing issue after the fact falls into the labeled-branch unhandled-label drop and is a no-op.

## Test plan
- [x] `python -m unittest tests.test_routing` — all 65 tests pass, including 3 new ones:
  - `test_issues_opened_with_auto_implement_label_skips_triage`
  - `test_issues_opened_with_auto_implement_label_routes_even_for_bot_author`
  - `test_auto_implement_label_added_post_open_is_dropped`
- [ ] Operator: create the `auto-implement` GitHub label in any repo that wants the behavior (the bot does not manage labels).
- [ ] End-to-end smoke on a dev installation:
  - File an issue with `auto-implement` pre-applied → confirm `RouteDecision.workflow == "create-implementation-from-issue"` in webhook logs and no triage comment is posted.
  - Confirm a draft PR is opened against the default branch and the progress comment is updated with the PR link when the agent finishes.
  - File an issue via a bot identity with the label → confirm dispatch still fires (bot-author drop is bypassed when label is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)