### PR TITLE
fix(ownership): strip angle-bracketed emails when parsing owner handles

### DIFF
--- a/oz/ownership.py
+++ b/oz/ownership.py
@@ -51,9 +51,11 @@ _MATCHES_BULLET_RE = re.compile(
     r"^\s*[-*]\s*\*\*Matches\*\*:\s*(?P<value>.*?)\s*$",
     re.IGNORECASE,
 )
-# Owner handles appear as ``@login`` separated by commas. Anything that
-# does not start with ``@`` (e.g. ``<TODO: resolve handle>``) is ignored
-# so partial entries in the markdown do not break the parse.
+# Owner handles appear as ``@login`` optionally followed by an email in
+# ``<...>``. Any ``<...>`` segment is stripped before handle extraction so
+# email domains like ``<name@warp.dev>`` do not contribute a bogus ``warp``
+# owner.
+_ANGLE_SEGMENT_RE = re.compile(r"<[^>]*>")
 _OWNER_HANDLE_RE = re.compile(r"@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)")
 
 
@@ -87,7 +89,8 @@ def _parse_owner_handles(value: str) -> list[str]:
     """
     seen: set[str] = set()
     owners: list[str] = []
-    for match in _OWNER_HANDLE_RE.finditer(value or ""):
+    sanitized = _ANGLE_SEGMENT_RE.sub(" ", value or "")
+    for match in _OWNER_HANDLE_RE.finditer(sanitized):
         handle = match.group(1)
         key = handle.lower()
         if key in seen:

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -97,6 +97,15 @@ class ParseOwnershipAreaFileTest(unittest.TestCase):
         areas = _parse_ownership_area_file(text)
         self.assertEqual(areas[0].owners, ["alice", "bob"])
 
+    def test_ignores_handles_inside_angle_bracketed_emails(self) -> None:
+        text = (
+            "### Area\n"
+            "- **Owners**: @alice <alice@warp.dev>, @bob <bob@warp.dev>\n"
+            "- **Matches**: x\n"
+        )
+        areas = _parse_ownership_area_file(text)
+        self.assertEqual(areas[0].owners, ["alice", "bob"])
+
 
 class LoadOwnershipAreasFromRepoTest(unittest.TestCase):
     def _make_repo(


### PR DESCRIPTION
## What
Strip `<...>` segments from each `**Owners**:` bullet value in `warp-ownership/ownership-areas/*.md` before extracting `@handles`, so emails like `<name@warp.dev>` no longer contribute a bogus `warp` owner.

## Why
The ownership-area bullets use the form `@handle <email@warp.dev>`. The previous owner-handle regex was unanchored, so it greedily picked up `@warp` from the email domain in addition to the real handle. `_resolve_reviewer_from_ownership_area` then random-picked uniformly across the polluted owner list. When the choice landed on `warp` (or another email-domain match), `pr.create_review_request(reviewers=[\"warp\"])` 422s on GitHub (\"Reviews may only be requested from collaborators\") and the workflow silently degraded to \"no human review was requested\" — leaving non-member approved PRs without an assigned reviewer.

Real-world example: PR [warpdotdev/warp#11946](https://github.com/warpdotdev/warp/pull/11946) (`recommended_area: \"Shell Compatibility\"`).

## How
- `oz/ownership.py`: added an `_ANGLE_SEGMENT_RE` substitution that strips `<...>` segments before `_OWNER_HANDLE_RE.finditer`. Same dedup/order behavior; just no longer counts email domains as handles.
- `tests/test_ownership.py`: one regression test (`test_ignores_handles_inside_angle_bracketed_emails`) using the real `@handle <email@warp.dev>` shape.

## Verification
`python -m unittest tests.test_ownership` → 16/16 pass, including the new test.

Generated with [Oz](https://staging.warp.dev/conversation/3843f759-01a1-43a5-ae12-65f04335d59d).