### PR TITLE
improvement: Surface STAKEHOLDERS fallback alongside ownership areas

### DIFF
--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -788,7 +788,8 @@ def _format_non_member_review_section(
     When ``ownership_areas_loaded`` is true, instruct the agent to return
     a single ``recommended_area`` from the parsed ``warpdotdev/warp-ownership``
     list. Vercel deterministically maps that area to one owner at apply
-    time. When ownership areas are unavailable (fetch failure, empty
+    time, with ``.github/STAKEHOLDERS`` shown as the explicit fallback
+    source. When ownership areas are unavailable (fetch failure, empty
     repo), fall back to the legacy STAKEHOLDERS prompt block where the
     agent returns ``recommended_reviewers`` directly.
     """
@@ -803,10 +804,14 @@ def _format_non_member_review_section(
             - Do NOT invent area names. Do NOT return multiple names, a list, or owner handles. The workflow itself looks up the owners for the chosen area and randomly selects one.
             - If the PR touches multiple areas, pick the **primary** area whose `matches:` description best fits the bulk of the change.
             - If you cannot confidently map the PR to a single area (cross-cutting, ambiguous, or no clear match), set `recommended_area` to the empty string `""`. The workflow will fall back to a deterministic reviewer chosen from `.github/STAKEHOLDERS` rather than guessing.
+            - Use `.github/STAKEHOLDERS` only as the fallback source when you cannot confidently choose exactly one ownership area.
             - Do not call GitHub yourself to post the review or request reviewers.
 
             Ownership Areas (from `warpdotdev/warp-ownership`):
             {ownership_areas_block}
+
+            Fallback Stakeholders (from `.github/STAKEHOLDERS`):
+            {stakeholders_block}
             """
         ).strip()
     return dedent(
@@ -1077,6 +1082,12 @@ def gather_review_context(
             pr_author_login=pr_author_login,
         )
         if not pr_assignee_reviewers:
+            # Load ``.github/STAKEHOLDERS`` directly from the repository
+            # that triggered the webhook. This is shown to the agent even
+            # when ownership areas are available so the fallback path is
+            # explicit in the dispatch prompt.
+            stakeholders_entries = load_stakeholders_from_repo(github)
+            stakeholders_block = format_stakeholders_for_prompt(stakeholders_entries)
             # Prefer the canonical ``warpdotdev/warp-ownership`` mapping when
             # an ownership-repo client is wired in. The agent picks one area
             # from the parsed list; Vercel resolves the area to an owner
@@ -1106,15 +1117,9 @@ def gather_review_context(
                     pr_author_login=pr_author_login,
                     ownership_areas_block=ownership_areas_block,
                     ownership_areas_loaded=True,
+                    stakeholders_block=stakeholders_block,
                 )
             else:
-                # Load ``.github/STAKEHOLDERS`` directly from the repository
-                # that triggered the webhook. The Vercel function does not
-                # check out the consuming repo, so the workspace-backed
-                # ``load_stakeholders`` would always return an empty list and
-                # silently disable non-member reviewer selection.
-                stakeholders_entries = load_stakeholders_from_repo(github)
-                stakeholders_block = format_stakeholders_for_prompt(stakeholders_entries)
                 non_member_review_section = _format_non_member_review_section(
                     pr_author_login=pr_author_login,
                     stakeholders_block=stakeholders_block,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -259,13 +259,17 @@ class ReviewDispatchPromptNonMemberTest(unittest.TestCase):
                 "  owners: @peicodes, @vkodithala\n"
                 "  matches: MCP server connections and resources"
             ),
+            stakeholders_block="- * → @fallback-owner",
             ownership_areas_loaded=True,
         )
         prompt = build_review_prompt_for_dispatch(context)
         self.assertIn("Ownership Areas (from `warpdotdev/warp-ownership`)", prompt)
+        self.assertIn("Fallback Stakeholders (from `.github/STAKEHOLDERS`)", prompt)
+        self.assertIn("Use `.github/STAKEHOLDERS` only as the fallback source", prompt)
         self.assertIn("recommended_area", prompt)
         self.assertIn("Do NOT invent area names", prompt)
         self.assertIn("empty string `\"\"`", prompt)
+        self.assertIn("- * → @fallback-owner", prompt)
         self.assertNotIn("exactly one bare GitHub login string", prompt)
 
     def test_prompt_includes_stakeholders_fallback_instructions(self) -> None:

--- a/tests/test_review_pr_reviewer_sampling.py
+++ b/tests/test_review_pr_reviewer_sampling.py
@@ -268,6 +268,7 @@ class OwnershipAreasPromptSectionTest(unittest.TestCase):
                 "  owners: @api-owner, @backup-owner\n"
                 "  matches: API reference docs and generated documentation"
             ),
+            stakeholders_block="- /docs/ → @docs-owner",
             ownership_areas_loaded=True,
         )
         self.assertIn("recommended_area", prompt)
@@ -277,6 +278,8 @@ class OwnershipAreasPromptSectionTest(unittest.TestCase):
         self.assertIn("empty string `\"\"`", prompt)
         self.assertIn("`verdict` is `\"APPROVE\"`", prompt)
         self.assertIn("REQUEST_CHANGES", prompt)
+        self.assertIn("Fallback Stakeholders (from `.github/STAKEHOLDERS`)", prompt)
+        self.assertIn("- /docs/ → @docs-owner", prompt)
 
     def test_fallback_prompt_keeps_legacy_stakeholders_contract(self) -> None:
         prompt = _format_non_member_review_section(


### PR DESCRIPTION
## What
Surface `.github/STAKEHOLDERS` in non-member PR review prompts even when canonical ownership areas are available.

Context in [this](https://warpdev.slack.com/archives/C0ANKD0Q5JL/p1780088178060269?thread_ts=1780087829.007039&cid=C0ANKD0Q5JL) Slack thread. When Oz isn't able to confidently assign a reviewer from ownership-areas, it probably doesn't hurt to fall back to Stakeholders, and would especially solve this case. Makes sense to include both for now IMO.

## Why
Review prompts should show both routing sources, with STAKEHOLDERS documented as the explicit fallback when the agent cannot confidently choose one ownership area.

## How
Load STAKEHOLDERS during non-member context gathering before ownership-area selection, pass the formatted fallback block into the ownership-area prompt, and update prompt tests to cover the combined presentation.

## Verification
- `.venv/bin/python -m unittest tests/test_prompts.py tests/test_review_pr_reviewer_sampling.py`

## Tracking
- Linear: https://linear.app/warpdotdev/issue/APP-4638/surface-stakeholders-fallback-alongside-ownership-areas-in-pr-review
- Public issue: https://github.com/warpdotdev/oz-for-oss/issues/470

_Conversation: https://staging.warp.dev/conversation/7b5b6075-251f-48a8-847d-b7b2a1ece538_
_Run: https://oz.staging.warp.dev/runs/019e83c6-ce35-7bc8-b36e-13de6967e094_
_This PR was generated with [Oz](https://warp.dev/oz)._
