### PR TITLE
feat: enumerate sibling PRs for the same issue and reuse reviewers

### DIFF
--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -12,7 +12,9 @@ from github.GithubException import GithubException
 from github.Repository import Repository
 from oz.helpers import (
     build_comment_body,
+    build_related_pr_reviewer_candidates,
     comment_metadata,
+    find_related_prs_for_issue,
     get_field,
     get_label_name,
     is_automation_user,
@@ -586,6 +588,118 @@ def _resolve_reviewer_from_ownership_area(
     return [choice]
 
 
+def _ownership_area_login_set(
+    ownership_areas: list[OwnershipArea],
+) -> set[str]:
+    """Return the lowercase union of owner logins across *ownership_areas*.
+
+    Used by :func:`_resolve_same_issue_reviewer` to keep sibling-PR
+    reviewer reuse aligned with the canonical maintainer set when the
+    ownership-areas integration is active.
+    """
+    logins: set[str] = set()
+    for area in ownership_areas or []:
+        for owner in getattr(area, "owners", None) or []:
+            if not isinstance(owner, str):
+                continue
+            login = owner.strip().lstrip("@").lower()
+            if login:
+                logins.add(login)
+    return logins
+
+
+def _resolve_same_issue_reviewer(
+    candidates: Any,
+    *,
+    ownership_areas: list[OwnershipArea],
+    stakeholder_entries: list[dict[str, Any]],
+    pr_author_login: str,
+) -> list[str]:
+    """Pick one same-issue sibling reviewer when there is a clear winner.
+
+    *candidates* is the precomputed
+    ``related_pr_reviewer_candidates`` list from the dispatched
+    :class:`ReviewContext`. Each entry is ``{"login": str, "source":
+    str}`` where ``source`` is either ``"requested-open"`` (highest
+    priority) or ``"prior-review"`` (fallback signal).
+
+    Tier selection:
+
+    1. Restrict to logins that are eligible under the current
+       maintainer set. When ownership areas were loaded the set is the
+       union of owners across all areas. Otherwise we filter through
+       ``.github/STAKEHOLDERS`` owners. This preserves the existing
+       collaborator/owner guard used by the other reviewer paths.
+    2. Within the ``requested-open`` tier, if exactly one eligible
+       login remains, pick it. If multiple distinct logins remain, log
+       the ambiguity and skip to the next tier rather than guess. This
+       matches issue #456's "do not guess silently" requirement.
+    3. Repeat (2) for the ``prior-review`` tier.
+    4. Return ``[]`` when no unambiguous winner exists in either tier,
+       so the caller falls through to the ownership-area / STAKEHOLDERS
+       path.
+    """
+    if not isinstance(candidates, list) or not candidates:
+        return []
+    if ownership_areas:
+        allowed_logins: set[str] | None = _ownership_area_login_set(ownership_areas)
+    elif stakeholder_entries:
+        allowed_logins = _stakeholder_logins(stakeholder_entries)
+    else:
+        # Without any maintainer set to validate against, sibling-PR
+        # reuse could request a reviewer outside the trusted roster,
+        # which is exactly the behavior we are trying to avoid. Skip.
+        return []
+    if not allowed_logins:
+        return []
+    author_key = (pr_author_login or "").strip().lower()
+    by_tier: dict[str, list[str]] = {
+        "requested-open": [],
+        "prior-review": [],
+    }
+    seen_by_tier: dict[str, set[str]] = {
+        "requested-open": set(),
+        "prior-review": set(),
+    }
+    for entry in candidates:
+        if not isinstance(entry, dict):
+            continue
+        raw_login = entry.get("login")
+        source = str(entry.get("source") or "").strip()
+        if source not in by_tier:
+            continue
+        login = _normalize_reviewer_login(
+            raw_login,
+            pr_author_login=pr_author_login,
+            allowed_logins=allowed_logins,
+        )
+        if not login:
+            continue
+        key = login.lower()
+        if key == author_key or key in seen_by_tier[source]:
+            continue
+        seen_by_tier[source].add(key)
+        by_tier[source].append(login)
+    for tier in ("requested-open", "prior-review"):
+        eligible = by_tier[tier]
+        if len(eligible) == 1:
+            choice = eligible[0]
+            logger.info(
+                "review-pr: reusing same-issue reviewer %s from tier %s",
+                choice,
+                tier,
+            )
+            return [choice]
+        if len(eligible) > 1:
+            logger.info(
+                "review-pr: same-issue reviewer tier %s is ambiguous "
+                "(eligible: %s); falling through to next tier",
+                tier,
+                eligible,
+            )
+    return []
+
+
 def _resolve_recommended_reviewers(
     review: Mapping[str, Any],
     *,
@@ -593,21 +707,42 @@ def _resolve_recommended_reviewers(
     repo_handle: Any,
     pr_author_login: str,
     changed_paths: list[str],
+    related_pr_reviewer_candidates: list[dict[str, str]] | None = None,
 ) -> list[str]:
-    """Resolve a single reviewer from ownership areas, falling back to STAKEHOLDERS.
+    """Resolve a single reviewer for a non-member APPROVE.
 
     Validation flow:
-    1. Try to match the agent-supplied ``recommended_area`` against the
-       parsed ownership-areas list. On match, pick one eligible owner
+    1. Reuse a same-issue sibling reviewer when there is exactly one
+       eligible candidate in either the ``requested-open`` tier or, as
+       a weaker signal, the ``prior-review`` tier. This lets one
+       reviewer handle every external PR for the same issue instead of
+       fanning out per-PR. Ambiguous tiers fall through rather than
+       picking a random eligible login.
+    2. Match the agent-supplied ``recommended_area`` against the parsed
+       ownership-areas list. On match, pick one eligible owner
        uniformly at random.
-    2. If ownership-areas resolution yields no reviewer (empty list,
+    3. If ownership-areas resolution yields no reviewer (empty list,
        agent gave up, unknown area, or area has no eligible owners),
-       lazily fetch ``.github/STAKEHOLDERS`` from the consuming repo and
-       use :func:`_deterministic_reviewer_from_stakeholders` as the
-       deterministic last-resort fallback.
-    3. If STAKEHOLDERS also yields nothing, return ``[]`` so the caller
+       lazily fetch ``.github/STAKEHOLDERS`` from the consuming repo
+       and use :func:`_deterministic_reviewer_from_stakeholders` as
+       the deterministic last-resort fallback.
+    4. If STAKEHOLDERS also yields nothing, return ``[]`` so the caller
        completes the review without requesting a human reviewer.
     """
+    # Lazily load STAKEHOLDERS so the eligibility filter for sibling-PR
+    # reuse has the same maintainer guard as the existing fallback,
+    # while keeping the call cheap when ownership areas are loaded.
+    stakeholder_entries = (
+        load_stakeholders_from_repo(repo_handle) if repo_handle is not None else []
+    )
+    sibling_reviewer = _resolve_same_issue_reviewer(
+        related_pr_reviewer_candidates,
+        ownership_areas=ownership_areas,
+        stakeholder_entries=stakeholder_entries,
+        pr_author_login=pr_author_login,
+    )
+    if sibling_reviewer:
+        return sibling_reviewer
     reviewer = _resolve_reviewer_from_ownership_area(
         review,
         ownership_areas=ownership_areas,
@@ -615,8 +750,6 @@ def _resolve_recommended_reviewers(
     )
     if reviewer:
         return reviewer
-    # Lazily load STAKEHOLDERS only if no reviewer found in ownership areas.
-    stakeholder_entries = load_stakeholders_from_repo(repo_handle) if repo_handle is not None else []
     fallback = _deterministic_reviewer_from_stakeholders(
         stakeholder_entries,
         changed_paths=changed_paths,
@@ -915,6 +1048,19 @@ class ReviewContext(TypedDict):
     # the agent's ``recommended_area`` back to an owner deterministically.
     ownership_areas: list[dict[str, Any]]
     ownership_areas_loaded: bool
+    # Same-issue sibling-PR context captured at dispatch time. Populated
+    # only for non-member, code (non-spec-only) PRs that resolve to a
+    # single linked issue; empty everywhere else. ``linked_issue_number``
+    # is the resolved primary same-repo issue (0 when none). ``related_prs``
+    # carries one record per sibling PR with reviewer signals.
+    # ``related_pr_reviewer_candidates`` is a precomputed ordered list of
+    # ``{login, source}`` records the apply step consumes to reuse a
+    # same-issue reviewer before falling through to the ownership-areas /
+    # STAKEHOLDERS path. ``source`` is ``"requested-open"`` or
+    # ``"prior-review"``.
+    linked_issue_number: int
+    related_prs: list[dict[str, Any]]
+    related_pr_reviewer_candidates: list[dict[str, str]]
     progress_comment_id: int
 
 
@@ -1027,6 +1173,29 @@ def gather_review_context(
     stakeholders_entries: list[dict[str, Any]] = []
     ownership_areas_serialized: list[dict[str, Any]] = []
     ownership_areas_loaded = False
+    related_prs: list[dict[str, Any]] = []
+    related_pr_reviewer_candidates: list[dict[str, str]] = []
+    linked_issue_number = int(issue_number or 0)
+    if is_non_member and linked_issue_number > 0:
+        # Enumerate sibling PRs that reference the same issue (closing
+        # keyword, manual link, or plain ``#N`` mention) so the apply
+        # step can prefer reusing a reviewer who is already engaged with
+        # this issue before falling through to ownership-areas /
+        # STAKEHOLDERS resolution. Limited to non-member, non-spec
+        # PRs per issue #456 to avoid expanding reviewer-assignment
+        # behavior for regular member PRs. Fail-open inside the helper
+        # keeps the dispatch path resilient to GraphQL/REST failures.
+        related_prs = find_related_prs_for_issue(
+            github,
+            owner,
+            repo,
+            linked_issue_number,
+            exclude_pr_number=int(pr_number),
+            exclude_pr_author_login=pr_author_login,
+        )
+        related_pr_reviewer_candidates = build_related_pr_reviewer_candidates(
+            related_prs
+        )
     if is_non_member:
         # Prefer the canonical ``warpdotdev/warp-ownership`` mapping when
         # an ownership-repo client is wired in. The agent picks one area
@@ -1121,8 +1290,74 @@ def gather_review_context(
         stakeholder_entries=stakeholders_entries,
         ownership_areas=ownership_areas_serialized,
         ownership_areas_loaded=bool(ownership_areas_loaded),
+        linked_issue_number=linked_issue_number,
+        related_prs=related_prs,
+        related_pr_reviewer_candidates=related_pr_reviewer_candidates,
         progress_comment_id=int(progress_comment_id or 0),
     )
+
+
+def _format_related_prs_block(
+    related_prs: Any,
+    *,
+    pr_number: int,
+) -> str:
+    """Render the same-issue sibling PRs as a compact prompt section.
+
+    Returns an empty string when no sibling PRs are available so callers
+    can skip the block entirely. The control plane uses this block to
+    surface context to the reviewing agent; reviewer reuse is enforced
+    deterministically at apply time via
+    ``related_pr_reviewer_candidates`` and does not depend on the agent
+    consuming this text.
+    """
+    if not isinstance(related_prs, list) or not related_prs:
+        return ""
+    lines: list[str] = []
+    for entry in related_prs:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            number = int(entry.get("number") or 0)
+        except (TypeError, ValueError):
+            continue
+        if number <= 0 or number == int(pr_number):
+            continue
+        title = str(entry.get("title") or "").strip()
+        url = str(entry.get("url") or "").strip()
+        state = str(entry.get("state") or "").strip().upper() or "UNKNOWN"
+        author = str(entry.get("author_login") or "").strip()
+        header = f"- #{number} [{state}]"
+        if title:
+            header += f" — {title}"
+        if url:
+            header += f" ({url})"
+        if author:
+            header += f" by @{author}"
+        lines.append(header)
+        requested = [
+            str(login).strip()
+            for login in (entry.get("requested_reviewers") or [])
+            if isinstance(login, str) and login.strip()
+        ]
+        prior = [
+            str(login).strip()
+            for login in (entry.get("prior_reviewers") or [])
+            if isinstance(login, str) and login.strip()
+        ]
+        if requested:
+            lines.append(
+                "    requested reviewers: "
+                + ", ".join(f"@{login}" for login in requested)
+            )
+        if prior:
+            lines.append(
+                "    prior reviewers: "
+                + ", ".join(f"@{login}" for login in prior)
+            )
+    if not lines:
+        return ""
+    return "\n".join(lines)
 
 
 def _format_ownership_areas_json_block(
@@ -1228,6 +1463,23 @@ def build_review_prompt_for_dispatch(context: Mapping[str, Any]) -> str:
     non_member_section = str(context.get("non_member_review_section") or "").rstrip()
     if non_member_section:
         prompt = prompt + "\n\n" + non_member_section
+    related_prs_block = _format_related_prs_block(
+        context.get("related_prs"),
+        pr_number=int(context.get("pr_number") or 0),
+    )
+    if related_prs_block:
+        linked_issue_number = int(context.get("linked_issue_number") or 0)
+        header_suffix = (
+            f" (linked issue #{linked_issue_number})"
+            if linked_issue_number > 0
+            else ""
+        )
+        prompt = (
+            prompt
+            + f"\n\nRelated same-issue PRs{header_suffix}:\n"
+            + "These are other open or recently active pull requests that reference the same issue. They are provided as context only — do not call GitHub to inspect them yourself. The control plane has already used this information to keep reviewer assignment consistent across sibling PRs.\n"
+            + related_prs_block
+        )
     if ownership_areas_loaded:
         prompt = (
             prompt
@@ -1320,12 +1572,21 @@ def apply_review_result(
             for entry in (context.get("ownership_areas") or [])
             if isinstance(entry, dict) and entry.get("name")
         ]
+        raw_related_candidates = context.get("related_pr_reviewer_candidates") or []
+        related_pr_reviewer_candidates = [
+            entry
+            for entry in raw_related_candidates
+            if isinstance(entry, dict)
+            and isinstance(entry.get("login"), str)
+            and isinstance(entry.get("source"), str)
+        ]
         recommended_reviewers = _resolve_recommended_reviewers(
             result,
             ownership_areas=ownership_areas,
             repo_handle=github,
             pr_author_login=pr_author_login,
             changed_paths=list(diff_line_map),
+            related_pr_reviewer_candidates=related_pr_reviewer_candidates,
         )
     else:
         recommended_reviewers = []

--- a/oz/helpers.py
+++ b/oz/helpers.py
@@ -79,6 +79,44 @@ _MANUAL_LINKED_ISSUES_QUERY = (
     " }"
     " }"
     " }"
+)
+
+# GraphQL query that walks the issue timeline and collects every
+# ``CrossReferencedEvent`` whose ``source`` is a ``PullRequest``. GitHub
+# records one of these events whenever a PR references the issue —
+# whether by closing keyword, manual link, or plain ``#N`` mention — so
+# the issue-timeline path is the canonical way to find sibling PRs that
+# point at the same issue. We additionally select the PR author and
+# state so the control plane can deterministically pick a same-issue
+# reviewer without needing extra round-trips. See
+# https://docs.github.com/en/graphql/reference/objects#crossreferencedevent
+# and https://docs.github.com/en/graphql/reference/unions#referencedsubject
+# for the schema.
+_ISSUE_CROSS_REFERENCED_PRS_QUERY = (
+    "query($owner: String!, $name: String!, $number: Int!, $after: String) {"
+    " repository(owner: $owner, name: $name) {"
+    " issue(number: $number) {"
+    " timelineItems(first: 100, after: $after, itemTypes: [CROSS_REFERENCED_EVENT]) {"
+    " pageInfo { hasNextPage endCursor }"
+    " nodes {"
+    " __typename"
+    " ... on CrossReferencedEvent {"
+    " isCrossRepository"
+    " source {"
+    " __typename"
+    " ... on PullRequest {"
+    " number"
+    " title"
+    " url"
+    " state"
+    " author { login __typename }"
+    " repository { owner { login } name }"
+    " }"
+    " }"
+    " }"
+    " }"
+    " }"
+    " }"
     " }"
 )
 
@@ -1963,6 +2001,319 @@ def resolve_issue_number_for_pr(
     )
     primary_issue_number = association.get("primary_issue_number")
     return int(primary_issue_number) if isinstance(primary_issue_number, int) else None
+
+
+def _normalize_cross_referenced_pr(
+    node: Any,
+    *,
+    owner: str,
+    repo: str,
+) -> dict[str, Any] | None:
+    """Return a compact same-repo PR record from a ``CrossReferencedEvent`` node.
+
+    Only ``CrossReferencedEvent`` entries whose ``source`` is a
+    ``PullRequest`` from the same ``owner/repo`` are kept. Cross-repo
+    references (e.g. PRs in forks that reference the issue) are dropped
+    so reviewer-reuse never proposes a login who cannot be requested on
+    the current PR.
+    """
+    if not isinstance(node, dict):
+        return None
+    source = node.get("source") or {}
+    if not isinstance(source, dict):
+        return None
+    if str(source.get("__typename") or "") != "PullRequest":
+        return None
+    number = source.get("number")
+    if not isinstance(number, int):
+        return None
+    source_repo = source.get("repository") or {}
+    source_owner = (
+        ((source_repo.get("owner") or {}).get("login") or "").strip()
+    )
+    source_repo_name = str(source_repo.get("name") or "").strip()
+    if (
+        source_owner.lower() != owner.lower()
+        or source_repo_name.lower() != repo.lower()
+    ):
+        return None
+    author = source.get("author") or {}
+    author_login = str(author.get("login") or "").strip()
+    author_typename = str(author.get("__typename") or "").strip()
+    state = str(source.get("state") or "").strip().upper()
+    return {
+        "number": int(number),
+        "title": str(source.get("title") or ""),
+        "url": str(source.get("url") or ""),
+        "state": state,
+        "author_login": author_login,
+        "author_typename": author_typename,
+    }
+
+
+def _fetch_cross_referenced_prs_for_issue(
+    requester: Any,
+    owner: str,
+    repo: str,
+    issue_number: int,
+) -> list[dict[str, Any]]:
+    """Return same-repo PRs that cross-reference ``issue_number``.
+
+    Walks the issue timeline via the
+    :data:`_ISSUE_CROSS_REFERENCED_PRS_QUERY` GraphQL query and collects
+    every ``CrossReferencedEvent`` source that resolves to a PullRequest
+    in the same ``owner/repo``. Pagination follows the standard
+    ``pageInfo.endCursor`` pattern used elsewhere in this module.
+    Records are deduplicated by PR number so a PR referenced multiple
+    times only appears once.
+    """
+    seen: dict[int, dict[str, Any]] = {}
+    cursor: str | None = None
+    while True:
+        _headers, data = requester.graphql_query(
+            _ISSUE_CROSS_REFERENCED_PRS_QUERY,
+            {
+                "owner": owner,
+                "name": repo,
+                "number": int(issue_number),
+                "after": cursor,
+            },
+        )
+        issue_data = (
+            ((data.get("data") or {}).get("repository") or {}).get("issue")
+            or {}
+        )
+        timeline_items = issue_data.get("timelineItems") or {}
+        for node in timeline_items.get("nodes") or []:
+            entry = _normalize_cross_referenced_pr(node, owner=owner, repo=repo)
+            if entry is None:
+                continue
+            seen.setdefault(entry["number"], entry)
+        page_info = timeline_items.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+    return sorted(seen.values(), key=lambda item: int(item["number"]))
+
+
+def _author_is_bot(entry: dict[str, Any]) -> bool:
+    """Return True when *entry*'s author looks like an automation account."""
+    if str(entry.get("author_typename") or "").strip() == "Bot":
+        return True
+    login = str(entry.get("author_login") or "").strip().lower()
+    return bool(login) and login.endswith("[bot]")
+
+
+def _collect_sibling_reviewer_signals(
+    pr: Any,
+    *,
+    exclude_logins: set[str],
+) -> tuple[list[str], list[str]]:
+    """Return ``(requested_human_logins, prior_human_logins)`` for *pr*.
+
+    Reviewer signals are gathered via PyGithub REST endpoints rather
+    than GraphQL because the existing apply-step contract already uses
+    PyGithub objects exclusively, ``get_review_requests`` /
+    ``get_reviews`` are cheap and paginated, and they expose the
+    ``user`` and ``state`` fields directly. Bots and any logins listed
+    in *exclude_logins* (the current PR's author plus its own author)
+    are filtered out.
+
+    Per-PR failures are logged and swallowed so one inaccessible PR
+    does not abort the sibling-PR discovery for the whole batch.
+    """
+    requested: list[str] = []
+    prior: list[str] = []
+    normalized_excluded = {login.strip().lower() for login in exclude_logins if login}
+
+    def _accept(login: str) -> str | None:
+        normalized = login.strip().lstrip("@")
+        if not normalized:
+            return None
+        if normalized.lower() in normalized_excluded:
+            return None
+        return normalized
+
+    try:
+        users, _teams = pr.get_review_requests()
+    except Exception:
+        logger.exception(
+            "Failed to list requested reviewers for sibling PR #%s",
+            getattr(pr, "number", "unknown"),
+        )
+        users = []
+    seen_requested: set[str] = set()
+    for user in users or []:
+        if is_automation_user(user):
+            continue
+        login = _accept(get_login(user))
+        if login is None:
+            continue
+        key = login.lower()
+        if key in seen_requested:
+            continue
+        seen_requested.add(key)
+        requested.append(login)
+
+    try:
+        reviews = list(pr.get_reviews())
+    except Exception:
+        logger.exception(
+            "Failed to list reviews for sibling PR #%s",
+            getattr(pr, "number", "unknown"),
+        )
+        reviews = []
+    seen_prior: set[str] = set()
+    for review in reviews:
+        state = str(getattr(review, "state", "") or "").strip().upper()
+        # PENDING reviews are drafts that have not been submitted, so
+        # ignore them. Every other state represents a real human review
+        # signal we are willing to reuse.
+        if state == "PENDING":
+            continue
+        if is_automation_user(getattr(review, "user", None)):
+            continue
+        login = _accept(get_login(getattr(review, "user", None)))
+        if login is None:
+            continue
+        key = login.lower()
+        if key in seen_prior:
+            continue
+        seen_prior.add(key)
+        prior.append(login)
+
+    return requested, prior
+
+
+def find_related_prs_for_issue(
+    github: Repository,
+    owner: str,
+    repo: str,
+    issue_number: int,
+    *,
+    exclude_pr_number: int | None = None,
+    exclude_pr_author_login: str = "",
+) -> list[dict[str, Any]]:
+    """Return sibling PRs in the same repo that reference ``issue_number``.
+
+    Uses the issue-timeline ``CrossReferencedEvent`` GraphQL query to
+    enumerate every PR that references the issue (closing keyword,
+    manual link, or plain ``#N`` mention), then enriches each record
+    with reviewer signals (currently requested reviewers and prior
+    human reviewers) drawn from PyGithub REST endpoints on each sibling
+    PR.
+
+    The current PR (``exclude_pr_number``) and its author
+    (``exclude_pr_author_login``) are excluded from the results so the
+    reviewer-reuse selector cannot recommend self-review.
+
+    Fail-open: any GraphQL or PyGithub error is logged and the
+    function returns an empty list so the workflow degrades to the
+    existing reviewer-resolution path.
+    """
+    requester = _graphql_requester(github)
+    if requester is None or not isinstance(issue_number, int) or issue_number <= 0:
+        return []
+    try:
+        sources = _fetch_cross_referenced_prs_for_issue(
+            requester, owner, repo, int(issue_number)
+        )
+    except Exception:
+        logger.exception(
+            "Failed to fetch cross-referenced PRs for issue #%s in %s/%s",
+            issue_number,
+            owner,
+            repo,
+        )
+        return []
+    results: list[dict[str, Any]] = []
+    exclude_author_key = (exclude_pr_author_login or "").strip().lower()
+    for entry in sources:
+        pr_number = int(entry["number"])
+        if exclude_pr_number is not None and pr_number == int(exclude_pr_number):
+            continue
+        if _author_is_bot(entry):
+            continue
+        author_login = entry.get("author_login") or ""
+        sibling_pr: Any = None
+        try:
+            sibling_pr = github.get_pull(pr_number)
+        except Exception:
+            logger.exception(
+                "Failed to fetch sibling PR #%s in %s/%s for reviewer signals",
+                pr_number,
+                owner,
+                repo,
+            )
+            requested, prior = [], []
+        if sibling_pr is not None:
+            exclude_logins = {author_login.lower()}
+            if exclude_author_key:
+                exclude_logins.add(exclude_author_key)
+            requested, prior = _collect_sibling_reviewer_signals(
+                sibling_pr,
+                exclude_logins=exclude_logins,
+            )
+        results.append(
+            {
+                "number": pr_number,
+                "title": str(entry.get("title") or ""),
+                "url": str(entry.get("url") or ""),
+                "state": str(entry.get("state") or "").upper(),
+                "author_login": author_login,
+                "requested_reviewers": requested,
+                "prior_reviewers": prior,
+            }
+        )
+    return results
+
+
+def build_related_pr_reviewer_candidates(
+    related_prs: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Return a deterministic ordered candidate list keyed by source tier.
+
+    Walks *related_prs* in (PR number) order and emits candidates as
+    ``{"login": str, "source": str}`` records. ``source`` is
+    ``"requested-open"`` for human reviewers currently requested on an
+    open sibling PR (the strongest signal), and ``"prior-review"`` for
+    humans who already submitted any non-PENDING review on a sibling.
+    Each login appears at most once per source tier; the apply-step
+    selector reads these tiers in order and picks the first unambiguous
+    eligible login.
+    """
+    requested_seen: set[str] = set()
+    requested_candidates: list[dict[str, str]] = []
+    prior_seen: set[str] = set()
+    prior_candidates: list[dict[str, str]] = []
+    for entry in related_prs or []:
+        if not isinstance(entry, dict):
+            continue
+        state = str(entry.get("state") or "").strip().upper()
+        if state == "OPEN":
+            for login in entry.get("requested_reviewers") or []:
+                if not isinstance(login, str):
+                    continue
+                key = login.strip().lower()
+                if not key or key in requested_seen:
+                    continue
+                requested_seen.add(key)
+                requested_candidates.append(
+                    {"login": login.strip(), "source": "requested-open"}
+                )
+        for login in entry.get("prior_reviewers") or []:
+            if not isinstance(login, str):
+                continue
+            key = login.strip().lower()
+            if not key or key in prior_seen:
+                continue
+            prior_seen.add(key)
+            prior_candidates.append(
+                {"login": login.strip(), "source": "prior-review"}
+            )
+    return requested_candidates + prior_candidates
 
 
 def is_spec_only_pr(changed_files: list[str]) -> bool:

--- a/tests/test_same_issue_reviewer_reuse.py
+++ b/tests/test_same_issue_reviewer_reuse.py
@@ -1,0 +1,624 @@
+"""Tests for sibling-PR discovery and same-issue reviewer reuse.
+
+Covers both the API-backed helpers in :mod:`oz.helpers` and the
+control-plane reviewer-reuse selector wired into
+``workflows.review_pr._resolve_recommended_reviewers``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from . import conftest  # noqa: F401
+
+from oz.helpers import (
+    build_related_pr_reviewer_candidates,
+    find_related_prs_for_issue,
+)
+from oz.ownership import OwnershipArea
+
+from workflows.review_pr import (  # type: ignore[import-not-found]
+    _resolve_recommended_reviewers,
+    _resolve_same_issue_reviewer,
+    apply_review_result,
+)
+
+
+STAKEHOLDERS = [
+    {"pattern": "*", "owners": ["fallback"]},
+    {"pattern": "/docs/", "owners": ["docs-owner"]},
+]
+
+OWNERSHIP_AREAS = [
+    OwnershipArea(
+        name="Docs",
+        owners=["docs-owner", "secondary-owner"],
+        matches="Docs and reference",
+    ),
+    OwnershipArea(
+        name="Runtime",
+        owners=["runtime-owner"],
+        matches="Runtime internals",
+    ),
+]
+
+
+def _user(login: str, *, type_: str = "User") -> SimpleNamespace:
+    return SimpleNamespace(login=login, type=type_)
+
+
+def _cross_ref_node(
+    *,
+    pr_number: int,
+    title: str = "Other PR",
+    url: str = "",
+    state: str = "OPEN",
+    author_login: str = "external-1",
+    author_typename: str = "User",
+    owner: str = "acme",
+    repo: str = "widgets",
+) -> dict:
+    return {
+        "__typename": "CrossReferencedEvent",
+        "isCrossRepository": False,
+        "source": {
+            "__typename": "PullRequest",
+            "number": pr_number,
+            "title": title,
+            "url": url or f"https://github.com/{owner}/{repo}/pull/{pr_number}",
+            "state": state,
+            "author": {"login": author_login, "__typename": author_typename},
+            "repository": {
+                "owner": {"login": owner},
+                "name": repo,
+            },
+        },
+    }
+
+
+class FindRelatedPrsForIssueTest(unittest.TestCase):
+    """``find_related_prs_for_issue`` queries the issue timeline.
+
+    Mocks GraphQL via ``github.requester.graphql_query`` to return
+    cross-referenced events, and PyGithub via ``github.get_pull(...)``
+    to expose ``get_review_requests`` / ``get_reviews`` for each
+    sibling PR.
+    """
+
+    def _make_github(
+        self,
+        *,
+        timeline_nodes: list[dict],
+        siblings: dict[int, MagicMock],
+        page_info: dict | None = None,
+    ) -> MagicMock:
+        page_info = page_info or {"hasNextPage": False, "endCursor": None}
+        graphql_response = (
+            {},
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "timelineItems": {
+                                "pageInfo": page_info,
+                                "nodes": timeline_nodes,
+                            }
+                        }
+                    }
+                }
+            },
+        )
+        requester = MagicMock()
+        requester.graphql_query.return_value = graphql_response
+        github = MagicMock()
+        github.requester = requester
+
+        def _get_pull(pr_number: int) -> MagicMock:
+            return siblings[int(pr_number)]
+
+        github.get_pull.side_effect = _get_pull
+        return github
+
+    def _make_sibling(
+        self,
+        *,
+        requested_users: list[SimpleNamespace] | None = None,
+        reviews: list[SimpleNamespace] | None = None,
+    ) -> MagicMock:
+        pr = MagicMock()
+        pr.get_review_requests.return_value = (requested_users or [], [])
+        pr.get_reviews.return_value = reviews or []
+        return pr
+
+    def test_returns_sibling_with_requested_and_prior_reviewers(self) -> None:
+        sibling = self._make_sibling(
+            requested_users=[_user("docs-owner")],
+            reviews=[
+                SimpleNamespace(
+                    state="APPROVED",
+                    user=_user("secondary-owner"),
+                )
+            ],
+        )
+        github = self._make_github(
+            timeline_nodes=[_cross_ref_node(pr_number=100, author_login="ext-1")],
+            siblings={100: sibling},
+        )
+
+        related = find_related_prs_for_issue(
+            github, "acme", "widgets", 42,
+            exclude_pr_number=99,
+            exclude_pr_author_login="contributor",
+        )
+
+        self.assertEqual(len(related), 1)
+        self.assertEqual(related[0]["number"], 100)
+        self.assertEqual(related[0]["state"], "OPEN")
+        self.assertEqual(related[0]["author_login"], "ext-1")
+        self.assertEqual(related[0]["requested_reviewers"], ["docs-owner"])
+        self.assertEqual(related[0]["prior_reviewers"], ["secondary-owner"])
+
+    def test_excludes_current_pr_and_cross_repo_sources(self) -> None:
+        # The current PR (#99) and a cross-repo PR source must be
+        # filtered out before reviewer signals are gathered.
+        cross_repo_node = _cross_ref_node(pr_number=200, owner="fork-owner")
+        nodes = [
+            _cross_ref_node(pr_number=99),
+            cross_repo_node,
+            _cross_ref_node(pr_number=101, author_login="ext-2"),
+        ]
+        sibling_101 = self._make_sibling()
+        github = self._make_github(
+            timeline_nodes=nodes,
+            siblings={101: sibling_101},
+        )
+
+        related = find_related_prs_for_issue(
+            github, "acme", "widgets", 42,
+            exclude_pr_number=99,
+            exclude_pr_author_login="contributor",
+        )
+
+        # Only #101 survives: #99 is excluded, the cross-repo node is
+        # dropped by the same-repo filter inside the helper.
+        self.assertEqual([entry["number"] for entry in related], [101])
+
+    def test_excludes_bot_authored_sibling(self) -> None:
+        nodes = [
+            _cross_ref_node(
+                pr_number=110,
+                author_login="dependabot[bot]",
+                author_typename="Bot",
+            ),
+            _cross_ref_node(pr_number=111, author_login="ext-3"),
+        ]
+        sibling_111 = self._make_sibling()
+        github = self._make_github(
+            timeline_nodes=nodes,
+            siblings={111: sibling_111},
+        )
+
+        related = find_related_prs_for_issue(
+            github, "acme", "widgets", 42,
+            exclude_pr_number=0,
+            exclude_pr_author_login="contributor",
+        )
+
+        # The bot-authored PR is dropped before we even look up reviewer
+        # signals, and the human-authored sibling is preserved.
+        self.assertEqual([entry["number"] for entry in related], [111])
+
+    def test_excludes_sibling_author_from_reviewer_signals(self) -> None:
+        sibling = self._make_sibling(
+            requested_users=[_user("ext-author"), _user("docs-owner")],
+            reviews=[
+                SimpleNamespace(state="APPROVED", user=_user("ext-author")),
+                SimpleNamespace(state="APPROVED", user=_user("secondary-owner")),
+            ],
+        )
+        github = self._make_github(
+            timeline_nodes=[
+                _cross_ref_node(pr_number=120, author_login="ext-author"),
+            ],
+            siblings={120: sibling},
+        )
+
+        related = find_related_prs_for_issue(
+            github, "acme", "widgets", 42,
+            exclude_pr_number=99,
+            exclude_pr_author_login="contributor",
+        )
+
+        # The sibling PR's own author and bot reviewers are filtered
+        # out; everyone else remains.
+        self.assertEqual(related[0]["requested_reviewers"], ["docs-owner"])
+        self.assertEqual(related[0]["prior_reviewers"], ["secondary-owner"])
+
+    def test_excludes_bot_reviewers(self) -> None:
+        sibling = self._make_sibling(
+            requested_users=[
+                SimpleNamespace(login="oz-for-oss[bot]", type="Bot"),
+                _user("docs-owner"),
+            ],
+            reviews=[
+                SimpleNamespace(
+                    state="APPROVED",
+                    user=SimpleNamespace(login="ci-bot[bot]", type="Bot"),
+                ),
+                SimpleNamespace(state="APPROVED", user=_user("secondary-owner")),
+            ],
+        )
+        github = self._make_github(
+            timeline_nodes=[_cross_ref_node(pr_number=130)],
+            siblings={130: sibling},
+        )
+
+        related = find_related_prs_for_issue(
+            github, "acme", "widgets", 42,
+            exclude_pr_number=99,
+            exclude_pr_author_login="contributor",
+        )
+
+        self.assertEqual(related[0]["requested_reviewers"], ["docs-owner"])
+        self.assertEqual(related[0]["prior_reviewers"], ["secondary-owner"])
+
+    def test_fail_open_on_graphql_error(self) -> None:
+        requester = MagicMock()
+        requester.graphql_query.side_effect = RuntimeError("graphql down")
+        github = MagicMock()
+        github.requester = requester
+
+        related = find_related_prs_for_issue(
+            github, "acme", "widgets", 42,
+            exclude_pr_number=99,
+            exclude_pr_author_login="contributor",
+        )
+
+        # Helper swallows the error and returns an empty list so the
+        # workflow falls through to the existing reviewer-resolution
+        # path.
+        self.assertEqual(related, [])
+
+
+class BuildRelatedPrReviewerCandidatesTest(unittest.TestCase):
+    def test_orders_requested_open_before_prior_review(self) -> None:
+        related = [
+            {
+                "number": 11,
+                "state": "OPEN",
+                "requested_reviewers": ["alice"],
+                "prior_reviewers": ["bob"],
+            },
+            {
+                "number": 12,
+                "state": "CLOSED",
+                "requested_reviewers": ["carol"],
+                "prior_reviewers": ["dave"],
+            },
+        ]
+        candidates = build_related_pr_reviewer_candidates(related)
+        self.assertEqual(
+            candidates,
+            [
+                {"login": "alice", "source": "requested-open"},
+                {"login": "bob", "source": "prior-review"},
+                {"login": "dave", "source": "prior-review"},
+            ],
+        )
+
+    def test_skips_requested_reviewers_from_closed_siblings(self) -> None:
+        related = [
+            {
+                "number": 21,
+                "state": "MERGED",
+                "requested_reviewers": ["alice"],
+                "prior_reviewers": ["bob"],
+            }
+        ]
+        candidates = build_related_pr_reviewer_candidates(related)
+        self.assertEqual(
+            candidates,
+            [{"login": "bob", "source": "prior-review"}],
+        )
+
+    def test_dedupes_within_tier(self) -> None:
+        related = [
+            {"number": 31, "state": "OPEN", "requested_reviewers": ["alice"]},
+            {"number": 32, "state": "OPEN", "requested_reviewers": ["alice"]},
+            {"number": 33, "state": "OPEN", "prior_reviewers": ["alice"]},
+        ]
+        candidates = build_related_pr_reviewer_candidates(related)
+        # ``alice`` appears once per tier, even though she shows up on
+        # multiple sibling PRs.
+        self.assertEqual(
+            candidates,
+            [
+                {"login": "alice", "source": "requested-open"},
+                {"login": "alice", "source": "prior-review"},
+            ],
+        )
+
+
+class ResolveSameIssueReviewerTest(unittest.TestCase):
+    def test_picks_requested_open_tier_when_unique(self) -> None:
+        candidates = [
+            {"login": "docs-owner", "source": "requested-open"},
+            {"login": "runtime-owner", "source": "prior-review"},
+        ]
+        reviewers = _resolve_same_issue_reviewer(
+            candidates,
+            ownership_areas=OWNERSHIP_AREAS,
+            stakeholder_entries=[],
+            pr_author_login="contributor",
+        )
+        self.assertEqual(reviewers, ["docs-owner"])
+
+    def test_falls_through_to_prior_review_tier(self) -> None:
+        candidates = [{"login": "runtime-owner", "source": "prior-review"}]
+        reviewers = _resolve_same_issue_reviewer(
+            candidates,
+            ownership_areas=OWNERSHIP_AREAS,
+            stakeholder_entries=[],
+            pr_author_login="contributor",
+        )
+        self.assertEqual(reviewers, ["runtime-owner"])
+
+    def test_ambiguous_requested_tier_skips_to_next_tier(self) -> None:
+        candidates = [
+            {"login": "docs-owner", "source": "requested-open"},
+            {"login": "secondary-owner", "source": "requested-open"},
+            {"login": "runtime-owner", "source": "prior-review"},
+        ]
+        reviewers = _resolve_same_issue_reviewer(
+            candidates,
+            ownership_areas=OWNERSHIP_AREAS,
+            stakeholder_entries=[],
+            pr_author_login="contributor",
+        )
+        # The requested-open tier is ambiguous (two eligible logins),
+        # so we skip to the prior-review tier and pick the single
+        # eligible login there.
+        self.assertEqual(reviewers, ["runtime-owner"])
+
+    def test_returns_empty_when_all_tiers_ambiguous(self) -> None:
+        candidates = [
+            {"login": "docs-owner", "source": "requested-open"},
+            {"login": "secondary-owner", "source": "requested-open"},
+            {"login": "runtime-owner", "source": "prior-review"},
+            {"login": "docs-owner", "source": "prior-review"},
+        ]
+        reviewers = _resolve_same_issue_reviewer(
+            candidates,
+            ownership_areas=OWNERSHIP_AREAS,
+            stakeholder_entries=[],
+            pr_author_login="contributor",
+        )
+        self.assertEqual(reviewers, [])
+
+    def test_filters_logins_outside_ownership_owner_set(self) -> None:
+        candidates = [
+            {"login": "outsider", "source": "requested-open"},
+            {"login": "docs-owner", "source": "prior-review"},
+        ]
+        reviewers = _resolve_same_issue_reviewer(
+            candidates,
+            ownership_areas=OWNERSHIP_AREAS,
+            stakeholder_entries=[],
+            pr_author_login="contributor",
+        )
+        # ``outsider`` is not in the ownership-areas owner set, so the
+        # requested-open tier becomes empty and we fall through to the
+        # prior-review tier where docs-owner is eligible.
+        self.assertEqual(reviewers, ["docs-owner"])
+
+    def test_uses_stakeholders_when_ownership_areas_unavailable(self) -> None:
+        candidates = [
+            {"login": "outsider", "source": "requested-open"},
+            {"login": "docs-owner", "source": "prior-review"},
+        ]
+        reviewers = _resolve_same_issue_reviewer(
+            candidates,
+            ownership_areas=[],
+            stakeholder_entries=STAKEHOLDERS,
+            pr_author_login="contributor",
+        )
+        # Falls back to the STAKEHOLDERS roster; ``outsider`` is not
+        # listed, ``docs-owner`` is.
+        self.assertEqual(reviewers, ["docs-owner"])
+
+    def test_excludes_pr_author_from_candidates(self) -> None:
+        candidates = [
+            {"login": "docs-owner", "source": "requested-open"},
+        ]
+        reviewers = _resolve_same_issue_reviewer(
+            candidates,
+            ownership_areas=OWNERSHIP_AREAS,
+            stakeholder_entries=[],
+            pr_author_login="docs-owner",
+        )
+        # The PR author cannot review their own PR; this candidate is
+        # dropped and no reviewer is selected.
+        self.assertEqual(reviewers, [])
+
+    def test_returns_empty_with_no_candidates(self) -> None:
+        self.assertEqual(
+            _resolve_same_issue_reviewer(
+                [],
+                ownership_areas=OWNERSHIP_AREAS,
+                stakeholder_entries=[],
+                pr_author_login="contributor",
+            ),
+            [],
+        )
+
+    def test_returns_empty_without_maintainer_set(self) -> None:
+        # Sibling reuse without any maintainer guard would risk pulling
+        # in random logins, so the selector intentionally bails out.
+        candidates = [{"login": "docs-owner", "source": "requested-open"}]
+        self.assertEqual(
+            _resolve_same_issue_reviewer(
+                candidates,
+                ownership_areas=[],
+                stakeholder_entries=[],
+                pr_author_login="contributor",
+            ),
+            [],
+        )
+
+
+class ResolveRecommendedReviewersWithSiblingsTest(unittest.TestCase):
+    """``_resolve_recommended_reviewers`` prefers sibling-PR reuse."""
+
+    def test_sibling_reviewer_wins_over_ownership_area(self) -> None:
+        repo_handle = MagicMock()
+        candidates = [{"login": "secondary-owner", "source": "requested-open"}]
+        with patch(
+            "workflows.review_pr.load_stakeholders_from_repo",
+            return_value=STAKEHOLDERS,
+        ):
+            reviewers = _resolve_recommended_reviewers(
+                {"recommended_area": "Docs"},
+                ownership_areas=OWNERSHIP_AREAS,
+                repo_handle=repo_handle,
+                pr_author_login="contributor",
+                changed_paths=["docs/readme.md"],
+                related_pr_reviewer_candidates=candidates,
+            )
+        # ``Docs`` ownership area would yield ``docs-owner`` (or a random
+        # pick); the sibling-PR signal overrides that with the requested
+        # reviewer from the open sibling.
+        self.assertEqual(reviewers, ["secondary-owner"])
+
+    def test_no_sibling_signal_falls_back_to_ownership_area(self) -> None:
+        repo_handle = MagicMock()
+        with patch(
+            "workflows.review_pr.load_stakeholders_from_repo",
+            return_value=STAKEHOLDERS,
+        ):
+            reviewers = _resolve_recommended_reviewers(
+                {"recommended_area": "Runtime"},
+                ownership_areas=OWNERSHIP_AREAS,
+                repo_handle=repo_handle,
+                pr_author_login="contributor",
+                changed_paths=["src/runtime.py"],
+                related_pr_reviewer_candidates=[],
+            )
+        self.assertEqual(reviewers, ["runtime-owner"])
+
+    def test_ambiguous_sibling_signal_falls_through(self) -> None:
+        repo_handle = MagicMock()
+        candidates = [
+            {"login": "docs-owner", "source": "requested-open"},
+            {"login": "secondary-owner", "source": "requested-open"},
+        ]
+        with patch(
+            "workflows.review_pr.load_stakeholders_from_repo",
+            return_value=STAKEHOLDERS,
+        ):
+            reviewers = _resolve_recommended_reviewers(
+                {"recommended_area": "Runtime"},
+                ownership_areas=OWNERSHIP_AREAS,
+                repo_handle=repo_handle,
+                pr_author_login="contributor",
+                changed_paths=["src/runtime.py"],
+                related_pr_reviewer_candidates=candidates,
+            )
+        # Sibling signal is ambiguous in the requested-open tier and
+        # the prior-review tier is empty, so we use the ownership-area
+        # match instead.
+        self.assertEqual(reviewers, ["runtime-owner"])
+
+
+class ApplyReviewResultSameIssueReuseTest(unittest.TestCase):
+    """End-to-end: ``apply_review_result`` honors sibling-PR reuse."""
+
+    def _make_context(
+        self,
+        *,
+        related_pr_reviewer_candidates: list[dict[str, str]] | None = None,
+    ) -> dict:
+        return {
+            "owner": "acme",
+            "repo": "widgets",
+            "pr_number": 99,
+            "requester": "alice",
+            "is_non_member": True,
+            "pr_author_login": "contributor",
+            "stakeholder_entries": STAKEHOLDERS,
+            "stakeholder_logins": ["fallback", "docs-owner"],
+            "ownership_areas": [area.to_dict() for area in OWNERSHIP_AREAS],
+            "ownership_areas_loaded": True,
+            "diff_line_map": {},
+            "diff_content_map": {},
+            "linked_issue_number": 42,
+            "related_prs": [],
+            "related_pr_reviewer_candidates": related_pr_reviewer_candidates or [],
+        }
+
+    def _make_github(self, pr: MagicMock) -> MagicMock:
+        github = MagicMock()
+        github.get_pull.return_value = pr
+        return github
+
+    def test_sibling_requested_reviewer_is_requested(self) -> None:
+        pr = MagicMock()
+        github = self._make_github(pr)
+        progress = MagicMock()
+        candidates = [{"login": "secondary-owner", "source": "requested-open"}]
+        with patch(
+            "workflows.review_pr.load_stakeholders_from_repo",
+            return_value=STAKEHOLDERS,
+        ):
+            apply_review_result(
+                github,
+                context=self._make_context(
+                    related_pr_reviewer_candidates=candidates,
+                ),
+                run=MagicMock(),
+                result={
+                    "verdict": "APPROVE",
+                    "summary": "Looks good",
+                    "comments": [],
+                    "recommended_area": "Docs",
+                },
+                progress=progress,
+            )
+        pr.create_review_request.assert_called_once_with(
+            reviewers=["secondary-owner"]
+        )
+
+    def test_member_pr_ignores_sibling_signal(self) -> None:
+        pr = MagicMock()
+        github = self._make_github(pr)
+        progress = MagicMock()
+        context = self._make_context(
+            related_pr_reviewer_candidates=[
+                {"login": "secondary-owner", "source": "requested-open"},
+            ],
+        )
+        context["is_non_member"] = False
+        with patch(
+            "workflows.review_pr.load_stakeholders_from_repo",
+            return_value=STAKEHOLDERS,
+        ):
+            apply_review_result(
+                github,
+                context=context,
+                run=MagicMock(),
+                result={
+                    "verdict": "APPROVE",
+                    "summary": "Looks good",
+                    "comments": [],
+                    "recommended_area": "Docs",
+                },
+                progress=progress,
+            )
+        # Member PRs never request human review; the sibling-PR
+        # signal should not change that.
+        pr.create_review_request.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

For non-member PRs reviewed via the `review-pull-request` workflow, the control plane now enumerates other PRs that reference the same issue and prefers reusing a same-issue reviewer before falling back to the existing ownership-area / STAKEHOLDERS resolution.

This is stacked on top of [`varoon/integrate-ownership-areas`](https://github.com/warpdotdev/oz-for-oss/tree/varoon/integrate-ownership-areas); base the review against that branch.

## What changed

- Added a paginated `Issue.timelineItems(CROSS_REFERENCED_EVENT)` GraphQL discovery in `oz/helpers.py` plus `find_related_prs_for_issue` which enriches each sibling PR with reviewer signals via `PullRequest.get_review_requests()` and `PullRequest.get_reviews()`. Bots, the current PR's author, and cross-repo sources are filtered out. Fails open on GraphQL errors.
- Added `build_related_pr_reviewer_candidates` which produces an ordered candidate list with two tiers:
  - `requested-open`: human reviewers currently requested on an open sibling PR (strongest signal).
  - `prior-review`: humans who already submitted a non-PENDING review on a sibling PR (weaker fallback signal).
- Extended `ReviewContext` with `linked_issue_number`, `related_prs`, and `related_pr_reviewer_candidates`. Populated only for non-member, non-spec PRs that resolve to a single linked issue.
- Rendered a `Related same-issue PRs` block in the dispatched review prompt so the agent sees the same context the control plane uses. The agent is still told not to call GitHub directly. No `review.json` schema change.
- Inserted a same-issue reviewer-reuse step ahead of the ownership-area / STAKEHOLDERS path in `_resolve_recommended_reviewers`. Eligibility is filtered through the union of ownership-area owners when ownership areas are loaded; otherwise the STAKEHOLDERS owner set is used. Ambiguous tiers log and fall through rather than picking randomly.

## Why this GraphQL query

GitHub records every PR-references-issue relationship (closing keyword, manual link, or plain `#N` mention) as a `CrossReferencedEvent` on the issue timeline, with `source` typed as a `PullRequest`. This is the same shape GitHub's web UI uses to render an issue's "linked PRs" section, and it's the only GraphQL path that catches PRs that reference the issue without a closing keyword (which `closingIssuesReferences` would miss).

- [`Issue.timelineItems`](https://docs.github.com/en/graphql/reference/objects#issue)
- [`IssueTimelineItemsItemType`](https://docs.github.com/en/graphql/reference/enums#issuetimelineitemsitemtype) (includes `CROSS_REFERENCED_EVENT`)
- [`CrossReferencedEvent`](https://docs.github.com/en/graphql/reference/objects#crossreferencedevent)

REST `/issues/{n}/timeline` returns the same events but collapses `source.issue` for both issues and PRs, requiring extra disambiguation; GraphQL gives us a typed `... on PullRequest` selection in one call and matches the pattern already used for linked-issue queries in `oz/helpers.py`.

## Tests

Added `tests/test_same_issue_reviewer_reuse.py` (23 tests) covering:

- Sibling discovery via cross-referenced timeline events.
- Cross-repo source rejection and current-PR exclusion.
- Bot author + bot reviewer filtering.
- Sibling-PR author exclusion from its own reviewer signals.
- Fail-open on GraphQL errors.
- Candidate ordering (requested-open before prior-review) and per-tier deduping.
- Tier selection: pick-when-unique, ambiguous-tier-skip, ownership-area eligibility filter, STAKEHOLDERS-only fallback eligibility filter, PR-author exclusion.
- End-to-end `apply_review_result`: sibling reviewer is requested for non-member APPROVE, and member PRs ignore the sibling signal entirely.

Full test suite: **413 passed, 59 subtests passed**.

## Plan

[Same-Issue PR Context and Reviewer Reuse for Review Workflow](https://staging.warp.dev/drive/notebook/VtVdoBvWN5evbX9HkCzAXG)

## Session

[View on Warp](https://staging.warp.dev/conversation/8a05d53f-9f05-4da2-b6ba-d733bf51be6e)

Closes #456

Co-Authored-By: Oz <oz-agent@warp.dev>
