### PR TITLE
change oz review limit to 5 and refresh automatically after 24hr

### DIFF
--- a/core/routing.py
+++ b/core/routing.py
@@ -103,11 +103,10 @@ AUTO_IMPLEMENT_LABEL = "auto-implement"
 OZ_AGENT_MENTION = "@oz-agent"
 OZ_REVIEW_COMMAND = "/oz-review"
 OZ_VERIFY_COMMAND = "/oz-verify"
-MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR = 3
 OZ_REVIEW_COMMAND_PATTERN = re.compile(
     r"(?:^|\s)(?:/oz-review|@oz-agent\s+/review)(?![-\w])", re.IGNORECASE
 )
-
+MAX_DAILY_REVIEW_INVOCATIONS = 5
 
 def has_oz_review_command(body: str) -> bool:
     """Return whether *body* carries an explicit Oz review invocation."""
@@ -481,6 +480,7 @@ def route_event(event: str, payload: dict[str, Any]) -> RouteDecision:
 
 __all__ = [
     "AUTO_IMPLEMENT_LABEL",
+    "MAX_DAILY_REVIEW_INVOCATIONS",
     "NEEDS_INFO_LABEL",
     "OZ_AGENT_LOGIN",
     "OZ_AGENT_MENTION",
@@ -488,7 +488,6 @@ __all__ = [
     "OZ_REVIEW_COMMAND_PATTERN",
     "OZ_VERIFY_COMMAND",
     "OZ_REVIEW_LABEL",
-    "MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR",
     "PLAN_APPROVED_LABEL",
     "READY_TO_IMPLEMENT_LABEL",
     "READY_TO_SPEC_LABEL",

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -156,25 +156,44 @@ def _is_automation_user(user: Any) -> bool:
     return bool(login) and login.endswith("[bot]")
 
 
+# run_id written into enforcement comments by review_pr._ENFORCEMENT_COMMENT_RUN_ID.
+# Must stay in sync with that constant.
+_REVIEW_ENFORCEMENT_RUN_ID = "pr-issue-state-enforcement"
+
+
 def _explicit_review_invocations_in_window(
     pr: Any,
 ) -> tuple[int, datetime | None]:
-    """Count non-bot /oz-review invocations within the rolling 24-hour window.
+    """Count Oz review progress comments on *pr* within the rolling 24-hour window.
+
+    Each dispatched /oz-review run produces one bot-authored issue comment
+    carrying the ``review-pull-request`` workflow metadata. Progress comments
+    are the unit of counting; enforcement-only comments (identified by the
+    ``pr-issue-state-enforcement`` run_id) are excluded because no review run
+    was dispatched for them.
 
     Returns ``(count, oldest)`` where *oldest* is the ``created_at`` of the
-    earliest in-window invocation, used to compute the retry message. Comments
-    without a ``created_at`` are counted conservatively but do not contribute
-    to *oldest*, so the retry duration may be omitted when timestamps are
-    unavailable.
+    earliest in-window progress comment, used to compute the retry message.
+    The current invocation has not yet been dispatched, so *count* reflects
+    only prior completed runs. Callers must therefore use ``>= MAX`` to block
+    and ``== MAX - 1`` to emit the advisory.
+
+    Comments without a ``created_at`` are counted conservatively but do not
+    contribute to *oldest*, so the retry duration may be omitted when
+    timestamps are unavailable.
     """
     window_start = datetime.now(timezone.utc) - timedelta(hours=24)
+    review_workflow_marker = f'"workflow":"{WORKFLOW_REVIEW_PR}"'
+    enforcement_marker = f'"run_id":"{_REVIEW_ENFORCEMENT_RUN_ID}"'
     count = 0
     oldest: datetime | None = None
-    for comment in list(pr.get_issue_comments()) + list(pr.get_review_comments()):
-        body = str(_get_field(comment, "body", "") or "")
-        if not has_oz_review_command(body):
+    for comment in list(pr.get_issue_comments()):
+        if not _is_automation_user(_get_field(comment, "user")):
             continue
-        if _is_automation_user(_get_field(comment, "user")):
+        body = str(_get_field(comment, "body", "") or "")
+        if review_workflow_marker not in body:
+            continue
+        if enforcement_marker in body:
             continue
         created_at = _get_field(comment, "created_at")
         if created_at is None:
@@ -264,9 +283,9 @@ class ReviewWorkflow(BaseWorkflow):
                 if oldest_invocation is not None
                 else ""
             )
-            if invocation_count > MAX_DAILY_REVIEW_INVOCATIONS:
+            if invocation_count >= MAX_DAILY_REVIEW_INVOCATIONS:
                 logger.info(
-                    "Skipping /oz-review for %s PR #%s: %s invocations in window exceeds daily limit %s",
+                    "Skipping /oz-review for %s PR #%s: %s prior runs in window meets/exceeds daily limit %s",
                     full_name,
                     pr_number,
                     invocation_count,
@@ -284,7 +303,7 @@ class ReviewWorkflow(BaseWorkflow):
                         pr_number,
                     )
                 return None
-            if invocation_count == MAX_DAILY_REVIEW_INVOCATIONS:
+            if invocation_count == MAX_DAILY_REVIEW_INVOCATIONS - 1:
                 try:
                     repo_handle.get_issue(pr_number).create_comment(
                         f"This is your last `/oz-review` for the current 24-hour window.{retry_suffix}"

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -11,6 +11,8 @@ from oz.agent_workflow import (
     make_run_adapter,
 )
 
+from oz.helpers import ENFORCEMENT_COMMENT_RUN_ID
+
 from core.routing import (
     MAX_DAILY_REVIEW_INVOCATIONS,
     WORKFLOW_CREATE_IMPLEMENTATION_FROM_ISSUE,
@@ -156,11 +158,6 @@ def _is_automation_user(user: Any) -> bool:
     return bool(login) and login.endswith("[bot]")
 
 
-# run_id written into enforcement comments by review_pr._ENFORCEMENT_COMMENT_RUN_ID.
-# Must stay in sync with that constant.
-_REVIEW_ENFORCEMENT_RUN_ID = "pr-issue-state-enforcement"
-
-
 def _explicit_review_invocations_in_window(
     pr: Any,
 ) -> tuple[int, datetime | None]:
@@ -184,7 +181,7 @@ def _explicit_review_invocations_in_window(
     """
     window_start = datetime.now(timezone.utc) - timedelta(hours=24)
     review_workflow_marker = f'"workflow":"{WORKFLOW_REVIEW_PR}"'
-    enforcement_marker = f'"run_id":"{_REVIEW_ENFORCEMENT_RUN_ID}"'
+    enforcement_marker = f'"run_id":"{ENFORCEMENT_COMMENT_RUN_ID}"'
     count = 0
     oldest: datetime | None = None
     for comment in list(pr.get_issue_comments()):

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -11,7 +12,7 @@ from oz.agent_workflow import (
 )
 
 from core.routing import (
-    MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR,
+    MAX_DAILY_REVIEW_INVOCATIONS,
     WORKFLOW_CREATE_IMPLEMENTATION_FROM_ISSUE,
     WORKFLOW_CREATE_SPEC_FROM_ISSUE,
     WORKFLOW_PLAN_APPROVED,
@@ -155,17 +156,53 @@ def _is_automation_user(user: Any) -> bool:
     return bool(login) and login.endswith("[bot]")
 
 
-def _explicit_review_invocation_count(pr: Any) -> int:
-    """Count non-bot explicit review invocations already persisted on *pr*."""
+def _explicit_review_invocations_in_window(
+    pr: Any,
+) -> tuple[int, datetime | None]:
+    """Count non-bot /oz-review invocations within the rolling 24-hour window.
+
+    Returns ``(count, oldest)`` where *oldest* is the ``created_at`` of the
+    earliest in-window invocation, used to compute the retry message. Comments
+    without a ``created_at`` are counted conservatively but do not contribute
+    to *oldest*, so the retry duration may be omitted when timestamps are
+    unavailable.
+    """
+    window_start = datetime.now(timezone.utc) - timedelta(hours=24)
     count = 0
+    oldest: datetime | None = None
     for comment in list(pr.get_issue_comments()) + list(pr.get_review_comments()):
         body = str(_get_field(comment, "body", "") or "")
         if not has_oz_review_command(body):
             continue
         if _is_automation_user(_get_field(comment, "user")):
             continue
-        count += 1
-    return count
+        created_at = _get_field(comment, "created_at")
+        if created_at is None:
+            # No timestamp: count conservatively without updating oldest.
+            count += 1
+            continue
+        # Normalise to UTC-aware for comparison.
+        if getattr(created_at, "tzinfo", None) is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        if created_at >= window_start:
+            count += 1
+            if oldest is None or created_at < oldest:
+                oldest = created_at
+    return count, oldest
+
+
+def _format_retry_duration(oldest_invocation: datetime) -> str:
+    """Return a human-readable duration until the oldest invocation ages out."""
+    reset_at = oldest_invocation + timedelta(hours=24)
+    remaining = reset_at - datetime.now(timezone.utc)
+    total_seconds = max(0, int(remaining.total_seconds()))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes = remainder // 60
+    if hours > 0:
+        return f"~{hours}h {minutes}m"
+    if minutes > 0:
+        return f"~{minutes}m"
+    return "shortly"
 
 
 def _is_explicit_review_invocation(payload: Mapping[str, Any]) -> bool:
@@ -209,9 +246,7 @@ class ReviewWorkflow(BaseWorkflow):
         pr = repo_handle.get_pull(pr_number)
         if _is_explicit_review_invocation(payload):
             try:
-                invocation_count = _explicit_review_invocation_count(
-                    pr
-                )
+                invocation_count, oldest_invocation = _explicit_review_invocations_in_window(pr)
             except Exception:
                 # Fail open: if the throttle lookup itself fails for any
                 # reason (transient API error, permissions issue, etc.) we
@@ -223,15 +258,43 @@ class ReviewWorkflow(BaseWorkflow):
                     pr_number,
                 )
                 invocation_count = 0
-            if invocation_count > MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR:
+                oldest_invocation = None
+            retry_suffix = (
+                f" Your next slot opens in {_format_retry_duration(oldest_invocation)}."
+                if oldest_invocation is not None
+                else ""
+            )
+            if invocation_count > MAX_DAILY_REVIEW_INVOCATIONS:
                 logger.info(
-                    "Skipping /oz-review for %s PR #%s: invocation count %s exceeds limit %s",
+                    "Skipping /oz-review for %s PR #%s: %s invocations in window exceeds daily limit %s",
                     full_name,
                     pr_number,
                     invocation_count,
-                    MAX_EXPLICIT_REVIEW_INVOCATIONS_PER_PR,
+                    MAX_DAILY_REVIEW_INVOCATIONS,
                 )
+                try:
+                    repo_handle.get_issue(pr_number).create_comment(
+                        f"You've used all {MAX_DAILY_REVIEW_INVOCATIONS} `/oz-review` slots "
+                        f"for the current 24-hour window.{retry_suffix}"
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to post review-limit comment for %s PR #%s",
+                        full_name,
+                        pr_number,
+                    )
                 return None
+            if invocation_count == MAX_DAILY_REVIEW_INVOCATIONS:
+                try:
+                    repo_handle.get_issue(pr_number).create_comment(
+                        f"This is your last `/oz-review` for the current 24-hour window.{retry_suffix}"
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to post review advisory comment for %s PR #%s",
+                        full_name,
+                        pr_number,
+                    )
         if not enforce_pr_issue_state_for_review(
             repo_handle,
             owner=owner,

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -11,6 +11,7 @@ from github.Repository import Repository
 from oz.helpers import (
     build_comment_body,
     comment_metadata,
+    ENFORCEMENT_COMMENT_RUN_ID,
     get_field,
     get_label_name,
     is_automation_user,
@@ -49,7 +50,6 @@ logger = logging.getLogger(__name__)
 _REVIEW_OUTPUT_FILENAME = "review.json"
 _READY_TO_SPEC_LABEL = "ready-to-spec"
 _READY_TO_IMPLEMENT_LABEL = "ready-to-implement"
-_ENFORCEMENT_COMMENT_RUN_ID = "pr-issue-state-enforcement"
 _READY_LABELS = frozenset({_READY_TO_SPEC_LABEL, _READY_TO_IMPLEMENT_LABEL})
 
 # Allowed values for the agent-supplied ``verdict`` field on ``review.json``.
@@ -287,7 +287,7 @@ def _upsert_pr_issue_state_enforcement_comment(
     metadata = comment_metadata(
         WORKFLOW_NAME,
         pr_number,
-        run_id=_ENFORCEMENT_COMMENT_RUN_ID,
+        run_id=ENFORCEMENT_COMMENT_RUN_ID,
     )
     comment_body = build_comment_body(body, metadata)
     issue = github.get_issue(pr_number)

--- a/oz/helpers.py
+++ b/oz/helpers.py
@@ -33,6 +33,9 @@ def _github_actions_error(message: str) -> None:
 # Author associations treated as trusted without org-membership probing.
 ORG_MEMBER_ASSOCIATIONS: set[str] = {"COLLABORATOR", "MEMBER", "OWNER"}
 
+ENFORCEMENT_COMMENT_RUN_ID = "pr-issue-state-enforcement"
+
+
 _CLOSING_ISSUES_QUERY = (
     "query($owner: String!, $name: String!, $number: Int!, $after: String) {"
     " repository(owner: $owner, name: $name) {"

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -203,10 +204,12 @@ class BuildReviewRequestTest(_BuilderTestBase):
         *,
         login: str = "alice",
         user_type: str = "User",
+        created_at: datetime | None = None,
     ) -> SimpleNamespace:
         return SimpleNamespace(
             body=body,
             user=SimpleNamespace(login=login, type=user_type),
+            created_at=created_at if created_at is not None else datetime.now(timezone.utc),
         )
 
     def _github_client_with_review_comments(
@@ -262,7 +265,7 @@ class BuildReviewRequestTest(_BuilderTestBase):
                 workspace_path=Path("/tmp/ws"),
             )
 
-    def test_allows_third_explicit_review_invocation(self) -> None:
+    def test_allows_fifth_explicit_review_invocation_and_posts_advisory(self) -> None:
         from core.builders import build_review_request
 
         github_client, repo, pr = self._github_client_with_review_comments(
@@ -270,6 +273,8 @@ class BuildReviewRequestTest(_BuilderTestBase):
                 self._review_comment("/oz-review"),
                 self._review_comment("please @oz-agent /review"),
                 self._review_comment("/oz-review again"),
+                self._review_comment("/oz-review once more"),
+                self._review_comment("/oz-review fifth"),
             ],
         )
 
@@ -285,6 +290,11 @@ class BuildReviewRequestTest(_BuilderTestBase):
         pr.get_review_comments.assert_called_once_with()
         review_module = sys.modules["workflows.review_pr"]
         review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
+        # Advisory comment must be posted when the daily limit is reached.
+        repo.get_issue.assert_called_with(42)
+        advisory_body: str = repo.get_issue.return_value.create_comment.call_args[0][0]
+        self.assertIn("last `/oz-review`", advisory_body)
+        self.assertIn("24-hour window", advisory_body)
 
     def test_skips_review_when_issue_state_enforcement_blocks(self) -> None:
         from core.builders import build_review_request
@@ -305,7 +315,7 @@ class BuildReviewRequestTest(_BuilderTestBase):
         review_module.gather_review_context.assert_not_called()  # type: ignore[attr-defined]
         review_module.build_review_prompt_for_dispatch.assert_not_called()  # type: ignore[attr-defined]
 
-    def test_skips_fourth_explicit_review_invocation(self) -> None:
+    def test_skips_sixth_explicit_review_invocation_and_posts_blocked_message(self) -> None:
         from core.builders import build_review_request
 
         github_client, repo, pr = self._github_client_with_review_comments(
@@ -313,8 +323,10 @@ class BuildReviewRequestTest(_BuilderTestBase):
                 self._review_comment("/oz-review"),
                 self._review_comment("/oz-review again"),
                 self._review_comment("please @oz-agent /review"),
+                self._review_comment("/oz-review once more"),
+                self._review_comment("/oz-review fifth"),
             ],
-            review_comments=[self._review_comment("/oz-review inline")],
+            review_comments=[self._review_comment("/oz-review sixth")],
         )
 
         request = build_review_request(
@@ -331,6 +343,11 @@ class BuildReviewRequestTest(_BuilderTestBase):
         review_module.gather_review_context.assert_not_called()  # type: ignore[attr-defined]
         review_module.build_review_prompt_for_dispatch.assert_not_called()  # type: ignore[attr-defined]
         self.assertEqual(len(self.progress_instances), 0)
+        # Blocked comment must be posted when the limit is exceeded.
+        repo.get_issue.assert_called_with(42)
+        blocked_body: str = repo.get_issue.return_value.create_comment.call_args[0][0]
+        self.assertIn("all 5 `/oz-review` slots", blocked_body)
+        self.assertIn("24-hour window", blocked_body)
 
     def test_ignores_bot_comments_when_counting_explicit_invocations(self) -> None:
         from core.builders import build_review_request
@@ -365,6 +382,38 @@ class BuildReviewRequestTest(_BuilderTestBase):
         repo.get_pull.assert_called_once_with(42)
         pr.get_issue_comments.assert_called_once_with()
         pr.get_review_comments.assert_called_once_with()
+        review_module = sys.modules["workflows.review_pr"]
+        review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
+
+    def test_does_not_count_out_of_window_comments(self) -> None:
+        from core.builders import build_review_request
+
+        old_time = datetime.now(timezone.utc) - timedelta(hours=25)
+        github_client, repo, pr = self._github_client_with_review_comments(
+            issue_comments=[
+                # These two are outside the 24-hour window and must not count.
+                self._review_comment("/oz-review", created_at=old_time),
+                self._review_comment("/oz-review old", created_at=old_time),
+                # These five are inside the window → hits the limit (advisory).
+                self._review_comment("/oz-review"),
+                self._review_comment("/oz-review"),
+                self._review_comment("/oz-review"),
+                self._review_comment("/oz-review"),
+                self._review_comment("/oz-review"),
+            ],
+        )
+
+        request = build_review_request(
+            self._explicit_review_payload(),
+            github_client=github_client,
+            workspace_path=Path("/tmp/ws"),
+        )
+
+        # Out-of-window comments are excluded, so only 5 in-window → advisory
+        # is posted but the review still proceeds.
+        self.assertIsNotNone(request)
+        advisory_body: str = repo.get_issue.return_value.create_comment.call_args[0][0]
+        self.assertIn("last `/oz-review`", advisory_body)
         review_module = sys.modules["workflows.review_pr"]
         review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -212,6 +212,22 @@ class BuildReviewRequestTest(_BuilderTestBase):
             created_at=created_at if created_at is not None else datetime.now(timezone.utc),
         )
 
+    def _bot_progress_comment(
+        self,
+        *,
+        run_id: str = "test-run-uuid",
+        created_at: datetime | None = None,
+    ) -> SimpleNamespace:
+        """Simulate a bot-authored review progress comment."""
+        return SimpleNamespace(
+            body=(
+                f'<!-- oz-agent-metadata: {{"type":"issue-status","workflow":"review-pull-request"'
+                f',"issue":42,"run_id":"{run_id}"}} -->'
+            ),
+            user=SimpleNamespace(login="oz-for-oss[bot]", type="Bot"),
+            created_at=created_at if created_at is not None else datetime.now(timezone.utc),
+        )
+
     def _github_client_with_review_comments(
         self,
         *,
@@ -268,13 +284,13 @@ class BuildReviewRequestTest(_BuilderTestBase):
     def test_allows_fifth_explicit_review_invocation_and_posts_advisory(self) -> None:
         from core.builders import build_review_request
 
+        # 4 prior completed reviews → this is the 5th (last) slot.
         github_client, repo, pr = self._github_client_with_review_comments(
             issue_comments=[
-                self._review_comment("/oz-review"),
-                self._review_comment("please @oz-agent /review"),
-                self._review_comment("/oz-review again"),
-                self._review_comment("/oz-review once more"),
-                self._review_comment("/oz-review fifth"),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
             ],
         )
 
@@ -287,7 +303,7 @@ class BuildReviewRequestTest(_BuilderTestBase):
         self.assertIsNotNone(request)
         repo.get_pull.assert_called_once_with(42)
         pr.get_issue_comments.assert_called_once_with()
-        pr.get_review_comments.assert_called_once_with()
+        pr.get_review_comments.assert_not_called()
         review_module = sys.modules["workflows.review_pr"]
         review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
         # Advisory comment must be posted when the daily limit is reached.
@@ -318,15 +334,15 @@ class BuildReviewRequestTest(_BuilderTestBase):
     def test_skips_sixth_explicit_review_invocation_and_posts_blocked_message(self) -> None:
         from core.builders import build_review_request
 
+        # 5 prior completed reviews → this would be the 6th, which is blocked.
         github_client, repo, pr = self._github_client_with_review_comments(
             issue_comments=[
-                self._review_comment("/oz-review"),
-                self._review_comment("/oz-review again"),
-                self._review_comment("please @oz-agent /review"),
-                self._review_comment("/oz-review once more"),
-                self._review_comment("/oz-review fifth"),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
             ],
-            review_comments=[self._review_comment("/oz-review sixth")],
         )
 
         request = build_review_request(
@@ -338,7 +354,7 @@ class BuildReviewRequestTest(_BuilderTestBase):
         self.assertIsNone(request)
         repo.get_pull.assert_called_once_with(42)
         pr.get_issue_comments.assert_called_once_with()
-        pr.get_review_comments.assert_called_once_with()
+        pr.get_review_comments.assert_not_called()
         review_module = sys.modules["workflows.review_pr"]
         review_module.gather_review_context.assert_not_called()  # type: ignore[attr-defined]
         review_module.build_review_prompt_for_dispatch.assert_not_called()  # type: ignore[attr-defined]
@@ -349,26 +365,26 @@ class BuildReviewRequestTest(_BuilderTestBase):
         self.assertIn("all 5 `/oz-review` slots", blocked_body)
         self.assertIn("24-hour window", blocked_body)
 
-    def test_ignores_bot_comments_when_counting_explicit_invocations(self) -> None:
+    def test_only_bot_progress_comments_count_toward_limit(self) -> None:
         from core.builders import build_review_request
 
+        # 3 bot progress comments count; user /oz-review commands and
+        # enforcement comments do not.
+        enforcement_comment = SimpleNamespace(
+            body=(
+                '<!-- oz-agent-metadata: {"type":"issue-status","workflow":"review-pull-request"'
+                ',"issue":42,"run_id":"pr-issue-state-enforcement"} -->'
+            ),
+            user=SimpleNamespace(login="oz-for-oss[bot]", type="Bot"),
+            created_at=datetime.now(timezone.utc),
+        )
         github_client, repo, pr = self._github_client_with_review_comments(
             issue_comments=[
-                self._review_comment("/oz-review"),
-                self._review_comment("/oz-review again"),
-                self._review_comment("please @oz-agent /review"),
-                self._review_comment(
-                    "/oz-review from automation",
-                    login="oz-for-oss[bot]",
-                    user_type="Bot",
-                ),
-            ],
-            review_comments=[
-                self._review_comment(
-                    "/oz-review bot suffix",
-                    login="dependabot[bot]",
-                    user_type="User",
-                )
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
+                enforcement_comment,
+                self._review_comment("/oz-review from user alice"),
             ],
         )
 
@@ -378,10 +394,12 @@ class BuildReviewRequestTest(_BuilderTestBase):
             workspace_path=Path("/tmp/ws"),
         )
 
+        # Only 3 real progress comments counted → under the limit, no advisory.
         self.assertIsNotNone(request)
         repo.get_pull.assert_called_once_with(42)
         pr.get_issue_comments.assert_called_once_with()
-        pr.get_review_comments.assert_called_once_with()
+        pr.get_review_comments.assert_not_called()
+        repo.get_issue.return_value.create_comment.assert_not_called()
         review_module = sys.modules["workflows.review_pr"]
         review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
 
@@ -392,14 +410,13 @@ class BuildReviewRequestTest(_BuilderTestBase):
         github_client, repo, pr = self._github_client_with_review_comments(
             issue_comments=[
                 # These two are outside the 24-hour window and must not count.
-                self._review_comment("/oz-review", created_at=old_time),
-                self._review_comment("/oz-review old", created_at=old_time),
-                # These five are inside the window → hits the limit (advisory).
-                self._review_comment("/oz-review"),
-                self._review_comment("/oz-review"),
-                self._review_comment("/oz-review"),
-                self._review_comment("/oz-review"),
-                self._review_comment("/oz-review"),
+                self._bot_progress_comment(created_at=old_time),
+                self._bot_progress_comment(created_at=old_time),
+                # These four are inside the window → 4 prior runs = advisory.
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
+                self._bot_progress_comment(),
             ],
         )
 
@@ -409,8 +426,8 @@ class BuildReviewRequestTest(_BuilderTestBase):
             workspace_path=Path("/tmp/ws"),
         )
 
-        # Out-of-window comments are excluded, so only 5 in-window → advisory
-        # is posted but the review still proceeds.
+        # Out-of-window comments excluded → 4 in-window prior runs → advisory
+        # posted but review proceeds.
         self.assertIsNotNone(request)
         advisory_body: str = repo.get_issue.return_value.create_comment.call_args[0][0]
         self.assertIn("last `/oz-review`", advisory_body)


### PR DESCRIPTION
This PR has the following changes:

1. Bump review limit from 3 to 5.
2. The limit is _daily_, i.e. 5 invocations on the PR per day.
3. On the 5th invocation, inform the user that they have hit the daily limit for reviews and to try again. The message will include the remaining time they need to wait.

The goals are to:

1. Prevent abuse. Malicious actors will still be unable to spam us since there is a daily limit.
2. Unblock contributors. They get more reviews and it will replenish automatically after a day. We are also clearer about this limit existing.
3. Consume less Warp eng time. No manual intervention is required.
