### PR TITLE
fix: support @warp-agent alias and acknowledge unrecognized PR mentions

### DIFF
--- a/api/webhook.py
+++ b/api/webhook.py
@@ -39,6 +39,7 @@ from core.dispatch import (
 )
 from core.routing import (
     RouteDecision,
+    WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION,
     WORKFLOW_ANNOUNCE_READY_ISSUE,
     WORKFLOW_PLAN_APPROVED,
     needs_triage_bot_author_allowlist,
@@ -120,6 +121,26 @@ def _run_synchronous_announce_ready_issue(
     return sync_announce_ready_issue(payload)
 
 
+def _run_synchronous_acknowledge_unknown_mention(
+    payload: Mapping[str, Any],
+    *,
+    sync_acknowledge_unknown_mention: Callable[[Mapping[str, Any]], dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    """Run the synchronous ``acknowledge-unknown-mention`` path inside the webhook.
+
+    The handler posts a one-shot acknowledgement comment on the PR
+    telling the commenter that the mentioned handle was not recognized
+    and pointing them at ``@oz-agent``. Like ``announce-ready-issue``
+    there is no cloud-agent dispatch fallback, so the helper always
+    returns a structured outcome dict (or ``None`` when the sync helper
+    itself wasn't wired in, which only happens for unit tests that
+    exercise pure routing).
+    """
+    if sync_acknowledge_unknown_mention is None:
+        return None
+    return sync_acknowledge_unknown_mention(payload)
+
+
 def process_webhook_request(
     *,
     body: bytes,
@@ -133,6 +154,7 @@ def process_webhook_request(
     store: StateStore | None = None,
     sync_plan_approved: Callable[[Mapping[str, Any]], dict[str, Any] | None] | None = None,
     sync_announce_ready_issue: Callable[[Mapping[str, Any]], dict[str, Any]] | None = None,
+    sync_acknowledge_unknown_mention: Callable[[Mapping[str, Any]], dict[str, Any]] | None = None,
     triage_bot_author_allowlist: Iterable[str] | None = None,
     triage_bot_author_allowlist_loader: Callable[[Mapping[str, Any]], Iterable[str]] | None = None,
 ) -> WebhookResponse:
@@ -265,6 +287,34 @@ def process_webhook_request(
             body={**base_body, "announce_ready_issue": outcome},
         )
 
+    # ``acknowledge-unknown-mention`` is fully synchronous: the webhook
+    # posts a one-shot comment letting the commenter know the mentioned
+    # handle was not recognized and never dispatches a cloud agent. The
+    # sync helper returns a structured outcome for observability; when it
+    # is not wired in (pure-routing unit tests) we surface the routed
+    # decision and skip the dispatch path entirely.
+    if decision.workflow == WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION:
+        try:
+            outcome = _run_synchronous_acknowledge_unknown_mention(
+                payload,
+                sync_acknowledge_unknown_mention=sync_acknowledge_unknown_mention,
+            )
+        except Exception as exc:
+            logger.exception("Synchronous acknowledge-unknown-mention run failed")
+            return WebhookResponse(
+                status=500,
+                body={
+                    **base_body,
+                    "error": f"acknowledge-unknown-mention path failed: {exc}",
+                },
+            )
+        if outcome is None:
+            return WebhookResponse(status=202, body=base_body)
+        return WebhookResponse(
+            status=202,
+            body={**base_body, "acknowledge_unknown_mention": outcome},
+        )
+
     if builder_registry is None or runner is None or config_factory is None or store is None:
         # The webhook handler is partially wired (e.g. unit tests that
         # only exercise routing). Keep returning 202 + reason so the
@@ -357,6 +407,9 @@ class handler(BaseHTTPRequestHandler):  # noqa: N801 - Vercel requires this exac
             store=wiring["store"],
             sync_plan_approved=wiring["sync_plan_approved"],
             sync_announce_ready_issue=wiring["sync_announce_ready_issue"],
+            sync_acknowledge_unknown_mention=wiring[
+                "sync_acknowledge_unknown_mention"
+            ],
             triage_bot_author_allowlist_loader=wiring[
                 "triage_bot_author_allowlist_loader"
             ],
@@ -396,6 +449,9 @@ def _build_runtime_wiring(*, body: bytes) -> dict[str, Any]:
     )
     from oz.workflow_config import (  # type: ignore[import-not-found]
         load_triage_bot_author_allowlist,
+    )
+    from workflows.acknowledge_unknown_mention import (  # type: ignore[import-not-found]
+        apply_acknowledge_unknown_mention_sync,
     )
     from workflows.announce_ready_issue import (  # type: ignore[import-not-found]
         apply_announce_ready_issue_sync,
@@ -529,6 +585,26 @@ def _build_runtime_wiring(*, body: bytes) -> dict[str, Any]:
             repo_handle, payload=payload
         )
 
+    def sync_acknowledge_unknown_mention(
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        installation_id = int(
+            (payload.get("installation") or {}).get("id") or 0
+        )
+        full_name = str(
+            (payload.get("repository") or {}).get("full_name") or ""
+        )
+        if installation_id <= 0 or "/" not in full_name:
+            return {
+                "action": "skipped",
+                "reason": "missing installation_id or repository.full_name",
+            }
+        client = _mint_github_client(installation_id)
+        repo_handle = client.get_repo(full_name)
+        return apply_acknowledge_unknown_mention_sync(
+            repo_handle, payload=payload
+        )
+
     def triage_bot_author_allowlist_loader(payload: Mapping[str, Any]) -> frozenset[str]:
         full_name = str(
             (payload.get("repository") or {}).get("full_name") or ""
@@ -552,6 +628,7 @@ def _build_runtime_wiring(*, body: bytes) -> dict[str, Any]:
         "store": build_state_store(),
         "sync_plan_approved": sync_plan_approved,
         "sync_announce_ready_issue": sync_announce_ready_issue,
+        "sync_acknowledge_unknown_mention": sync_acknowledge_unknown_mention,
         "triage_bot_author_allowlist_loader": triage_bot_author_allowlist_loader,
     }
 

--- a/core/routing.py
+++ b/core/routing.py
@@ -31,9 +31,15 @@ Webhook coverage today:
     ``oz-agent`` is assigned.
 - ``pull_request_review_comment`` events route to
   ``review-pull-request`` (``/oz-review``), ``verify-pr-comment``
-  (``/oz-verify``), or ``respond-to-pr-comment`` (``@oz-agent``).
+  (``/oz-verify``), or ``respond-to-pr-comment`` (``@oz-agent`` or the
+  legacy ``@warp-agent`` alias). A comment that mentions an
+  unrecognized but agent-like handle (for example ``@warp-bot``)
+  routes to ``acknowledge-unknown-mention`` so the bot posts a
+  clarifying comment instead of silently doing nothing.
 - ``pull_request_review`` events route to ``respond-to-pr-comment``
-  when the review body mentions ``@oz-agent``.
+  when the review body mentions ``@oz-agent`` / ``@warp-agent``, or to
+  ``acknowledge-unknown-mention`` when it mentions an unrecognized
+  agent-like handle.
 - ``issue_comment`` ``created`` events on a pull request route to the same
   set as ``pull_request_review_comment`` (GitHub delivers PR conversation
   comments under the ``issue_comment`` event). Edited issue comments are
@@ -91,6 +97,7 @@ WORKFLOW_CREATE_SPEC_FROM_ISSUE = "create-spec-from-issue"
 WORKFLOW_CREATE_IMPLEMENTATION_FROM_ISSUE = "create-implementation-from-issue"
 WORKFLOW_PLAN_APPROVED = "plan-approved"
 WORKFLOW_ANNOUNCE_READY_ISSUE = "announce-ready-issue"
+WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION = "acknowledge-unknown-mention"
 
 OZ_AGENT_LOGIN = "oz-agent"
 OZ_REVIEW_LABEL = "oz-review"
@@ -102,16 +109,76 @@ READY_TO_IMPLEMENT_LABEL = "ready-to-implement"
 AUTO_IMPLEMENT_LABEL = "auto-implement"
 
 OZ_AGENT_MENTION = "@oz-agent"
+# Pre-rebrand handle, retained as an alias so legacy ``@warp-agent``
+# mentions still trigger a run instead of silently doing nothing.
+WARP_AGENT_MENTION = "@warp-agent"
 OZ_REVIEW_COMMAND = "/oz-review"
 OZ_VERIFY_COMMAND = "/oz-verify"
 OZ_REVIEW_COMMAND_PATTERN = re.compile(
-    r"(?:^|\s)(?:/oz-review|@oz-agent\s+/review)(?![-\w])", re.IGNORECASE
+    r"(?:^|\s)(?:/oz-review|@(?:oz|warp)-agent\s+/review)(?![-\w])", re.IGNORECASE
 )
 MAX_DAILY_REVIEW_INVOCATIONS = 5
+
+# Handles (without the leading ``@``) that address the Oz agent. ``warp-agent``
+# is the pre-rebrand handle, kept as an alias so the branding change does not
+# silently break existing muscle memory.
+RECOGNIZED_AGENT_HANDLES = frozenset({"oz-agent", "warp-agent"})
+
+# Matches an ``@handle`` mention token. The leading boundary mirrors GitHub's
+# own mention parsing (start of string or a non-identifier char, and never the
+# local part of an email address) and the captured handle stops at the first
+# character that cannot appear in a login. Underscores are accepted in the
+# capture so typo variants like ``@oz_agent`` are detected, even though real
+# GitHub logins never contain them.
+_MENTION_TOKEN_PATTERN = re.compile(r"(?<![A-Za-z0-9_])@([A-Za-z0-9][A-Za-z0-9_-]*)")
+
+# Recognizes a near-miss variant of the Oz agent handle so an unrecognized
+# mention can be acknowledged rather than silently dropped. Underscores are
+# normalized to hyphens before matching. Examples: ``ozagent``, ``oz-bot``,
+# ``warpbot``, ``warp-ai``. Bare ``oz`` / ``warp`` are intentionally excluded
+# to avoid pinging unrelated users.
+_AGENT_LIKE_HANDLE_PATTERN = re.compile(r"(?:oz|warp)-?(?:agent|bot|ai)")
+
 
 def has_oz_review_command(body: str) -> bool:
     """Return whether *body* carries an explicit Oz review invocation."""
     return bool(OZ_REVIEW_COMMAND_PATTERN.search(body or ""))
+
+
+def _iter_mention_handles(body: str):
+    """Yield each ``@handle`` token (without the ``@``) found in *body*."""
+    for match in _MENTION_TOKEN_PATTERN.finditer(body or ""):
+        yield match.group(1)
+
+
+def has_agent_mention(body: str) -> bool:
+    """Return whether *body* mentions a recognized agent handle.
+
+    Both the current ``@oz-agent`` handle and the legacy ``@warp-agent``
+    alias count, so mentions written before the rebrand keep working.
+    """
+    return any(
+        handle.strip().lower() in RECOGNIZED_AGENT_HANDLES
+        for handle in _iter_mention_handles(body)
+    )
+
+
+def find_unrecognized_agent_mention(body: str) -> str | None:
+    """Return an agent-like handle in *body* that is not recognized, else ``None``.
+
+    Catches near-miss variants such as ``@warp-bot``, ``@oz-bot``,
+    ``@ozagent`` (missing hyphen), or ``@oz_agent`` (underscore) so the
+    bot can reply with the correct handle instead of ignoring the
+    mention. Recognized handles are skipped, so callers should use this
+    only after :func:`has_agent_mention` returns ``False``.
+    """
+    for handle in _iter_mention_handles(body):
+        normalized = handle.strip().lower()
+        if normalized in RECOGNIZED_AGENT_HANDLES:
+            continue
+        if _AGENT_LIKE_HANDLE_PATTERN.fullmatch(normalized.replace("_", "-")):
+            return handle
+    return None
 
 
 @dataclass(frozen=True)
@@ -213,8 +280,15 @@ def _route_issue_comment(payload: dict[str, Any]) -> RouteDecision:
         return RouteDecision(WORKFLOW_VERIFY_PR_COMMENT, "/oz-verify on PR comment")
     if has_oz_review_command(body):
         return RouteDecision(WORKFLOW_REVIEW_PR, "/oz-review on PR comment")
-    if OZ_AGENT_MENTION in body:
-        return RouteDecision(WORKFLOW_RESPOND_TO_PR_COMMENT, "@oz-agent mention on PR")
+    if has_agent_mention(body):
+        return RouteDecision(WORKFLOW_RESPOND_TO_PR_COMMENT, "agent mention on PR")
+    unknown_handle = find_unrecognized_agent_mention(body)
+    if unknown_handle is not None:
+        return RouteDecision(
+            WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION,
+            f"unrecognized agent handle @{unknown_handle} on PR comment",
+            extra={"mentioned_handle": unknown_handle},
+        )
     return RouteDecision(None, "PR comment without Oz command or mention")
 
 
@@ -239,7 +313,7 @@ def _route_plain_issue_comment(
     picks up the new context the reporter just supplied.
     """
     labels = _label_names(issue.get("labels"))
-    has_mention = OZ_AGENT_MENTION in body
+    has_mention = has_agent_mention(body)
     if has_mention:
         # ``ready-to-implement`` and ``ready-to-spec`` issues are
         # already past triage — a maintainer pinging ``@oz-agent``
@@ -465,10 +539,17 @@ def _route_pull_request_review_comment(payload: dict[str, Any]) -> RouteDecision
         return RouteDecision(WORKFLOW_REVIEW_PR, "/oz-review on review comment")
     if OZ_VERIFY_COMMAND in body:
         return RouteDecision(WORKFLOW_VERIFY_PR_COMMENT, "/oz-verify on review comment")
-    if OZ_AGENT_MENTION in body:
+    if has_agent_mention(body):
         return RouteDecision(
             WORKFLOW_RESPOND_TO_PR_COMMENT,
-            "@oz-agent mention on review comment",
+            "agent mention on review comment",
+        )
+    unknown_handle = find_unrecognized_agent_mention(body)
+    if unknown_handle is not None:
+        return RouteDecision(
+            WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION,
+            f"unrecognized agent handle @{unknown_handle} on review comment",
+            extra={"mentioned_handle": unknown_handle},
         )
     return RouteDecision(None, "review comment without Oz command or mention")
 
@@ -483,8 +564,15 @@ def _route_pull_request_review(payload: dict[str, Any]) -> RouteDecision:
     if _is_bot(review.get("user")):
         return RouteDecision(None, "review authored by automation user")
     body = str(review.get("body") or "")
-    if OZ_AGENT_MENTION in body:
-        return RouteDecision(WORKFLOW_RESPOND_TO_PR_COMMENT, "@oz-agent mention in PR review body")
+    if has_agent_mention(body):
+        return RouteDecision(WORKFLOW_RESPOND_TO_PR_COMMENT, "agent mention in PR review body")
+    unknown_handle = find_unrecognized_agent_mention(body)
+    if unknown_handle is not None:
+        return RouteDecision(
+            WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION,
+            f"unrecognized agent handle @{unknown_handle} in PR review body",
+            extra={"mentioned_handle": unknown_handle},
+        )
     return RouteDecision(None, "review body without Oz mention")
 
 
@@ -535,8 +623,11 @@ __all__ = [
     "PLAN_APPROVED_LABEL",
     "READY_TO_IMPLEMENT_LABEL",
     "READY_TO_SPEC_LABEL",
+    "RECOGNIZED_AGENT_HANDLES",
     "RouteDecision",
     "TRIAGED_LABEL",
+    "WARP_AGENT_MENTION",
+    "WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION",
     "WORKFLOW_ANNOUNCE_READY_ISSUE",
     "WORKFLOW_CREATE_IMPLEMENTATION_FROM_ISSUE",
     "WORKFLOW_CREATE_SPEC_FROM_ISSUE",
@@ -545,6 +636,8 @@ __all__ = [
     "WORKFLOW_REVIEW_PR",
     "WORKFLOW_TRIAGE_NEW_ISSUES",
     "WORKFLOW_VERIFY_PR_COMMENT",
+    "find_unrecognized_agent_mention",
+    "has_agent_mention",
     "has_oz_review_command",
     "needs_triage_bot_author_allowlist",
     "route_event",

--- a/core/workflows/acknowledge_unknown_mention.py
+++ b/core/workflows/acknowledge_unknown_mention.py
@@ -1,0 +1,196 @@
+"""Synchronous handler for the ``acknowledge-unknown-mention`` webhook flow.
+
+The webhook routes a PR conversation comment, inline review comment, or
+PR review body to this handler when it mentions a handle that *looks*
+like the Oz agent but is not recognized — for example the pre-rebrand
+typo ``@warp-bot`` or a mistyped ``@ozagent``. The recognized handles
+(``@oz-agent`` and the legacy ``@warp-agent`` alias) are handled by the
+``respond-to-pr-comment`` flow instead.
+
+Before this handler existed, an unrecognized handle was dropped
+silently, so a user who typed the wrong handle got no agent response and
+no error and assumed the integration was down. This handler closes that
+gap by posting a one-shot acknowledgement comment that tells the user the
+mention was received but not recognized, and points them at the correct
+``@oz-agent`` handle.
+
+The handler is fully synchronous — there is no cloud agent to dispatch —
+and runs inline inside the Vercel webhook function. Idempotency is
+enforced via a metadata marker keyed on the triggering comment/review id
+so retried webhook deliveries (or multiple unrecognized mentions on the
+same PR) do not double-post.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Mapping
+
+from github.Repository import Repository
+
+from core.routing import find_unrecognized_agent_mention
+
+logger = logging.getLogger(__name__)
+
+WORKFLOW_NAME = "acknowledge-unknown-mention"
+OZ_AGENT_MENTION = "@oz-agent"
+WARP_AGENT_MENTION = "@warp-agent"
+
+
+def _resolve_pr_number(payload: Mapping[str, Any]) -> int:
+    """Return the PR/issue number the triggering comment lives on."""
+    pull_request = payload.get("pull_request")
+    if isinstance(pull_request, dict) and pull_request.get("number") is not None:
+        return int(pull_request.get("number") or 0)
+    issue = payload.get("issue")
+    if isinstance(issue, dict) and issue.get("number") is not None:
+        return int(issue.get("number") or 0)
+    return 0
+
+
+def _resolve_trigger(payload: Mapping[str, Any]) -> tuple[int, str]:
+    """Return the ``(id, body)`` of the comment or review that triggered the event."""
+    comment = payload.get("comment")
+    if isinstance(comment, dict):
+        return int(comment.get("id") or 0), str(comment.get("body") or "")
+    review = payload.get("review")
+    if isinstance(review, dict):
+        return int(review.get("id") or 0), str(review.get("body") or "")
+    return 0, ""
+
+
+def _acknowledgement_metadata(pr_number: int, trigger_comment_id: int) -> str:
+    """Return the idempotency metadata marker for an acknowledgement.
+
+    The marker embeds the triggering comment/review id so each
+    unrecognized mention is acknowledged at most once even when the same
+    PR receives several of them, while retried webhook deliveries for the
+    same comment stay deduplicated.
+    """
+    payload: dict[str, Any] = {
+        "type": "issue-status",
+        "workflow": WORKFLOW_NAME,
+        "issue": int(pr_number),
+        "trigger_comment": int(trigger_comment_id),
+    }
+    return f"<!-- oz-agent-metadata: {json.dumps(payload, separators=(',', ':'))} -->"
+
+
+def _build_acknowledgement_body(handle: str) -> str:
+    """Return the acknowledgement comment body for an unrecognized *handle*."""
+    return (
+        f"I noticed you mentioned `@{handle}`, which isn't a handle I "
+        "recognize, so I didn't start a run. To have me take a look, "
+        f"mention `{OZ_AGENT_MENTION}` (the legacy `{WARP_AGENT_MENTION}` "
+        "handle works too)."
+    )
+
+
+def _existing_acknowledgement(issue_handle: Any, *, marker: str) -> Any | None:
+    """Return a prior acknowledgement comment matching *marker*, if any."""
+    try:
+        comments = list(issue_handle.get_comments())
+    except Exception:
+        logger.exception(
+            "Failed to list comments while deduping acknowledge-unknown-mention post"
+        )
+        return None
+    for comment in comments:
+        body = str(getattr(comment, "body", "") or "")
+        if marker in body:
+            return comment
+    return None
+
+
+def apply_acknowledge_unknown_mention_sync(
+    repo_handle: Repository,
+    *,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Run the synchronous side effect for an ``acknowledge-unknown-mention`` event.
+
+    Returns a structured outcome the webhook surfaces in the 202 response
+    body. The handler always returns a non-``None`` outcome because the
+    webhook never falls through to a cloud-agent dispatch for this
+    workflow.
+
+    Outcomes:
+
+    - ``{"action": "skipped", "reason": ...}`` when the payload is
+      malformed (missing PR number / repository) or the triggering body
+      no longer carries an unrecognized agent-like mention.
+    - ``{"action": "acknowledged", ...}`` when a fresh acknowledgement
+      comment was posted.
+    - ``{"action": "noop", ...}`` when a prior acknowledgement already
+      exists for the same triggering comment.
+    """
+    pr_number = _resolve_pr_number(payload)
+    if pr_number <= 0:
+        return {"action": "skipped", "reason": "missing PR/issue number"}
+
+    repo_payload = payload.get("repository") or {}
+    full_name = str(repo_payload.get("full_name") or "")
+    if "/" not in full_name:
+        return {
+            "action": "skipped",
+            "reason": "missing repository.full_name",
+            "pr_number": pr_number,
+        }
+    owner, repo = full_name.split("/", 1)
+
+    trigger_comment_id, body = _resolve_trigger(payload)
+    handle = find_unrecognized_agent_mention(body)
+    if handle is None:
+        return {
+            "action": "skipped",
+            "reason": "no unrecognized agent mention in trigger body",
+            "pr_number": pr_number,
+        }
+
+    issue_handle = repo_handle.get_issue(int(pr_number))
+
+    # Idempotency: skip the post when a prior acknowledgement already
+    # exists for this triggering comment. The marker pins the dedupe to
+    # this workflow + comment so retried deliveries do not double-post,
+    # while a different unrecognized mention on the same PR still gets
+    # its own acknowledgement.
+    marker = _acknowledgement_metadata(pr_number, trigger_comment_id)
+    if _existing_acknowledgement(issue_handle, marker=marker) is not None:
+        return {
+            "action": "noop",
+            "reason": "acknowledgement already posted for this comment",
+            "pr_number": pr_number,
+            "mentioned_handle": handle,
+        }
+
+    comment_body = _build_acknowledgement_body(handle)
+    try:
+        issue_handle.create_comment(f"{comment_body}\n\n{marker}")
+    except Exception:
+        logger.exception(
+            "Failed to post unknown-mention acknowledgement on PR #%s in %s/%s",
+            pr_number,
+            owner,
+            repo,
+        )
+        return {
+            "action": "skipped",
+            "reason": "failed to post acknowledgement comment",
+            "pr_number": pr_number,
+            "mentioned_handle": handle,
+        }
+
+    return {
+        "action": "acknowledged",
+        "pr_number": pr_number,
+        "mentioned_handle": handle,
+    }
+
+
+__all__ = [
+    "OZ_AGENT_MENTION",
+    "WARP_AGENT_MENTION",
+    "WORKFLOW_NAME",
+    "apply_acknowledge_unknown_mention_sync",
+]

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -44,7 +44,9 @@ The verification role uses [`verify-pr`](../.agents/skills/verify-pr/SKILL.md) a
 
 ### PR comment response
 
-The `respond-to-pr-comment` workflow handles `@oz-agent` mentions on PR conversations, inline review comments, and review bodies. It uses the implementation skill family with PR context and any available spec context.
+The `respond-to-pr-comment` workflow handles `@oz-agent` mentions (and the legacy `@warp-agent` alias, kept after the rebrand) on PR conversations, inline review comments, and review bodies. It uses the implementation skill family with PR context and any available spec context.
+
+When a PR comment, review comment, or review body mentions an agent-*like* handle that is not recognized — for example the pre-rebrand `@warp-bot` typo or a mistyped `@ozagent` — the `acknowledge-unknown-mention` synchronous path posts a one-shot comment letting the commenter know the mention was received but not recognized and points them at `@oz-agent`, instead of silently doing nothing.
 
 ## Repo-local companions
 
@@ -63,6 +65,7 @@ Each loop has a narrow write surface and keeps the core cross-repo skills stable
 Some routed webhook branches perform deterministic GitHub mutations without dispatching an Oz run:
 
 - `announce-ready-issue` posts fixed availability guidance when `ready-to-spec` or `ready-to-implement` is added without assigning `oz-agent`.
+- `acknowledge-unknown-mention` posts a one-shot comment when a PR mention uses an unrecognized but agent-like handle (e.g. `@warp-bot`), so the mention is acknowledged rather than dropped.
 - `plan-approved` performs approval bookkeeping synchronously and only falls through to implementation dispatch when the linked issue is ready.
 
 ## In one sentence

--- a/tests/test_acknowledge_unknown_mention.py
+++ b/tests/test_acknowledge_unknown_mention.py
@@ -1,0 +1,208 @@
+"""Tests for ``workflows.acknowledge_unknown_mention``.
+
+The webhook handler invokes ``apply_acknowledge_unknown_mention_sync``
+synchronously whenever a PR comment, review comment, or review body
+mentions an agent-like-but-unrecognized handle (for example the
+pre-rebrand ``@warp-bot`` typo). The helper posts a one-shot
+acknowledgement comment pointing the user at ``@oz-agent`` and never
+falls through to a cloud-agent dispatch.
+
+These tests exercise the helper's branching (acknowledged vs. noop vs.
+skipped) with a stubbed GitHub repo handle.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from . import conftest  # noqa: F401
+
+from workflows.acknowledge_unknown_mention import (
+    apply_acknowledge_unknown_mention_sync,
+)
+
+
+def _comment(body: str) -> Any:
+    return SimpleNamespace(body=body)
+
+
+def _issue_handle(*, comments: list[str] | None = None) -> Any:
+    handle = MagicMock(name="issue")
+    handle.get_comments.return_value = [_comment(body) for body in (comments or [])]
+    return handle
+
+
+def _repo_handle(*, issue: Any) -> Any:
+    handle = MagicMock(name="repo_handle")
+    handle.get_issue.return_value = issue
+    return handle
+
+
+def _pr_comment_payload(
+    *,
+    body: str = "@warp-bot please fix lint",
+    pr_number: int = 42,
+    comment_id: int = 7,
+    full_name: str = "acme/widgets",
+) -> dict[str, Any]:
+    return {
+        "action": "created",
+        "repository": {"full_name": full_name},
+        "installation": {"id": 1234},
+        "issue": {"number": pr_number, "pull_request": {"url": "..."}},
+        "comment": {
+            "id": comment_id,
+            "body": body,
+            "user": {"login": "alice", "type": "User"},
+        },
+    }
+
+
+def _review_payload(
+    *,
+    body: str = "@ozagent please update",
+    pr_number: int = 42,
+    review_id: int = 9,
+    full_name: str = "acme/widgets",
+) -> dict[str, Any]:
+    return {
+        "action": "submitted",
+        "repository": {"full_name": full_name},
+        "installation": {"id": 1234},
+        "pull_request": {"number": pr_number},
+        "review": {
+            "id": review_id,
+            "body": body,
+            "user": {"login": "alice", "type": "User"},
+        },
+    }
+
+
+class ApplyAcknowledgeUnknownMentionSyncTest(unittest.TestCase):
+    def test_acknowledges_unrecognized_handle_on_pr_comment(self) -> None:
+        issue = _issue_handle()
+        repo_handle = _repo_handle(issue=issue)
+
+        result = apply_acknowledge_unknown_mention_sync(
+            repo_handle, payload=_pr_comment_payload()
+        )
+
+        self.assertEqual(result["action"], "acknowledged")
+        self.assertEqual(result["pr_number"], 42)
+        self.assertEqual(result["mentioned_handle"], "warp-bot")
+        repo_handle.get_issue.assert_called_once_with(42)
+        issue.create_comment.assert_called_once()
+        body = issue.create_comment.call_args.args[0]
+        self.assertIn("@warp-bot", body)
+        self.assertIn("@oz-agent", body)
+        # The idempotency marker is embedded so retries can dedupe.
+        self.assertIn('"workflow":"acknowledge-unknown-mention"', body)
+        self.assertIn('"trigger_comment":7', body)
+
+    def test_acknowledges_unrecognized_handle_in_review_body(self) -> None:
+        issue = _issue_handle()
+        repo_handle = _repo_handle(issue=issue)
+
+        result = apply_acknowledge_unknown_mention_sync(
+            repo_handle, payload=_review_payload()
+        )
+
+        self.assertEqual(result["action"], "acknowledged")
+        self.assertEqual(result["mentioned_handle"], "ozagent")
+        body = issue.create_comment.call_args.args[0]
+        self.assertIn('"trigger_comment":9', body)
+
+    def test_idempotent_when_acknowledgement_already_posted(self) -> None:
+        # A prior acknowledgement carrying the same trigger-comment marker
+        # suppresses a duplicate post when the webhook redelivers.
+        prior = (
+            "Already acknowledged.\n\n"
+            '<!-- oz-agent-metadata: {"type":"issue-status",'
+            '"workflow":"acknowledge-unknown-mention","issue":42,'
+            '"trigger_comment":7} -->'
+        )
+        issue = _issue_handle(comments=[prior])
+        repo_handle = _repo_handle(issue=issue)
+
+        result = apply_acknowledge_unknown_mention_sync(
+            repo_handle, payload=_pr_comment_payload()
+        )
+
+        self.assertEqual(result["action"], "noop")
+        self.assertEqual(result["pr_number"], 42)
+        issue.create_comment.assert_not_called()
+
+    def test_distinct_comment_still_acknowledged(self) -> None:
+        # A prior acknowledgement for a *different* triggering comment must
+        # not suppress acknowledging a new one on the same PR.
+        prior = (
+            "Already acknowledged a different comment.\n\n"
+            '<!-- oz-agent-metadata: {"type":"issue-status",'
+            '"workflow":"acknowledge-unknown-mention","issue":42,'
+            '"trigger_comment":1} -->'
+        )
+        issue = _issue_handle(comments=[prior])
+        repo_handle = _repo_handle(issue=issue)
+
+        result = apply_acknowledge_unknown_mention_sync(
+            repo_handle, payload=_pr_comment_payload(comment_id=7)
+        )
+
+        self.assertEqual(result["action"], "acknowledged")
+        issue.create_comment.assert_called_once()
+
+    def test_skips_when_no_unrecognized_mention(self) -> None:
+        issue = _issue_handle()
+        repo_handle = _repo_handle(issue=issue)
+
+        result = apply_acknowledge_unknown_mention_sync(
+            repo_handle, payload=_pr_comment_payload(body="thanks, looks good")
+        )
+
+        self.assertEqual(result["action"], "skipped")
+        issue.create_comment.assert_not_called()
+
+    def test_skips_when_repository_full_name_missing(self) -> None:
+        issue = _issue_handle()
+        repo_handle = _repo_handle(issue=issue)
+        payload = _pr_comment_payload()
+        payload["repository"] = {"full_name": ""}
+
+        result = apply_acknowledge_unknown_mention_sync(
+            repo_handle, payload=payload
+        )
+
+        self.assertEqual(result["action"], "skipped")
+        self.assertIn("repository.full_name", result["reason"])
+        issue.create_comment.assert_not_called()
+
+    def test_skips_when_pr_number_missing(self) -> None:
+        repo_handle = _repo_handle(issue=_issue_handle())
+        payload = _pr_comment_payload()
+        payload["issue"] = {"pull_request": {"url": "..."}}
+
+        result = apply_acknowledge_unknown_mention_sync(
+            repo_handle, payload=payload
+        )
+
+        self.assertEqual(result["action"], "skipped")
+        self.assertIn("PR/issue number", result["reason"])
+
+    def test_skips_when_comment_post_fails(self) -> None:
+        issue = _issue_handle()
+        issue.create_comment.side_effect = RuntimeError("github outage")
+        repo_handle = _repo_handle(issue=issue)
+
+        result = apply_acknowledge_unknown_mention_sync(
+            repo_handle, payload=_pr_comment_payload()
+        )
+
+        self.assertEqual(result["action"], "skipped")
+        self.assertIn("failed to post", result["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -17,6 +17,7 @@ from core.routing import (
     AUTO_IMPLEMENT_LABEL,
     OZ_AGENT_LOGIN,
     RouteDecision,
+    WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION,
     WORKFLOW_ANNOUNCE_READY_ISSUE,
     WORKFLOW_CREATE_IMPLEMENTATION_FROM_ISSUE,
     WORKFLOW_CREATE_SPEC_FROM_ISSUE,
@@ -25,6 +26,8 @@ from core.routing import (
     WORKFLOW_REVIEW_PR,
     WORKFLOW_TRIAGE_NEW_ISSUES,
     WORKFLOW_VERIFY_PR_COMMENT,
+    find_unrecognized_agent_mention,
+    has_agent_mention,
     route_event,
 )
 
@@ -502,6 +505,49 @@ class IssueCommentEventTest(unittest.TestCase):
         )
         self.assertEqual(decision.workflow, WORKFLOW_RESPOND_TO_PR_COMMENT)
 
+    def test_warp_agent_alias_on_pr_routes_to_respond_to_pr_comment(self) -> None:
+        # The legacy ``@warp-agent`` handle is kept as an alias after the
+        # rebrand so mentions written before the change still trigger a run.
+        decision = route_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": _issue(pull_request={"url": "..."}),
+                "comment": _comment(body="@warp-agent please fix clippy/lint issues"),
+            },
+        )
+        self.assertEqual(decision.workflow, WORKFLOW_RESPOND_TO_PR_COMMENT)
+
+    def test_warp_agent_review_alias_on_pr_routes_to_review(self) -> None:
+        decision = route_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": _issue(pull_request={"url": "..."}),
+                "comment": _comment(body="please @warp-agent /review"),
+            },
+        )
+        self.assertEqual(decision.workflow, WORKFLOW_REVIEW_PR)
+
+    def test_unrecognized_agent_handle_on_pr_routes_to_acknowledge(self) -> None:
+        # An agent-like but unrecognized handle (e.g. the pre-rebrand
+        # ``@warp-bot`` typo) should surface a clarifying acknowledgement
+        # instead of being silently dropped.
+        decision = route_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": _issue(pull_request={"url": "..."}),
+                "comment": _comment(body="@warp-bot please fix lint"),
+            },
+        )
+        self.assertEqual(
+            decision.workflow, WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION
+        )
+        self.assertEqual(
+            (decision.extra or {}).get("mentioned_handle"), "warp-bot"
+        )
+
     def test_pr_comment_without_command_or_mention_skipped(self) -> None:
         decision = route_event(
             "issue_comment",
@@ -509,6 +555,19 @@ class IssueCommentEventTest(unittest.TestCase):
                 "action": "created",
                 "issue": _issue(pull_request={"url": "..."}),
                 "comment": _comment(body="thanks for the feedback"),
+            },
+        )
+        self.assertIsNone(decision.workflow)
+
+    def test_unrelated_mention_on_pr_is_not_acknowledged(self) -> None:
+        # A non-agent mention (a normal teammate) must not trigger an
+        # acknowledgement; only agent-like handles do.
+        decision = route_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": _issue(pull_request={"url": "..."}),
+                "comment": _comment(body="cc @alice can you take a look"),
             },
         )
         self.assertIsNone(decision.workflow)
@@ -585,6 +644,18 @@ class IssueCommentEventTest(unittest.TestCase):
                 "action": "created",
                 "issue": _issue(labels=[]),
                 "comment": _comment(body="@oz-agent please look"),
+            },
+        )
+        self.assertEqual(decision.workflow, WORKFLOW_TRIAGE_NEW_ISSUES)
+
+    def test_warp_agent_alias_on_plain_issue_routes_to_triage(self) -> None:
+        # The legacy alias works on plain issues too.
+        decision = route_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": _issue(labels=[]),
+                "comment": _comment(body="@warp-agent please look"),
             },
         )
         self.assertEqual(decision.workflow, WORKFLOW_TRIAGE_NEW_ISSUES)
@@ -844,6 +915,31 @@ class PullRequestReviewCommentTest(unittest.TestCase):
         )
         self.assertEqual(decision.workflow, WORKFLOW_RESPOND_TO_PR_COMMENT)
 
+    def test_warp_agent_alias_routes_to_respond_to_pr_comment(self) -> None:
+        decision = route_event(
+            "pull_request_review_comment",
+            {
+                "action": "created",
+                "comment": _comment(body="@warp-agent address this"),
+            },
+        )
+        self.assertEqual(decision.workflow, WORKFLOW_RESPOND_TO_PR_COMMENT)
+
+    def test_unrecognized_handle_routes_to_acknowledge(self) -> None:
+        decision = route_event(
+            "pull_request_review_comment",
+            {
+                "action": "created",
+                "comment": _comment(body="@ozagent address this"),
+            },
+        )
+        self.assertEqual(
+            decision.workflow, WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION
+        )
+        self.assertEqual(
+            (decision.extra or {}).get("mentioned_handle"), "ozagent"
+        )
+
     def test_no_command_or_mention_skipped(self) -> None:
         decision = route_event(
             "pull_request_review_comment",
@@ -885,6 +981,31 @@ class PullRequestReviewTest(unittest.TestCase):
             },
         )
         self.assertEqual(decision.workflow, WORKFLOW_RESPOND_TO_PR_COMMENT)
+
+    def test_warp_agent_alias_in_review_body_routes_to_respond_to_pr_comment(self) -> None:
+        decision = route_event(
+            "pull_request_review",
+            {
+                "action": "submitted",
+                "review": _comment(body="@warp-agent please update this"),
+            },
+        )
+        self.assertEqual(decision.workflow, WORKFLOW_RESPOND_TO_PR_COMMENT)
+
+    def test_unrecognized_handle_in_review_body_routes_to_acknowledge(self) -> None:
+        decision = route_event(
+            "pull_request_review",
+            {
+                "action": "submitted",
+                "review": _comment(body="@oz_agent please update this"),
+            },
+        )
+        self.assertEqual(
+            decision.workflow, WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION
+        )
+        self.assertEqual(
+            (decision.extra or {}).get("mentioned_handle"), "oz_agent"
+        )
 
     def test_review_body_without_mention_is_dropped(self) -> None:
         decision = route_event(
@@ -935,6 +1056,37 @@ class RouteDecisionDefaultsTest(unittest.TestCase):
         # logging. The dataclass must accept it without breaking.
         decision = RouteDecision(workflow=None, reason="skip", extra={"trigger": "labeled"})
         self.assertEqual(decision.extra, {"trigger": "labeled"})
+
+
+class AgentMentionHelpersTest(unittest.TestCase):
+    """Unit coverage for the mention-detection helpers."""
+
+    def test_recognized_handles(self) -> None:
+        self.assertTrue(has_agent_mention("ping @oz-agent here"))
+        self.assertTrue(has_agent_mention("ping @warp-agent here"))
+        self.assertTrue(has_agent_mention("(@OZ-Agent)"))  # case-insensitive + punctuation
+
+    def test_non_agent_mentions_are_not_recognized(self) -> None:
+        self.assertFalse(has_agent_mention("cc @alice"))
+        self.assertFalse(has_agent_mention("email me at foo@oz-agent.com"))
+        self.assertFalse(has_agent_mention("no mentions at all"))
+        # A longer handle that merely starts with the recognized text.
+        self.assertFalse(has_agent_mention("@oz-agentx hello"))
+
+    def test_unrecognized_agent_like_handles(self) -> None:
+        self.assertEqual(find_unrecognized_agent_mention("@warp-bot go"), "warp-bot")
+        self.assertEqual(find_unrecognized_agent_mention("@ozagent go"), "ozagent")
+        self.assertEqual(find_unrecognized_agent_mention("@oz_agent go"), "oz_agent")
+        self.assertEqual(find_unrecognized_agent_mention("@warp-ai go"), "warp-ai")
+
+    def test_recognized_handles_are_not_flagged_as_unrecognized(self) -> None:
+        self.assertIsNone(find_unrecognized_agent_mention("@oz-agent go"))
+        self.assertIsNone(find_unrecognized_agent_mention("@warp-agent go"))
+
+    def test_unrelated_mentions_are_not_flagged(self) -> None:
+        self.assertIsNone(find_unrecognized_agent_mention("cc @alice"))
+        self.assertIsNone(find_unrecognized_agent_mention("@warp please"))  # bare product name
+        self.assertIsNone(find_unrecognized_agent_mention("@deploy-agent"))  # unrelated -agent user
 
 
 if __name__ == "__main__":

--- a/tests/test_webhook_dispatch.py
+++ b/tests/test_webhook_dispatch.py
@@ -22,6 +22,7 @@ from . import conftest  # noqa: F401
 from api.webhook import process_webhook_request
 from core.dispatch import DispatchRequest
 from core.routing import (
+    WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION,
     WORKFLOW_ANNOUNCE_READY_ISSUE,
     WORKFLOW_PLAN_APPROVED,
     WORKFLOW_REVIEW_PR,
@@ -546,6 +547,107 @@ class SynchronousAnnounceReadyIssuePathTest(unittest.TestCase):
         self.assertEqual(response.status, 500)
         self.assertIn(
             "announce-ready-issue path failed", response.body["error"]
+        )
+
+
+class SynchronousAcknowledgeUnknownMentionPathTest(unittest.TestCase):
+    def _payload(self, *, body: str = "@warp-bot please fix lint") -> dict[str, Any]:
+        return {
+            "action": "created",
+            "repository": {"full_name": "acme/widgets"},
+            "installation": {"id": 1234},
+            "issue": {"number": 42, "pull_request": {"url": "..."}},
+            "comment": {
+                "id": 7,
+                "body": body,
+                "user": {"login": "alice", "type": "User"},
+            },
+        }
+
+    def test_acknowledge_outcome_short_circuits_dispatch(self) -> None:
+        # The acknowledge-unknown-mention workflow is fully synchronous;
+        # the webhook never falls through to a cloud-agent dispatch so
+        # neither the builder nor the runner should be invoked.
+        body, signature = _signed_envelope(self._payload())
+
+        sync_calls: list[Mapping[str, Any]] = []
+
+        def sync_acknowledge(payload: Mapping[str, Any]) -> dict[str, Any]:
+            sync_calls.append(payload)
+            return {
+                "action": "acknowledged",
+                "pr_number": 42,
+                "mentioned_handle": "warp-bot",
+            }
+
+        runner_called = MagicMock(side_effect=AssertionError("should not run"))
+
+        response = process_webhook_request(
+            body=body,
+            signature_header=signature,
+            event_header="issue_comment",
+            delivery_id="delivery-aum-1",
+            secret=_SECRET,
+            builder_registry={},
+            runner=runner_called,
+            config_factory=lambda name, role: {},
+            store=InMemoryStateStore(),
+            sync_acknowledge_unknown_mention=sync_acknowledge,
+        )
+        self.assertEqual(response.status, 202)
+        self.assertEqual(
+            response.body["workflow"], WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION
+        )
+        self.assertEqual(
+            response.body["acknowledge_unknown_mention"]["action"],
+            "acknowledged",
+        )
+        self.assertEqual(len(sync_calls), 1)
+        runner_called.assert_not_called()
+
+    def test_returns_202_without_outcome_when_sync_helper_not_wired(self) -> None:
+        body, signature = _signed_envelope(self._payload())
+
+        runner_called = MagicMock(side_effect=AssertionError("should not run"))
+        response = process_webhook_request(
+            body=body,
+            signature_header=signature,
+            event_header="issue_comment",
+            delivery_id="delivery-aum-2",
+            secret=_SECRET,
+            builder_registry={},
+            runner=runner_called,
+            config_factory=lambda name, role: {},
+            store=InMemoryStateStore(),
+        )
+        self.assertEqual(response.status, 202)
+        self.assertEqual(
+            response.body["workflow"], WORKFLOW_ACKNOWLEDGE_UNKNOWN_MENTION
+        )
+        self.assertNotIn("acknowledge_unknown_mention", response.body)
+        runner_called.assert_not_called()
+
+    def test_500_when_sync_acknowledge_raises(self) -> None:
+        body, signature = _signed_envelope(self._payload())
+
+        def exploding_sync(_payload: Mapping[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("github outage")
+
+        response = process_webhook_request(
+            body=body,
+            signature_header=signature,
+            event_header="issue_comment",
+            delivery_id="delivery-aum-3",
+            secret=_SECRET,
+            builder_registry={},
+            runner=lambda **_: SimpleNamespace(run_id="x"),
+            config_factory=lambda name, role: {},
+            store=InMemoryStateStore(),
+            sync_acknowledge_unknown_mention=exploding_sync,
+        )
+        self.assertEqual(response.status, 500)
+        self.assertIn(
+            "acknowledge-unknown-mention path failed", response.body["error"]
         )
 
 


### PR DESCRIPTION
## Summary

After the Oz rebrand, GitHub PR comments using the old `@warp-agent` handle stopped triggering anything and produced no feedback, so users assumed the integration was down ([REMOTE-1900](https://linear.app/warp/issue/REMOTE-1900); reported on a comment in warpdotdev/warp#10839). The correct handle is now `@oz-agent`.

This PR fixes both halves of the reported problem in the `oz-for-oss` webhook control plane:

### 1. `@warp-agent` works again as an alias for `@oz-agent`
- Recognized agent handles are now `{oz-agent, warp-agent}`, applied everywhere mentions are parsed: PR conversation comments, inline review comments, PR review bodies, and plain issues.
- The `/review` command form accepts both `@oz-agent /review` and `@warp-agent /review`.
- Mention parsing moved from a naive substring check to token-based matching, so near-miss handles like `@oz-agentx` and email-style `foo@oz-agent.com` are not mistaken for the bot.

### 2. Unrecognized agent-like mentions are acknowledged instead of dropped
- A PR comment / review comment / review body that mentions an agent-*like* but unrecognized handle (e.g. the pre-rebrand `@warp-bot`, or typos like `@ozagent` / `@oz_agent`) now routes to a new synchronous `acknowledge-unknown-mention` workflow.
- That workflow posts a one-shot comment telling the commenter the mention was received but not recognized and points them at `@oz-agent`. It is idempotent per triggering comment (via a metadata marker) so retries and multiple bad mentions don't double-post.
- Unrelated mentions (regular users, bare `@warp`) are intentionally not flagged to avoid pinging real people.

## Changes
- `core/routing.py`: `WARP_AGENT_MENTION`, `RECOGNIZED_AGENT_HANDLES`, `has_agent_mention`, `find_unrecognized_agent_mention`, updated review-command regex, `acknowledge-unknown-mention` route across PR comment / review comment / review body.
- `core/workflows/acknowledge_unknown_mention.py`: new synchronous handler (mirrors `announce-ready-issue`).
- `api/webhook.py`: wires the new synchronous path and `sync_acknowledge_unknown_mention` runtime closure.
- `docs/platform.md`: documents the alias and the new acknowledgement path.

## Testing
`python -m pytest tests` — 450 passed, 67 subtests passed. Added routing tests (alias + unrecognized handle across all surfaces), helper unit tests, a dedicated `test_acknowledge_unknown_mention.py`, and webhook dispatch tests for the new synchronous branch.

_Conversation: https://staging.warp.dev/conversation/57e07f29-2b98-446f-a849-a6e666ce0422_
_Run: https://oz.staging.warp.dev/runs/019eadc6-36bb-7705-b542-bc0f61275a46_

_This PR was generated with [Oz](https://warp.dev/oz)._
