### PR TITLE
fix: Prefer PR assignees for review routing

### DIFF
--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -824,23 +824,6 @@ def _format_non_member_review_section(
     ).strip()
 
 
-def _format_assignee_review_section(
-    *,
-    pr_author_login: str,
-    reviewer_login: str,
-) -> str:
-    return dedent(
-        f"""
-        Non-Member Reviewer Selection:
-        - The PR author (@{pr_author_login or 'unknown'}) is not a repository member or collaborator, so the workflow should request exactly one human reviewer when your `verdict` is `"APPROVE"`.
-        - This PR is already assigned to @{reviewer_login}; the workflow will request that assignee as the human reviewer for an `"APPROVE"` verdict.
-        - If your `verdict` is `"REJECT"`, the workflow will post a GitHub `REQUEST_CHANGES` review and will not request a human reviewer.
-        - Do not return `recommended_area` or `recommended_reviewers`; the workflow already has the assignee-based reviewer.
-        - Do not call GitHub yourself to post the review or request reviewers.
-        """
-    ).strip()
-
-
 def _format_pr_description(
     *,
     pr_number: int,
@@ -1089,12 +1072,7 @@ def gather_review_context(
             pr,
             pr_author_login=pr_author_login,
         )
-        if pr_assignee_reviewers:
-            non_member_review_section = _format_assignee_review_section(
-                pr_author_login=pr_author_login,
-                reviewer_login=pr_assignee_reviewers[0],
-            )
-        else:
+        if not pr_assignee_reviewers:
             # Prefer the canonical ``warpdotdev/warp-ownership`` mapping when
             # an ownership-repo client is wired in. The agent picks one area
             # from the parsed list; Vercel resolves the area to an owner

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -16,6 +16,7 @@ from oz.helpers import (
     ENFORCEMENT_COMMENT_RUN_ID,
     get_field,
     get_label_name,
+    get_login,
     is_automation_user,
     is_spec_only_pr,
     ORG_MEMBER_ASSOCIATIONS,
@@ -496,6 +497,27 @@ def _first_eligible_owner(
     return None
 
 
+def _reviewer_from_pr_assignee(
+    pr: Any,
+    *,
+    pr_author_login: str,
+) -> list[str]:
+    for assignee in get_field(pr, "assignees", []) or []:
+        if is_automation_user(assignee):
+            continue
+        login = _normalize_reviewer_login(
+            get_login(assignee),
+            pr_author_login=pr_author_login,
+        )
+        if login:
+            logger.info(
+                "review-pr: using existing PR assignee %s as reviewer",
+                login,
+            )
+            return [login]
+    return []
+
+
 def _deterministic_reviewer_from_stakeholders(
     entries: list[dict[str, Any]],
     *,
@@ -802,6 +824,23 @@ def _format_non_member_review_section(
     ).strip()
 
 
+def _format_assignee_review_section(
+    *,
+    pr_author_login: str,
+    reviewer_login: str,
+) -> str:
+    return dedent(
+        f"""
+        Non-Member Reviewer Selection:
+        - The PR author (@{pr_author_login or 'unknown'}) is not a repository member or collaborator, so the workflow should request exactly one human reviewer when your `verdict` is `"APPROVE"`.
+        - This PR is already assigned to @{reviewer_login}; the workflow will request that assignee as the human reviewer for an `"APPROVE"` verdict.
+        - If your `verdict` is `"REJECT"`, the workflow will post a GitHub `REQUEST_CHANGES` review and will not request a human reviewer.
+        - Do not return `recommended_area` or `recommended_reviewers`; the workflow already has the assignee-based reviewer.
+        - Do not call GitHub yourself to post the review or request reviewers.
+        """
+    ).strip()
+
+
 def _format_pr_description(
     *,
     pr_number: int,
@@ -889,7 +928,6 @@ def _format_pr_diff(files: list[File]) -> str:
     return "\n\n".join(sections).rstrip() + "\n"
 
 
-
 class ReviewContext(TypedDict):
     """Serializable context for a Vercel-dispatched PR review run.
 
@@ -924,6 +962,7 @@ class ReviewContext(TypedDict):
     pr_author_login: str
     stakeholder_logins: list[str]
     stakeholder_entries: list[dict[str, Any]]
+    pr_assignee_reviewers: list[str]
     # Ownership-areas snapshot taken at dispatch time. ``ownership_areas`` is
     # a JSON-serializable list of ``{name, owners, matches}`` dicts derived
     # from ``warpdotdev/warp-ownership/ownership-areas/*.md`` via
@@ -1042,52 +1081,63 @@ def gather_review_context(
     )
     non_member_review_section = ""
     stakeholders_entries: list[dict[str, Any]] = []
+    pr_assignee_reviewers: list[str] = []
     ownership_areas_serialized: list[dict[str, Any]] = []
     ownership_areas_loaded = False
     if is_non_member:
-        # Prefer the canonical ``warpdotdev/warp-ownership`` mapping when
-        # an ownership-repo client is wired in. The agent picks one area
-        # from the parsed list; Vercel resolves the area to an owner
-        # deterministically at apply time.
-        ownership_areas: list[OwnershipArea] = []
-        if ownership_repo_handle is not None:
-            try:
-                ownership_areas = load_ownership_areas_from_repo(
-                    ownership_repo_handle
-                )
-            except Exception:
-                # Fail open: any unexpected error pulling warp-ownership
-                # falls through to the STAKEHOLDERS prompt block below.
-                logger.exception(
-                    "review-pr: failed to load ownership areas; falling back to STAKEHOLDERS"
-                )
-                ownership_areas = []
-        if ownership_areas:
-            ownership_areas_loaded = True
-            ownership_areas_serialized = [
-                area.to_dict() for area in ownership_areas
-            ]
-            ownership_areas_block = format_ownership_areas_for_prompt(
-                ownership_areas
-            )
-            non_member_review_section = _format_non_member_review_section(
+        pr_assignee_reviewers = _reviewer_from_pr_assignee(
+            pr,
+            pr_author_login=pr_author_login,
+        )
+        if pr_assignee_reviewers:
+            non_member_review_section = _format_assignee_review_section(
                 pr_author_login=pr_author_login,
-                ownership_areas_block=ownership_areas_block,
-                ownership_areas_loaded=True,
+                reviewer_login=pr_assignee_reviewers[0],
             )
         else:
-            # Load ``.github/STAKEHOLDERS`` directly from the repository
-            # that triggered the webhook. The Vercel function does not
-            # check out the consuming repo, so the workspace-backed
-            # ``load_stakeholders`` would always return an empty list and
-            # silently disable non-member reviewer selection.
-            stakeholders_entries = load_stakeholders_from_repo(github)
-            stakeholders_block = format_stakeholders_for_prompt(stakeholders_entries)
-            non_member_review_section = _format_non_member_review_section(
-                pr_author_login=pr_author_login,
-                stakeholders_block=stakeholders_block,
-                ownership_areas_loaded=False,
-            )
+            # Prefer the canonical ``warpdotdev/warp-ownership`` mapping when
+            # an ownership-repo client is wired in. The agent picks one area
+            # from the parsed list; Vercel resolves the area to an owner
+            # deterministically at apply time.
+            ownership_areas: list[OwnershipArea] = []
+            if ownership_repo_handle is not None:
+                try:
+                    ownership_areas = load_ownership_areas_from_repo(
+                        ownership_repo_handle
+                    )
+                except Exception:
+                    # Fail open: any unexpected error pulling warp-ownership
+                    # falls through to the STAKEHOLDERS prompt block below.
+                    logger.exception(
+                        "review-pr: failed to load ownership areas; falling back to STAKEHOLDERS"
+                    )
+                    ownership_areas = []
+            if ownership_areas:
+                ownership_areas_loaded = True
+                ownership_areas_serialized = [
+                    area.to_dict() for area in ownership_areas
+                ]
+                ownership_areas_block = format_ownership_areas_for_prompt(
+                    ownership_areas
+                )
+                non_member_review_section = _format_non_member_review_section(
+                    pr_author_login=pr_author_login,
+                    ownership_areas_block=ownership_areas_block,
+                    ownership_areas_loaded=True,
+                )
+            else:
+                # Load ``.github/STAKEHOLDERS`` directly from the repository
+                # that triggered the webhook. The Vercel function does not
+                # check out the consuming repo, so the workspace-backed
+                # ``load_stakeholders`` would always return an empty list and
+                # silently disable non-member reviewer selection.
+                stakeholders_entries = load_stakeholders_from_repo(github)
+                stakeholders_block = format_stakeholders_for_prompt(stakeholders_entries)
+                non_member_review_section = _format_non_member_review_section(
+                    pr_author_login=pr_author_login,
+                    stakeholders_block=stakeholders_block,
+                    ownership_areas_loaded=False,
+                )
     pr_description_text = _format_pr_description(
         pr_number=pr_number,
         pr_title=str(pr.title or ""),
@@ -1136,6 +1186,7 @@ def gather_review_context(
         pr_author_login=pr_author_login,
         stakeholder_logins=sorted(_stakeholder_logins(stakeholders_entries)),
         stakeholder_entries=stakeholders_entries,
+        pr_assignee_reviewers=pr_assignee_reviewers,
         ownership_areas=ownership_areas_serialized,
         ownership_areas_loaded=bool(ownership_areas_loaded),
         progress_comment_id=int(progress_comment_id or 0),
@@ -1256,6 +1307,7 @@ def build_review_prompt_for_dispatch(context: Mapping[str, Any]) -> str:
         prompt = prompt + "\n\n" + non_member_section
     return prompt
 
+
 def apply_review_result(
     github: Repository,
     *,
@@ -1324,26 +1376,31 @@ def apply_review_result(
         else "COMMENT"
     )
     if is_non_member and verdict == _VERDICT_APPROVE:
-        ownership_areas = [
-            OwnershipArea(
-                name=str(entry.get("name") or ""),
-                owners=[
-                    str(owner_login)
-                    for owner_login in (entry.get("owners") or [])
-                    if isinstance(owner_login, str) and owner_login.strip()
-                ],
-                matches=str(entry.get("matches") or ""),
-            )
-            for entry in (context.get("ownership_areas") or [])
-            if isinstance(entry, dict) and entry.get("name")
-        ]
-        recommended_reviewers = _resolve_recommended_reviewers(
-            result,
-            ownership_areas=ownership_areas,
-            repo_handle=github,
+        recommended_reviewers = _reviewer_from_pr_assignee(
+            pr,
             pr_author_login=pr_author_login,
-            changed_paths=list(diff_line_map),
         )
+        if not recommended_reviewers:
+            ownership_areas = [
+                OwnershipArea(
+                    name=str(entry.get("name") or ""),
+                    owners=[
+                        str(owner_login)
+                        for owner_login in (entry.get("owners") or [])
+                        if isinstance(owner_login, str) and owner_login.strip()
+                    ],
+                    matches=str(entry.get("matches") or ""),
+                )
+                for entry in (context.get("ownership_areas") or [])
+                if isinstance(entry, dict) and entry.get("name")
+            ]
+            recommended_reviewers = _resolve_recommended_reviewers(
+                result,
+                ownership_areas=ownership_areas,
+                repo_handle=github,
+                pr_author_login=pr_author_login,
+                changed_paths=list(diff_line_map),
+            )
     else:
         recommended_reviewers = []
     if verdict == _VERDICT_APPROVE:

--- a/tests/test_review_pr_reviewer_sampling.py
+++ b/tests/test_review_pr_reviewer_sampling.py
@@ -12,7 +12,6 @@ from github.GithubException import GithubException
 
 from workflows.review_pr import (  # type: ignore[import-not-found]
     _deterministic_reviewer_from_stakeholders,
-    _format_assignee_review_section,
     _format_non_member_review_section,
     _format_review_completion_message,
     _is_team_slug,
@@ -256,7 +255,7 @@ class PrAssigneeReviewerTest(unittest.TestCase):
 
         self.assertEqual(context["pr_assignee_reviewers"], ["assigned-owner"])
         self.assertFalse(context["ownership_areas_loaded"])
-        self.assertIn("assigned to @assigned-owner", context["non_member_review_section"])
+        self.assertEqual(context["non_member_review_section"], "")
         load_ownership.assert_not_called()
 
 
@@ -278,14 +277,6 @@ class OwnershipAreasPromptSectionTest(unittest.TestCase):
         self.assertIn("empty string `\"\"`", prompt)
         self.assertIn("`verdict` is `\"APPROVE\"`", prompt)
         self.assertIn("REQUEST_CHANGES", prompt)
-
-    def test_assignee_prompt_omits_area_and_reviewer_fields(self) -> None:
-        prompt = _format_assignee_review_section(
-            pr_author_login="contributor",
-            reviewer_login="assigned-owner",
-        )
-        self.assertIn("assigned to @assigned-owner", prompt)
-        self.assertIn("Do not return `recommended_area` or `recommended_reviewers`", prompt)
 
     def test_fallback_prompt_keeps_legacy_stakeholders_contract(self) -> None:
         prompt = _format_non_member_review_section(

--- a/tests/test_review_pr_reviewer_sampling.py
+++ b/tests/test_review_pr_reviewer_sampling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from . import conftest  # noqa: F401
@@ -11,15 +12,18 @@ from github.GithubException import GithubException
 
 from workflows.review_pr import (  # type: ignore[import-not-found]
     _deterministic_reviewer_from_stakeholders,
+    _format_assignee_review_section,
     _format_non_member_review_section,
     _format_review_completion_message,
     _is_team_slug,
     _parse_verdict,
     _resolve_recommended_reviewers,
+    _reviewer_from_pr_assignee,
     _split_reviewers,
     _stakeholder_pattern_matches,
     _team_slug_only,
     apply_review_result,
+    gather_review_context,
     review_payload_subset,
     RETRIGGER_HINT,
 )
@@ -199,6 +203,63 @@ class OwnershipAreasResolveReviewerTest(unittest.TestCase):
         load.assert_called_once_with(repo_handle)
 
 
+class PrAssigneeReviewerTest(unittest.TestCase):
+    def test_uses_first_eligible_assignee(self) -> None:
+        pr = SimpleNamespace(
+            assignees=[
+                SimpleNamespace(login="contributor"),
+                SimpleNamespace(login="assigned-owner"),
+            ]
+        )
+        self.assertEqual(
+            _reviewer_from_pr_assignee(pr, pr_author_login="contributor"),
+            ["assigned-owner"],
+        )
+
+    def test_gather_context_skips_ownership_lookup_when_assignee_exists(self) -> None:
+        pr = MagicMock()
+        pr.get_files.return_value = [
+            SimpleNamespace(
+                filename="src/app.py",
+                patch="+print('hi')",
+                status="modified",
+            )
+        ]
+        pr.user.login = "contributor"
+        pr.user.type = "User"
+        pr.author_association = "CONTRIBUTOR"
+        pr.assignees = [SimpleNamespace(login="assigned-owner")]
+        pr.title = "feat: add app"
+        pr.body = ""
+        pr.base.ref = "main"
+        pr.head.ref = "feature"
+        github = MagicMock()
+        github.get_pull.return_value = pr
+
+        with (
+            patch("workflows.review_pr.resolve_issue_number_for_pr", return_value=None),
+            patch("workflows.review_pr.repo_local_skill_path_for_dispatch", return_value=None),
+            patch("workflows.review_pr.resolve_spec_context_for_pr_via_api", return_value={}),
+            patch("workflows.review_pr._build_diff_maps", return_value=({}, {})),
+            patch("workflows.review_pr.load_ownership_areas_from_repo") as load_ownership,
+        ):
+            context = gather_review_context(
+                github,
+                owner="acme",
+                repo="widgets",
+                pr_number=7,
+                trigger_source="pull_request",
+                requester="alice",
+                workspace_path=MagicMock(),
+                ownership_repo_handle=MagicMock(),
+            )
+
+        self.assertEqual(context["pr_assignee_reviewers"], ["assigned-owner"])
+        self.assertFalse(context["ownership_areas_loaded"])
+        self.assertIn("assigned to @assigned-owner", context["non_member_review_section"])
+        load_ownership.assert_not_called()
+
+
 class OwnershipAreasPromptSectionTest(unittest.TestCase):
     def test_prompt_requires_single_area_and_gates_on_verdict(self) -> None:
         prompt = _format_non_member_review_section(
@@ -217,6 +278,14 @@ class OwnershipAreasPromptSectionTest(unittest.TestCase):
         self.assertIn("empty string `\"\"`", prompt)
         self.assertIn("`verdict` is `\"APPROVE\"`", prompt)
         self.assertIn("REQUEST_CHANGES", prompt)
+
+    def test_assignee_prompt_omits_area_and_reviewer_fields(self) -> None:
+        prompt = _format_assignee_review_section(
+            pr_author_login="contributor",
+            reviewer_login="assigned-owner",
+        )
+        self.assertIn("assigned to @assigned-owner", prompt)
+        self.assertIn("Do not return `recommended_area` or `recommended_reviewers`", prompt)
 
     def test_fallback_prompt_keeps_legacy_stakeholders_contract(self) -> None:
         prompt = _format_non_member_review_section(
@@ -426,6 +495,37 @@ class ApplyReviewResultVerdictTest(unittest.TestCase):
         pr.create_review.assert_called_once()
         self.assertEqual(pr.create_review.call_args.kwargs["event"], "COMMENT")
         pr.create_review_request.assert_called_once_with(reviewers=["api-owner"])
+
+    def test_approve_non_member_pr_prefers_existing_assignee(self) -> None:
+        pr = MagicMock()
+        pr.assignees = [SimpleNamespace(login="assigned-owner")]
+        github = self._make_github(pr)
+        progress = MagicMock()
+        with patch("workflows.review_pr._resolve_recommended_reviewers") as resolve:
+            apply_review_result(
+                github,
+                context=self._make_context(
+                    is_non_member=True,
+                    ownership_areas=[
+                        {
+                            "name": "Docs API",
+                            "owners": ["api-owner"],
+                            "matches": "API reference docs and generated documentation",
+                        }
+                    ],
+                ),
+                run=MagicMock(),
+                result={
+                    "verdict": "APPROVE",
+                    "summary": "Looks good",
+                    "comments": [],
+                    "recommended_area": "Docs API",
+                },
+                progress=progress,
+            )
+        resolve.assert_not_called()
+        pr.create_review.assert_called_once()
+        pr.create_review_request.assert_called_once_with(reviewers=["assigned-owner"])
 
     def test_approve_member_pr_uses_comment_event_without_reviewer_request(self) -> None:
         pr = MagicMock()


### PR DESCRIPTION
## Summary
- Prefer an existing eligible PR assignee as the human reviewer for non-member PR approvals before consulting ownership areas or STAKEHOLDERS.
- Tell review agents to omit ownership reviewer fields when assignee-based routing is already available.
- Keep ownership-area and STAKEHOLDERS fallbacks for PRs without eligible assignees.

## Tracking
- Linear: https://linear.app/warpdotdev/issue/APP-4628/prefer-pr-assignees-for-oss-pr-review-reviewer-routing
- Public issue: https://github.com/warpdotdev/oz-for-oss/issues/464

## Verification
- `/tmp/oz-for-oss-venv/bin/python -m unittest tests.test_review_pr_reviewer_sampling tests.test_prompts tests.test_builders`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/ec75d587-68d8-456a-bd6d-71ad076a3b30_
_Run: https://oz.staging.warp.dev/runs/019e7584-6eac-76c0-82db-90540c8c4e18_
_This PR was generated with [Oz](https://warp.dev/oz)._
