### PR TITLE
fix: allowlist oz-for-x[bot] for issue triage

### DIFF
--- a/.github/oz/config.yml
+++ b/.github/oz/config.yml
@@ -4,3 +4,4 @@ self_improvement:
 triage:
   bot_author_allowlist:
     - warp-dev-github-integration[bot]
+    - oz-for-x[bot]


### PR DESCRIPTION
Add `oz-for-x[bot]` to `triage.bot_author_allowlist` so issues filed by the X/Twitter feedback integration get triaged by default.

Previously the bot was silently dropped by the bot-author guard in `_route_issues()` because it wasn't on the allowlist. `warp-dev-github-integration[bot]` (Slack) was added in #477 but `oz-for-x[bot]` was missed.

_Conversation: https://staging.warp.dev/conversation/49224410-8ef9-4ea5-9d46-496471ba3c67_
_Run: https://oz.staging.warp.dev/runs/019ea9f0-fc1b-7d71-8875-2ee2812bd985_

_This PR was generated with [Oz](https://warp.dev/oz)._
