### PR TITLE
Surface PR author trust in the review prompt

### DIFF
--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -906,6 +906,12 @@ def _format_non_member_review_section(
     ).strip()
 
 
+def _author_trust_label(author_association: str) -> str:
+    """Return ``TRUSTED`` for org members/collaborators, else ``UNVERIFIED``."""
+    normalized = str(author_association or "").strip().upper()
+    return "TRUSTED" if normalized in ORG_MEMBER_ASSOCIATIONS else "UNVERIFIED"
+
+
 def _format_pr_description(
     *,
     pr_number: int,
@@ -916,11 +922,19 @@ def _format_pr_description(
     trigger_source: str,
     focus_line: str,
     issue_line: str,
+    author_login: str,
+    author_association: str,
 ) -> str:
     body = pr_body.strip() or "No description provided."
+    association = str(author_association or "").strip().upper() or "NONE"
+    author = author_login.strip() or "unknown"
+    author_line = (
+        f"@{author} [association={association}, trust={_author_trust_label(association)}]"
+    )
     return (
         f"# Pull Request #{pr_number}\n\n"
         f"- Title: {pr_title}\n"
+        f"- Author: {author_line}\n"
         f"- Base branch: {base_branch}\n"
         f"- Head branch: {head_branch}\n"
         f"- Trigger: {trigger_source}\n"
@@ -1151,6 +1165,7 @@ def gather_review_context(
     pr_author_login = str(
         getattr(getattr(pr, "user", None), "login", "") or ""
     )
+    pr_author_association = str(getattr(pr, "author_association", "") or "")
     non_member_review_section = ""
     stakeholders_entries: list[dict[str, Any]] = []
     pr_assignee_reviewers: list[str] = []
@@ -1216,6 +1231,8 @@ def gather_review_context(
         trigger_source=trigger_source,
         focus_line=focus_line,
         issue_line=issue_line,
+        author_login=pr_author_login,
+        author_association=pr_author_association,
     )
     pr_diff_text = _format_pr_diff(pr_files)
     # Resolve the spec context entirely through the GitHub API. The

--- a/tests/test_review_pr_reviewer_sampling.py
+++ b/tests/test_review_pr_reviewer_sampling.py
@@ -1070,6 +1070,34 @@ class RequiresHumanReviewerEscalationTest(unittest.TestCase):
                 pr = self._apply_approve(context)
                 pr.create_review_request.assert_not_called()
 
+    def test_pr_description_marks_member_author_trusted(self) -> None:
+        context = self._gather(
+            self._make_pr(
+                login="maintainer",
+                user_type="User",
+                association="MEMBER",
+                filenames=["core/app.py"],
+            )
+        )
+        self.assertIn(
+            "- Author: @maintainer [association=MEMBER, trust=TRUSTED]",
+            context["pr_description_text"],
+        )
+
+    def test_pr_description_marks_external_author_unverified(self) -> None:
+        context = self._gather(
+            self._make_pr(
+                login="contributor",
+                user_type="User",
+                association="CONTRIBUTOR",
+                filenames=["core/app.py"],
+            )
+        )
+        self.assertIn(
+            "- Author: @contributor [association=CONTRIBUTOR, trust=UNVERIFIED]",
+            context["pr_description_text"],
+        )
+
     def test_oz_authored_reject_stays_comment_event(self) -> None:
         context = self._gather(
             self._make_pr(


### PR DESCRIPTION
## Summary

Threads an explicit **author trust** signal into the PR review prompt so the cloud review agent can tell whether a PR was authored by a Warp organization member or an external contributor.

The review agent is explicitly instructed not to call GitHub, so today it has no membership signal at all. This adds an `Author` line to the PR description the agent already reads (`pr_description.txt`):

```
- Author: @octocat [association=MEMBER, trust=TRUSTED]
```

`trust` is `TRUSTED` when the GitHub `author_association` is in `ORG_MEMBER_ASSOCIATIONS` (`MEMBER`/`OWNER`/`COLLABORATOR`), and `UNVERIFIED` otherwise.

## Why

In #feedback-app, internal contributors ("warpers") have been getting `Request changes` on nearly every PR because the warp `review-pr-local` skill requires visual evidence (screenshots/recordings) for user-facing changes. The agreed fix is to keep that requirement for external contributors but drop it for org members. The skill had no way to distinguish the two — this change provides the signal. The companion skill change lives in `warpdotdev/warp`.

## Testing

- `python -m pytest tests` — 438 passed, 67 subtests passed.
- Added tests asserting the `Author` trust line renders `TRUSTED` for `MEMBER` authors and `UNVERIFIED` for external (`CONTRIBUTOR`) authors.

_Conversation: https://staging.warp.dev/conversation/484fda0c-894d-40f0-b9af-e9688acfb6fa_
_Run: https://oz.staging.warp.dev/runs/019ecd58-d020-7d93-9008-d5b4cb9fc0b2_

_This PR was generated with [Oz](https://warp.dev/oz)._
