### PR TITLE
fix: surface Warp session link when a PR-comment run completes with no work

### DIFF
--- a/core/workflow_adapters.py
+++ b/core/workflow_adapters.py
@@ -165,6 +165,18 @@ def handlers_for_workflow(
         client = _client_factory(state.installation_id, github_client_factory)
         repo_handle = client.get_repo(state.repo)
         progress = workflow.progress_for_state(repo_handle, state=state)
+        # Record the Oz session link onto the progress comment before
+        # applying the result. A run that reaches a terminal SUCCEEDED
+        # state on the first cron poll never passes through
+        # ``non_terminal_handler``, so without this the completion comment
+        # posted back to the PR/issue -- including the "completed with no
+        # work" message -- would omit the link back to the Warp
+        # conversation that explains what the agent did. ``run_adapter``
+        # derives its ``session_link`` from the progress comment, so this
+        # must run before the adapter is built. Mirrors the failure
+        # handler, which records the link before ``report_error``.
+        if run is not None:
+            record_session_link_safely(progress, run)
         run_adapter = workflow.run_adapter_for_state(state=state, progress=progress, run=run)
         try:
             workflow.apply_result(

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -296,6 +296,57 @@ class RespondHandlersTest(_HandlerTestBase):
         # posting onto the PR conversation.
         repo_handle.get_pull.assert_called_once_with(7)
 
+    def test_result_applier_records_session_link_for_terminal_run(self) -> None:
+        # A run that is already terminal on the first cron poll never
+        # passes through ``non_terminal_handler``. The applier must still
+        # record the session link so the completion comment posted back
+        # to the PR (including the "completed with no work" message)
+        # links to the Warp conversation that explains what the agent did.
+        from core.handlers import build_respond_handlers
+
+        github_client = MagicMock()
+        github_client.get_repo.return_value = MagicMock(name="repo")
+        handlers = build_respond_handlers(_factory(github_client))
+
+        state = _state(
+            "respond-to-pr-comment",
+            payload_subset={
+                "owner": "acme",
+                "repo": "widgets",
+                "pr_number": 7,
+                "head_branch": "feature",
+                "trigger_kind": "conversation",
+                "requester": "alice",
+                "progress_comment_id": 6543,
+            },
+        )
+        run = MagicMock(
+            state="SUCCEEDED",
+            session_link="https://app.warp.dev/run/abc",
+            run_id="oz-run-123",
+        )
+        handlers.result_applier(state=state, result={}, run=run)
+
+        helpers = sys.modules["oz.helpers"]
+        helpers.record_run_session_link.assert_called_once_with(  # type: ignore[attr-defined]
+            self.progress_instances[-1], run
+        )
+
+    def test_result_applier_skips_session_link_when_run_missing(self) -> None:
+        # Synchronous callers and tests may invoke the applier without a
+        # run handle; recording must be skipped rather than passing
+        # ``None`` into ``record_run_session_link``.
+        from core.handlers import build_respond_handlers
+
+        github_client = MagicMock()
+        github_client.get_repo.return_value = MagicMock(name="repo")
+        handlers = build_respond_handlers(_factory(github_client))
+
+        handlers.result_applier(state=_state("respond-to-pr-comment"), result={})
+
+        helpers = sys.modules["oz.helpers"]
+        helpers.record_run_session_link.assert_not_called()  # type: ignore[attr-defined]
+
 
 class VerifyHandlersTest(_HandlerTestBase):
     def test_artifact_loader_calls_load_run_artifact_with_report_filename(self) -> None:


### PR DESCRIPTION
## Summary
Addresses REMOTE-1909: when an Oz/ambient agent invoked from a GitHub PR completes without producing any work (or otherwise reaches a terminal state on the first cron poll), the comment posted back to the PR did not link to the Warp conversation explaining what happened, leaving the stale "I'm working on it" comment with no actionable resolution.

## Root cause
The cron poller already posts a completion comment for SUCCEEDED runs (`apply_pr_comment_result` → `progress.complete("I analyzed the request but did not produce any changes.")`) and an error comment for FAILED/ERROR/CANCELLED/EXPIRED runs (`failure_handler` → `report_error`). The failure and non-terminal handlers record the Warp session link onto the progress comment, but the **SUCCEEDED applier did not**.

The run adapter handed to `apply_result` derives its `session_link` from the progress comment (`oz/agent_workflow.py:make_run_adapter`). A run that is already terminal on the **first** poll never passes through `non_terminal_handler`, so the session link was never recorded and the no-work/completion comment had no pointer to the conversation that explains why no changes were produced.

## Change
In `core/workflow_adapters.py`, the SUCCEEDED `applier` now records the session link onto the progress comment (via the existing `record_session_link_safely`) before building the run adapter and applying the result — mirroring what the failure handler already does before `report_error`. This guarantees terminal/no-work completion comments link back to the Warp conversation regardless of how quickly the run finishes. The call is guarded for `run is not None` so synchronous callers that omit a run handle are unaffected.

## Scope note
This is the general, app-accessible-repo case. The separate known issue (everything routed to the OSS app which lacks access to private repos such as `warp-server`, causing GitHub API calls — and thus comment writes — to 404) is tracked independently.

## Tests
- Added `test_result_applier_records_session_link_for_terminal_run` and `test_result_applier_skips_session_link_when_run_missing` in `tests/test_handlers.py`.
- All handler/adapter/poll-runs/dispatch tests pass (56 tests).

_Conversation: https://staging.warp.dev/conversation/e32a0f4d-b9ce-4ed2-9111-3697b39cdca3_

_Run: https://oz.staging.warp.dev/runs/019eb2ed-39a1-7cd8-8847-d91aaa7b8b54_

_This PR was generated with [Oz](https://warp.dev/oz)._
