### PR TITLE
feat: promote linked issue to ready-to-implement on plan-approved

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,17 @@ In practice, that means:
 - wait until the Warp team marks the issue `ready-to-implement`
 - open a PR with the implementation once the issue is in that state
 
+When a spec PR exists for the issue, the spec must be `plan-approved` before implementation starts, and the implementation PR should branch off the spec PR's head branch so it builds on the approved spec.
+
 For smaller changes, we can go straight from issue to code. For larger changes, we usually expect the spec step first and then implementation on that same PR or a linked follow-up PR.
+
+### How approval flows through labels
+
+`plan-approved` is the label an internal reviewer applies to a spec PR once the product and technical approach are accepted. Applying it automatically removes `ready-to-spec` and adds `ready-to-implement` on the linked issue, so the issue advances from speccing to implementation without manual relabeling.
+
+### Maintainer-driven Oz triggers
+
+Once `oz-agent` is assigned to an issue, applying `ready-to-spec` or `ready-to-implement` makes Oz draft the matching spec or implementation PR. Without an `oz-agent` assignee, those same labels post a one-shot community-contribution announcement instead. An `@oz-agent` mention on an issue is the equivalent contributor-driven trigger.
 
 ## Who decides readiness
 

--- a/core/workflows/plan_approved.py
+++ b/core/workflows/plan_approved.py
@@ -209,6 +209,20 @@ def apply_plan_approved_sync(
                 issue_number,
             )
 
+    # Promote the issue into the implementation phase. ``add_to_labels``
+    # is idempotent server-side, so it runs even when the label is
+    # already present; ``ready_to_implement_added`` records a fresh add.
+    ready_to_implement_added = READY_TO_IMPLEMENT_LABEL not in label_names
+    try:
+        issue_handle.add_to_labels(READY_TO_IMPLEMENT_LABEL)
+    except Exception:
+        logger.exception(
+            "Failed to add %r label to issue #%s",
+            READY_TO_IMPLEMENT_LABEL,
+            issue_number,
+        )
+ 
+
     # Decide whether implementation should be triggered. The label
     # set after the removal above (``ready-to-spec`` may have just
     # been stripped) determines whether the issue is ready for
@@ -239,6 +253,7 @@ def apply_plan_approved_sync(
         "linked_issue_number": int(issue_number),
         "comment_posted": comment_posted,
         "label_removed": label_removed,
+        "ready_to_implement_added": ready_to_implement_added,
         "implementation_triggered": False,
     }
 

--- a/tests/test_plan_approved.py
+++ b/tests/test_plan_approved.py
@@ -228,6 +228,7 @@ class ApplyPlanApprovedSyncTest(_PlanApprovedTestBase):
         self.assertEqual(result["linked_issue_number"], 91)
         self.assertTrue(result["comment_posted"])
         self.assertTrue(result["label_removed"])
+        self.assertTrue(result["ready_to_implement_added"])
         self.assertFalse(result["implementation_triggered"])
         # Sync helper mutates the payload so the dispatch builder can
         # reuse the resolved number even when implementation IS needed.
@@ -237,6 +238,7 @@ class ApplyPlanApprovedSyncTest(_PlanApprovedTestBase):
         self.assertIn("PR #121", body)
         self.assertIn("https://github.com/acme/widgets/pull/121", body)
         issue.remove_from_labels.assert_called_once_with("ready-to-spec")
+        issue.add_to_labels.assert_called_once_with("ready-to-implement")
 
     def test_existing_comment_is_not_re_posted(self) -> None:
         # Idempotency: a prior plan-approved comment on the issue
@@ -284,6 +286,9 @@ class ApplyPlanApprovedSyncTest(_PlanApprovedTestBase):
         self.assertEqual(payload.get("linked_issue_number"), 91)
         issue.create_comment.assert_called_once()
         issue.remove_from_labels.assert_called_once_with("ready-to-spec")
+        # The label add runs idempotently even when ``ready-to-implement``
+        # is already present (and the issue falls through to dispatch).
+        issue.add_to_labels.assert_called_once_with("ready-to-implement")
 
     def test_spec_only_filenames_qualify_without_spec_branch(self) -> None:
         # PR on an unusual branch still qualifies if every changed


### PR DESCRIPTION
## Summary
When a spec PR is labeled `plan-approved`, the linked issue now advances automatically: `apply_plan_approved_sync` adds `ready-to-implement` (idempotently) after removing `ready-to-spec`, letting the existing `issues.labeled` route cascade into the implementation flow without a maintainer hand-labeling the issue.

## Changes
- `core/workflows/plan_approved.py`: add `ready-to-implement` to the linked issue when missing, wrapped in the same defensive try/except as the existing label removal. New `ready_to_implement_added` field on the `synced` result; all other keys unchanged so the webhook 202 body is stable. The existing fall-through-to-dispatch path (when `ready-to-implement` + `oz-agent` are already present) is preserved.
- `CONTRIBUTING.md`: document that implementation PRs should branch off a `plan-approved` spec PR's branch, plus new "How approval flows through labels" and "Maintainer-driven Oz triggers" subsections.
- `tests/test_plan_approved.py`: assert the label-add (idempotent) and the new result field.

## Validation
`python -m pytest tests` → 389 passed.

## Notes
The internal Warp-only OSS playbook lives outside this repo and should be updated separately to mirror this guidance.

Plan: https://staging.warp.dev/drive/notebook/0E2GIBz7PG49b3XXhB5ahs
Conversation: https://staging.warp.dev/conversation/6e6abd3f-0b79-40a6-8128-12862b792588

Co-Authored-By: Oz <oz-agent@warp.dev>