### PR TITLE
Reuse existing review requests

### DIFF
--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -1454,37 +1454,37 @@ def apply_review_result(
         else "COMMENT"
     )
     if requires_human_reviewer and verdict == _VERDICT_APPROVE:
-        recommended_reviewers = _reviewer_from_existing_review_request(
-            pr,
-            owner=owner,
-            pr_author_login=pr_author_login,
-        )
-        if not recommended_reviewers:
-            recommended_reviewers = _reviewer_from_pr_assignee(
+        ownership_areas = [
+            OwnershipArea(
+                name=str(entry.get("name") or ""),
+                owners=[
+                    str(owner_login)
+                    for owner_login in (entry.get("owners") or [])
+                    if isinstance(owner_login, str) and owner_login.strip()
+                ],
+                matches=str(entry.get("matches") or ""),
+            )
+            for entry in (context.get("ownership_areas") or [])
+            if isinstance(entry, dict) and entry.get("name")
+        ]
+        recommended_reviewers = (
+            _reviewer_from_existing_review_request(
+                pr,
+                owner=owner,
+                pr_author_login=pr_author_login,
+            )
+            or _reviewer_from_pr_assignee(
                 pr,
                 pr_author_login=pr_author_login,
             )
-        if not recommended_reviewers:
-            ownership_areas = [
-                OwnershipArea(
-                    name=str(entry.get("name") or ""),
-                    owners=[
-                        str(owner_login)
-                        for owner_login in (entry.get("owners") or [])
-                        if isinstance(owner_login, str) and owner_login.strip()
-                    ],
-                    matches=str(entry.get("matches") or ""),
-                )
-                for entry in (context.get("ownership_areas") or [])
-                if isinstance(entry, dict) and entry.get("name")
-            ]
-            recommended_reviewers = _resolve_recommended_reviewers(
+            or _resolve_recommended_reviewers(
                 result,
                 ownership_areas=ownership_areas,
                 repo_handle=github,
                 pr_author_login=pr_author_login,
                 changed_paths=list(diff_line_map),
             )
+        )
     else:
         recommended_reviewers = []
     if verdict == _VERDICT_APPROVE:

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -554,6 +554,36 @@ def _reviewer_from_pr_assignee(
     return []
 
 
+def _reviewer_from_existing_review_request(
+    pr: Any,
+    *,
+    owner: str,
+    pr_author_login: str,
+) -> list[str]:
+    for reviewer in get_field(pr, "requested_reviewers", []) or []:
+        if is_automation_user(reviewer):
+            continue
+        login = _normalize_reviewer_login(
+            get_login(reviewer),
+            pr_author_login=pr_author_login,
+        )
+        if login:
+            logger.info(
+                "review-pr: using existing requested reviewer %s",
+                login,
+            )
+            return [login]
+    for team in get_field(pr, "requested_teams", []) or []:
+        slug = str(get_field(team, "slug", "") or "").strip().lstrip("@")
+        if slug:
+            logger.info(
+                "review-pr: using existing requested team reviewer %s",
+                slug,
+            )
+            return [f"{owner}/{slug}"]
+    return []
+
+
 def _deterministic_reviewer_from_stakeholders(
     entries: list[dict[str, Any]],
     *,
@@ -1424,10 +1454,16 @@ def apply_review_result(
         else "COMMENT"
     )
     if requires_human_reviewer and verdict == _VERDICT_APPROVE:
-        recommended_reviewers = _reviewer_from_pr_assignee(
+        recommended_reviewers = _reviewer_from_existing_review_request(
             pr,
+            owner=owner,
             pr_author_login=pr_author_login,
         )
+        if not recommended_reviewers:
+            recommended_reviewers = _reviewer_from_pr_assignee(
+                pr,
+                pr_author_login=pr_author_login,
+            )
         if not recommended_reviewers:
             ownership_areas = [
                 OwnershipArea(

--- a/tests/test_review_pr_reviewer_sampling.py
+++ b/tests/test_review_pr_reviewer_sampling.py
@@ -540,6 +540,75 @@ class ApplyReviewResultVerdictTest(unittest.TestCase):
         pr.create_review.assert_called_once()
         pr.create_review_request.assert_called_once_with(reviewers=["assigned-owner"])
 
+    def test_approve_non_member_pr_prefers_existing_requested_reviewer(self) -> None:
+        pr = MagicMock()
+        pr.requested_reviewers = [SimpleNamespace(login="requested-owner")]
+        pr.assignees = [SimpleNamespace(login="assigned-owner")]
+        github = self._make_github(pr)
+        progress = MagicMock()
+        with patch("workflows.review_pr._resolve_recommended_reviewers") as resolve:
+            apply_review_result(
+                github,
+                context=self._make_context(
+                    is_non_member=True,
+                    ownership_areas=[
+                        {
+                            "name": "Docs API",
+                            "owners": ["api-owner"],
+                            "matches": "API reference docs and generated documentation",
+                        }
+                    ],
+                ),
+                run=MagicMock(),
+                result={
+                    "verdict": "APPROVE",
+                    "summary": "Looks good",
+                    "comments": [],
+                    "recommended_area": "Docs API",
+                },
+                progress=progress,
+            )
+        resolve.assert_not_called()
+        pr.create_review.assert_called_once()
+        pr.create_review_request.assert_called_once_with(
+            reviewers=["requested-owner"]
+        )
+
+    def test_approve_non_member_pr_prefers_existing_requested_team(self) -> None:
+        pr = MagicMock()
+        pr.requested_reviewers = []
+        pr.requested_teams = [SimpleNamespace(slug="reviewers")]
+        pr.assignees = [SimpleNamespace(login="assigned-owner")]
+        github = self._make_github(pr)
+        progress = MagicMock()
+        with patch("workflows.review_pr._resolve_recommended_reviewers") as resolve:
+            apply_review_result(
+                github,
+                context=self._make_context(
+                    is_non_member=True,
+                    ownership_areas=[
+                        {
+                            "name": "Docs API",
+                            "owners": ["api-owner"],
+                            "matches": "API reference docs and generated documentation",
+                        }
+                    ],
+                ),
+                run=MagicMock(),
+                result={
+                    "verdict": "APPROVE",
+                    "summary": "Looks good",
+                    "comments": [],
+                    "recommended_area": "Docs API",
+                },
+                progress=progress,
+            )
+        resolve.assert_not_called()
+        pr.create_review.assert_called_once()
+        pr.create_review_request.assert_called_once_with(
+            team_reviewers=["reviewers"]
+        )
+
     def test_approve_member_pr_uses_comment_event_without_reviewer_request(self) -> None:
         pr = MagicMock()
         github = self._make_github(pr)


### PR DESCRIPTION
## What
Prefer an existing requested reviewer or team when applying a successful non-member `/oz-review` result.

## Why
Repeated review runs should re-request the same pending reviewer instead of sampling another owner from ownership areas.

Linear: https://linear.app/warpdotdev/issue/APP-4655/reuse-existing-reviewers-for-oz-for-oss-review-requests
Public issue: https://github.com/warpdotdev/oz-for-oss/issues/473

## How
- Check `requested_reviewers` and `requested_teams` before assignee and ownership fallback selection.
- Reuse the existing reviewer/team through the existing review-request path.

## Verification
- `/tmp/oz-for-oss-venv/bin/python -m unittest tests/test_review_pr_reviewer_sampling.py`
- `/tmp/oz-for-oss-venv/bin/python -m py_compile core/workflows/review_pr.py tests/test_review_pr_reviewer_sampling.py`

_Conversation: https://staging.warp.dev/conversation/88e26142-7074-4987-a3ad-d1d03aecc7d2_
_Run: https://oz.staging.warp.dev/runs/019e8eac-a7f0-73f7-ab11-490077f67dc2_

_This PR was generated with [Oz](https://warp.dev/oz)._
