### PR TITLE
[APP-4613] Make PR issue-state enforcement message more actionable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ For smaller changes, we can go straight from issue to code. For larger changes, 
 
 ## Who decides readiness
 
-Contributors can file issues, comment on issues and PRs, and open PRs directly. The Warp team is still the group that decides whether an issue is ready for speccing or ready for implementation. Contributors should not treat discussion alone as approval to start a spec or code change if the readiness label is missing.
+Only the Warp team applies the `ready-to-spec` and `ready-to-implement` labels. Contributors cannot set or request them directly and should not treat discussion alone as approval to start a spec or code change while those labels are missing. File issues, comment on issues and PRs, and open PRs freely — but wait for one of those labels before opening a spec or code PR against an issue.
 
 ## A note on parallel work
 

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -48,6 +48,7 @@ from oz.review_validation import (
     serialize_diff_line_map as _serialize_diff_line_map,
 )
 from oz.triage import (
+    decode_repo_text_file,
     format_stakeholders_for_prompt,
     load_stakeholders_from_repo,
 )
@@ -258,20 +259,29 @@ def _format_issue_numbers(numbers: list[int]) -> str:
     return ", ".join(f"#{number}" for number in numbers)
 
 
+def _resolve_contributing_url(
+    github: Repository, owner: str, repo: str
+) -> str | None:
+    """Return a link to the consuming repo's ``CONTRIBUTING.md`` when present.
+
+    The control plane runs against any repo that installs the GitHub App, so
+    we can't assume the file exists. Probe via the GitHub API and skip the
+    link when the file is absent rather than emitting a 404 in the message.
+    """
+    if decode_repo_text_file(github, "CONTRIBUTING.md") is None:
+        return None
+    branch = str(getattr(github, "default_branch", "") or "main").strip() or "main"
+    return f"https://github.com/{owner}/{repo}/blob/{branch}/CONTRIBUTING.md"
+
+
 def _format_pr_issue_state_failure_message(
     check: Mapping[str, Any],
     *,
     requester: str,
-    owner: str,
-    repo: str,
-    default_branch: str,
+    contributing_url: str | None,
 ) -> str:
     required_label = str(check["required_label"])
     issue_numbers = [int(number) for number in check.get("issue_numbers") or []]
-    branch = default_branch.strip() or "main"
-    contributing_url = (
-        f"https://github.com/{owner}/{repo}/blob/{branch}/CONTRIBUTING.md"
-    )
     sections: list[str] = []
     normalized_requester = requester.strip().removeprefix("@")
     if normalized_requester:
@@ -283,8 +293,8 @@ def _format_pr_issue_state_failure_message(
         issue_text = _format_issue_numbers(issue_numbers)
         sections.append(
             f"This PR is linked to {issue_text}, but no linked issue is marked "
-            f"`{required_label}` yet. Only the Warp team applies that label, so "
-            "please wait for a maintainer to mark the issue. Once it is marked, "
+            f"`{required_label}` yet. Only repository maintainers apply that label, "
+            "so please wait for a maintainer to mark the issue. Once it is marked, "
             "push a new commit or comment `/oz-review` to re-trigger review."
         )
     else:
@@ -295,10 +305,11 @@ def _format_pr_issue_state_failure_message(
             f"mark the issue `{required_label}` when it is ready and review will "
             "run automatically."
         )
-    sections.append(
-        f"See the [contribution guidelines]({contributing_url}) for the full "
-        "readiness model."
-    )
+    if contributing_url:
+        sections.append(
+            f"See the [contribution guidelines]({contributing_url}) for the full "
+            "readiness model."
+        )
     return "\n\n".join(sections)
 
 
@@ -356,13 +367,10 @@ def enforce_pr_issue_state_for_review(
             "review-pr: cannot post issue-state enforcement review without a PR number"
         )
         return False
-    default_branch = str(getattr(github, "default_branch", "") or "main")
     failure_body = _format_pr_issue_state_failure_message(
         check,
         requester=requester,
-        owner=owner,
-        repo=repo,
-        default_branch=default_branch,
+        contributing_url=_resolve_contributing_url(github, owner, repo),
     )
     _upsert_pr_issue_state_enforcement_comment(
         github,

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -258,54 +258,46 @@ def _format_issue_numbers(numbers: list[int]) -> str:
     return ", ".join(f"#{number}" for number in numbers)
 
 
-def _format_issue_status(status: IssueReadinessStatus, *, required_label: str) -> str:
-    readiness_text = (
-        ", ".join(f"`{label}`" for label in status.readiness_labels)
-        if status.readiness_labels
-        else "none"
-    )
-    if status.is_pull_request:
-        state = "is a pull request, not an issue"
-    elif status.has_required_label:
-        state = f"has `{required_label}`"
-    else:
-        state = f"missing `{required_label}`"
-    return f"- #{status.number}: {state}; readiness labels present: {readiness_text}"
-
-
 def _format_pr_issue_state_failure_message(
     check: Mapping[str, Any],
     *,
     requester: str,
+    owner: str,
+    repo: str,
+    default_branch: str,
 ) -> str:
     required_label = str(check["required_label"])
     issue_numbers = [int(number) for number in check.get("issue_numbers") or []]
-    associated_text = _format_issue_numbers(issue_numbers) if issue_numbers else "none"
-    opening = (
-        f"This PR is not linked to an issue that is marked with `{required_label}`."
+    branch = default_branch.strip() or "main"
+    contributing_url = (
+        f"https://github.com/{owner}/{repo}/blob/{branch}/CONTRIBUTING.md"
     )
     sections: list[str] = []
     normalized_requester = requester.strip().removeprefix("@")
     if normalized_requester:
         sections.append(f"@{normalized_requester}")
-    sections.extend(
-        [
-            opening,
-            "Issue-state enforcement details:",
-            f"- Associated same-repo issues checked: {associated_text}",
-            f"- Required readiness label: `{required_label}`",
-        ]
+    sections.append(
+        "Every PR must be linked to a same-repo issue before Oz can review it."
     )
-    statuses = check.get("issue_statuses") or []
-    if statuses:
-        sections.append("Readiness check:")
-        sections.extend(
-            _format_issue_status(status, required_label=required_label)
-            for status in statuses
+    if issue_numbers:
+        issue_text = _format_issue_numbers(issue_numbers)
+        sections.append(
+            f"This PR is linked to {issue_text}, but no linked issue is marked "
+            f"`{required_label}` yet. Only the Warp team applies that label, so "
+            "please wait for a maintainer to mark the issue. Once it is marked, "
+            "push a new commit or comment `/oz-review` to re-trigger review."
+        )
+    else:
+        sections.append(
+            "**Next step:** open or find a same-repo issue describing this change, "
+            "then link it to this PR by adding `Closes #123` to the PR description "
+            "(or using the \"Development\" sidebar on GitHub). A maintainer will "
+            f"mark the issue `{required_label}` when it is ready and review will "
+            "run automatically."
         )
     sections.append(
-        f"To continue, link this PR to a same-repo issue such as `Closes #123` "
-        f"in the PR description, and make sure that issue has `{required_label}`."
+        f"See the [contribution guidelines]({contributing_url}) for the full "
+        "readiness model."
     )
     return "\n\n".join(sections)
 
@@ -364,9 +356,13 @@ def enforce_pr_issue_state_for_review(
             "review-pr: cannot post issue-state enforcement review without a PR number"
         )
         return False
+    default_branch = str(getattr(github, "default_branch", "") or "main")
     failure_body = _format_pr_issue_state_failure_message(
         check,
         requester=requester,
+        owner=owner,
+        repo=repo,
+        default_branch=default_branch,
     )
     _upsert_pr_issue_state_enforcement_comment(
         github,

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -302,8 +302,8 @@ def _format_pr_issue_state_failure_message(
             "**Next step:** open or find a same-repo issue describing this change, "
             "then link it to this PR by adding `Closes #123` to the PR description "
             "(or using the \"Development\" sidebar on GitHub). A maintainer will "
-            f"mark the issue `{required_label}` when it is ready and review will "
-            "run automatically."
+            f"mark the issue `{required_label}` when it is ready. Once it is marked, "
+            "comment `/oz-review` to re-trigger review."
         )
     if contributing_url:
         sections.append(

--- a/tests/test_pr_issue_state_enforcement.py
+++ b/tests/test_pr_issue_state_enforcement.py
@@ -209,13 +209,17 @@ class EnforcePrIssueStateForReviewTest(unittest.TestCase):
             create_review=_create_review,
         )
 
-        allowed = enforce_pr_issue_state_for_review(
-            repo,  # type: ignore[arg-type]
-            owner="acme",
-            repo="widgets",
-            pr=pr,
-            requester="alice",
-        )
+        with patch(
+            "workflows.review_pr.decode_repo_text_file",
+            return_value="# Contributing",
+        ):
+            allowed = enforce_pr_issue_state_for_review(
+                repo,  # type: ignore[arg-type]
+                owner="acme",
+                repo="widgets",
+                pr=pr,
+                requester="alice",
+            )
 
         self.assertFalse(allowed)
         self.assertEqual(len(pr_issue.comments), 1)
@@ -228,11 +232,6 @@ class EnforcePrIssueStateForReviewTest(unittest.TestCase):
             "https://github.com/acme/widgets/blob/main/CONTRIBUTING.md",
             body,
         )
-        # Should NOT tell the contributor to apply the label themselves.
-        self.assertNotIn("make sure that issue has", body)
-        # Enforcement-details / readiness-check boilerplate should be gone.
-        self.assertNotIn("Issue-state enforcement details", body)
-        self.assertNotIn("Readiness check", body)
         # Verify REQUEST_CHANGES review was posted with the same body.
         self.assertEqual(len(reviews_created), 1)
         self.assertEqual(reviews_created[0]["event"], "REQUEST_CHANGES")
@@ -271,7 +270,13 @@ class EnforcePrIssueStateForReviewTest(unittest.TestCase):
             "primary_issue_number": 100,
             "ambiguous": False,
         }
-        with patch("workflows.review_pr.resolve_pr_association", return_value=association):
+        with patch(
+            "workflows.review_pr.resolve_pr_association",
+            return_value=association,
+        ), patch(
+            "workflows.review_pr.decode_repo_text_file",
+            return_value="# Contributing",
+        ):
             allowed = enforce_pr_issue_state_for_review(
                 repo,  # type: ignore[arg-type]
                 owner="acme",
@@ -284,15 +289,46 @@ class EnforcePrIssueStateForReviewTest(unittest.TestCase):
         self.assertEqual(len(pr_issue.comments), 1)
         body = pr_issue.comments[0].body
         self.assertIn("#100", body)
-        self.assertIn("Only the Warp team applies that label", body)
+        self.assertIn("Only repository maintainers apply that label", body)
         self.assertIn("`ready-to-implement`", body)
         self.assertIn(
             "https://github.com/acme/widgets/blob/develop/CONTRIBUTING.md",
             body,
         )
-        # Don't instruct the contributor to label the issue themselves.
-        self.assertNotIn("make sure that issue has", body)
         self.assertEqual(reviews_created[0]["event"], "REQUEST_CHANGES")
+
+    def test_blocked_pr_without_contributing_md_omits_link(self) -> None:
+        pr_issue = _IssueWithComments()
+        repo = _Repo({11: pr_issue})
+        repo.default_branch = "main"
+        reviews_created: list[dict] = []
+
+        pr = SimpleNamespace(
+            number=11,
+            body="",
+            user=SimpleNamespace(login="external-user", type="User"),
+            author_association="NONE",
+            get_files=lambda: [_file("core/routing.py")],
+            create_review=lambda body, event: reviews_created.append(
+                {"body": body, "event": event}
+            ),
+        )
+
+        with patch(
+            "workflows.review_pr.decode_repo_text_file",
+            return_value=None,
+        ):
+            enforce_pr_issue_state_for_review(
+                repo,  # type: ignore[arg-type]
+                owner="acme",
+                repo="widgets",
+                pr=pr,
+                requester="alice",
+            )
+
+        body = pr_issue.comments[0].body
+        self.assertIn("Every PR must be linked to a same-repo issue", body)
+        self.assertNotIn("CONTRIBUTING.md", body)
 
     def test_org_member_pr_skips_enforcement(self) -> None:
         pr_issue = _IssueWithComments()

--- a/tests/test_pr_issue_state_enforcement.py
+++ b/tests/test_pr_issue_state_enforcement.py
@@ -191,9 +191,10 @@ class CheckPrIssueStateForReviewTest(unittest.TestCase):
 
 
 class EnforcePrIssueStateForReviewTest(unittest.TestCase):
-    def test_blocked_pr_posts_actionable_comment_and_changes_requested_review(self) -> None:
+    def test_blocked_pr_with_no_linked_issue_posts_actionable_comment(self) -> None:
         pr_issue = _IssueWithComments()
         repo = _Repo({7: pr_issue})
+        repo.default_branch = "main"
         reviews_created: list[dict] = []
 
         def _create_review(body: str, event: str) -> None:
@@ -220,15 +221,78 @@ class EnforcePrIssueStateForReviewTest(unittest.TestCase):
         self.assertEqual(len(pr_issue.comments), 1)
         body = pr_issue.comments[0].body
         self.assertIn("@alice", body)
-        self.assertIn("This PR is not linked to an issue that is marked with `ready-to-implement`", body)
-        self.assertIn("Required readiness label: `ready-to-implement`", body)
+        self.assertIn("Every PR must be linked to a same-repo issue", body)
+        self.assertIn("Next step", body)
         self.assertIn("Closes #123", body)
-        self.assertNotIn("PR description issue reference", body)
-        # Verify REQUEST_CHANGES review was posted
+        self.assertIn(
+            "https://github.com/acme/widgets/blob/main/CONTRIBUTING.md",
+            body,
+        )
+        # Should NOT tell the contributor to apply the label themselves.
+        self.assertNotIn("make sure that issue has", body)
+        # Enforcement-details / readiness-check boilerplate should be gone.
+        self.assertNotIn("Issue-state enforcement details", body)
+        self.assertNotIn("Readiness check", body)
+        # Verify REQUEST_CHANGES review was posted with the same body.
         self.assertEqual(len(reviews_created), 1)
         self.assertEqual(reviews_created[0]["event"], "REQUEST_CHANGES")
-        self.assertIn("not linked to an issue", reviews_created[0]["body"])
+        self.assertIn("Every PR must be linked to a same-repo issue", reviews_created[0]["body"])
 
+    def test_blocked_pr_with_linked_unready_issue_defers_to_maintainer(self) -> None:
+        pr_issue = _IssueWithComments()
+        linked_issue = _issue("triaged")
+        repo = _Repo({9: pr_issue, 100: linked_issue})
+        repo.default_branch = "develop"
+        reviews_created: list[dict] = []
+
+        def _create_review(body: str, event: str) -> None:
+            reviews_created.append({"body": body, "event": event})
+
+        pr = SimpleNamespace(
+            number=9,
+            body="",
+            user=SimpleNamespace(login="external-user", type="User"),
+            author_association="NONE",
+            get_files=lambda: [_file("core/routing.py")],
+            create_review=_create_review,
+        )
+
+        association = {
+            "same_repo_issue_numbers": [100],
+            "github_linked_issues": [
+                {
+                    "owner": "acme",
+                    "repo": "widgets",
+                    "number": 100,
+                    "source": "closingIssuesReferences",
+                }
+            ],
+            "deterministic_issue_numbers": [],
+            "primary_issue_number": 100,
+            "ambiguous": False,
+        }
+        with patch("workflows.review_pr.resolve_pr_association", return_value=association):
+            allowed = enforce_pr_issue_state_for_review(
+                repo,  # type: ignore[arg-type]
+                owner="acme",
+                repo="widgets",
+                pr=pr,
+                requester="alice",
+            )
+
+        self.assertFalse(allowed)
+        self.assertEqual(len(pr_issue.comments), 1)
+        body = pr_issue.comments[0].body
+        self.assertIn("#100", body)
+        self.assertIn("Only the Warp team applies that label", body)
+        self.assertIn("`ready-to-implement`", body)
+        self.assertIn(
+            "https://github.com/acme/widgets/blob/develop/CONTRIBUTING.md",
+            body,
+        )
+        # Don't instruct the contributor to label the issue themselves.
+        self.assertNotIn("make sure that issue has", body)
+        self.assertEqual(reviews_created[0]["event"], "REQUEST_CHANGES")
 
     def test_org_member_pr_skips_enforcement(self) -> None:
         pr_issue = _IssueWithComments()


### PR DESCRIPTION
## What
Make the PR issue-state enforcement message more actionable for external contributors and clean up `CONTRIBUTING.md`'s readiness-label guidance.

## Why
Resolves [APP-4613](https://linear.app/warpdotdev/issue/APP-4613) / oz-for-oss#463. Contributors who open a PR without a linked, ready issue currently get a long enforcement comment that buries the actionable bit under enforcement details and tells them to apply a label they can't apply themselves. They skim it and ping maintainers in Slack instead of taking the next step on GitHub.

## How
**`CONTRIBUTING.md`** — rewrote the "Who decides readiness" section to directly name `ready-to-spec` / `ready-to-implement` as maintainer-only labels and tell contributors not to expect to apply them.

**`core/workflows/review_pr.py`** — rewrote `_format_pr_issue_state_failure_message`:
- Leads with the actionable rule: every PR must be linked to a same-repo issue.
- Branches on the two failure modes (no linked issue vs linked issue without the readiness label) so the next step is unambiguous.
- Drops the `Issue-state enforcement details` and `Readiness check` sections, which were mostly maintainer-facing diagnostics.
- Removes the "make sure that issue has `ready-to-spec`/`ready-to-implement`" instruction; replaces it with "Only repository maintainers apply that label, so please wait for a maintainer to mark the issue."
- Appends a link to the consuming repo's `CONTRIBUTING.md`, but only after probing for the file via `decode_repo_text_file`. The control plane runs against any repo with the GitHub App installed, so the file is not guaranteed to exist.

**`tests/test_pr_issue_state_enforcement.py`** — refreshed assertions to validate the new copy and the conditional `CONTRIBUTING.md` link. Added a test for the linked-but-not-ready branch and one for the no-`CONTRIBUTING.md` branch.

## Validation
`python -m pytest tests` → 391 passed, 59 subtests passed.

Co-Authored-By: Oz <oz-agent@warp.dev>
