### PR TITLE
Improve GitHub rate-limit handling in Oz PR review flow (REMOTE-2012)

### DIFF
--- a/core/workflow_adapters.py
+++ b/core/workflow_adapters.py
@@ -90,9 +90,11 @@ def record_session_link_safely(progress: Any, run: Any) -> None:
         )
 
 
-def report_workflow_error_with_progress(progress: Any) -> None:
+def report_workflow_error_with_progress(
+    progress: Any, *, retrigger_hint: str = ""
+) -> None:
     try:
-        progress.report_error()
+        progress.report_error(retrigger_hint=retrigger_hint)
     except Exception:
         logger.exception(
             "Failed to update workflow error comment for %s on issue #%s in %s/%s",
@@ -184,7 +186,8 @@ def handlers_for_workflow(
         repo_handle = client.get_repo(state.repo)
         progress = workflow.progress_for_state(repo_handle, state=state)
         record_session_link_safely(progress, run)
-        report_workflow_error_with_progress(progress)
+        retrigger_hint = str(getattr(workflow, "error_retrigger_hint", "") or "")
+        report_workflow_error_with_progress(progress, retrigger_hint=retrigger_hint)
 
     def non_terminal(*, state: RunState, run: Any) -> None:
         client = _client_factory(state.installation_id, github_client_factory)

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -242,9 +242,90 @@ class BaseWorkflow:
         return make_run_adapter(state=state, progress=progress, run=run)
 
 
+# Retrigger hint included in review-run error comments so users know how to
+# recover from a failed review without consulting the documentation.
+_REVIEW_ERROR_RETRIGGER_HINT = (
+    "Comment `/oz-review` on this pull request to try again."
+)
+
+
+def _is_github_rate_limit_error(exc: Exception) -> bool:
+    """Return True when *exc* looks like a GitHub API rate-limit response.
+
+    Detects both primary rate limits (HTTP 429 / ``RateLimitExceededException``)
+    and secondary rate limits (HTTP 403 with a rate-limit message) so the
+    caller can emit a more specific user-facing message in each case.
+    """
+    try:
+        from github.GithubException import GithubException, RateLimitExceededException
+    except ImportError:
+        return False
+    if isinstance(exc, RateLimitExceededException):
+        return True
+    if isinstance(exc, GithubException):
+        status = int(getattr(exc, "status", 0) or 0)
+        if status == 429:
+            return True
+        if status == 403:
+            # Secondary rate limit: GitHub returns 403 with a message such as
+            # "You have exceeded a secondary rate limit" or "rate limit".
+            data = getattr(exc, "data", None) or {}
+            message = str(
+                data.get("message") if isinstance(data, dict) else data
+            ).lower()
+            if "rate limit" in message or "secondary rate" in message:
+                return True
+    return False
+
+
+def _post_review_context_error_comment(
+    exc: Exception,
+    *,
+    repo_handle: Any,
+    pr_number: int,
+    requester: str,
+    full_name: str,
+) -> None:
+    """Post a user-facing error comment when review context gathering fails.
+
+    Called from :meth:`ReviewWorkflow.build_dispatch` when ``gather_review_context``
+    raises an exception (e.g. due to GitHub API rate-limiting). Posts a comment
+    on the PR so the user knows what happened and how to retry, instead of the
+    webhook silently returning a 500 with no user-visible feedback.
+    """
+    if _is_github_rate_limit_error(exc):
+        error_body = (
+            "GitHub API rate limits prevented Oz from gathering pull request context. "
+            "Please comment `/oz-review` to retry once rate limits reset "
+            "(usually within an hour)."
+        )
+    else:
+        error_body = (
+            "Oz encountered a GitHub API error while gathering pull request context. "
+            "Comment `/oz-review` to retry."
+        )
+    normalized_requester = (requester or "").strip().removeprefix("@")
+    sections: list[str] = []
+    if normalized_requester:
+        sections.append(f"@{normalized_requester}")
+    sections.append(error_body)
+    comment_body = "\n\n".join(sections)
+    try:
+        repo_handle.get_issue(pr_number).create_comment(comment_body)
+    except Exception:
+        logger.exception(
+            "review-pr: failed to post context-gathering error comment for %s PR #%s",
+            full_name,
+            pr_number,
+        )
+
+
 class ReviewWorkflow(BaseWorkflow):
     workflow = WORKFLOW_REVIEW_PR
     config_name = WORKFLOW_REVIEW_PR
+    # Retrigger hint included in run-failure error comments so users know
+    # they can comment /oz-review to try again after a transient failure.
+    error_retrigger_hint = _REVIEW_ERROR_RETRIGGER_HINT
 
     def build_dispatch(
         self,
@@ -342,16 +423,37 @@ class ReviewWorkflow(BaseWorkflow):
                 OWNERSHIP_REPO,
             )
             ownership_repo_handle = None
-        context = review_workflow.gather_review_context(
-            repo_handle,
-            owner=owner,
-            repo=repo,
-            pr_number=pr_number,
-            trigger_source=trigger_source,
-            requester=requester,
-            workspace_path=workspace_path or Path("/tmp"),
-            ownership_repo_handle=ownership_repo_handle,
-        )
+        try:
+            context = review_workflow.gather_review_context(
+                repo_handle,
+                owner=owner,
+                repo=repo,
+                pr_number=pr_number,
+                trigger_source=trigger_source,
+                requester=requester,
+                workspace_path=workspace_path or Path("/tmp"),
+                ownership_repo_handle=ownership_repo_handle,
+            )
+        except Exception as exc:
+            # GitHub API errors (e.g. rate-limiting) during context gathering
+            # would otherwise propagate as a silent 500 from the webhook handler
+            # with no user-visible feedback on the PR. Catch here, post a
+            # comment so the user knows to retry with /oz-review, and return
+            # None to skip dispatch for this delivery.
+            logger.exception(
+                "review-pr: failed to gather review context for %s PR #%s; "
+                "posting error comment and skipping dispatch",
+                full_name,
+                pr_number,
+            )
+            _post_review_context_error_comment(
+                exc,
+                repo_handle=repo_handle,
+                pr_number=pr_number,
+                requester=requester,
+                full_name=full_name,
+            )
+            return None
         return WorkflowDispatch(
             workflow=self.workflow,
             repo=full_name,

--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -747,8 +747,7 @@ def _resolve_recommended_reviewers(
 # request another review by commenting ``/oz-review`` on the PR, subject
 # to the per-PR throttle enforced by ``resolve_review_context``.
 RETRIGGER_HINT = (
-    "Comment `/oz-review` on this pull request to retrigger a review "
-    "(up to 3 times on the same pull request)."
+    "Comment `/oz-review` on this pull request to request another review."
 )
 
 _STALE_REVIEW_DISMISSAL_MESSAGE = (

--- a/oz/helpers.py
+++ b/oz/helpers.py
@@ -704,7 +704,7 @@ class WorkflowProgressComment:
     def complete(self, status_line: str) -> None:
         self._append_sections([status_line])
 
-    def report_error(self) -> None:
+    def report_error(self, *, retrigger_hint: str = "") -> None:
         """Update the progress comment to indicate a workflow failure.
 
         ``report_error`` is the last-chance hook before the caller re-raises,
@@ -717,6 +717,10 @@ class WorkflowProgressComment:
         fallback comment write itself fails, surface the problem via logs
         and a CI-compatible ``::error::`` annotation instead of silently
         swallowing the exception.
+
+        *retrigger_hint* is an optional workflow-specific message (e.g.
+        "Comment `/oz-review` to try again.") appended after the error body
+        so users know how to recover without having to read workflow docs.
         """
         run_url = _workflow_run_url()
         if run_url:
@@ -731,6 +735,9 @@ class WorkflowProgressComment:
         if normalized_requester:
             sections.append(f"@{normalized_requester}")
         sections.append(message)
+        normalized_hint = (retrigger_hint or "").strip()
+        if normalized_hint:
+            sections.append(normalized_hint)
         if self.session_link:
             sections.append(_format_progress_link_section(self.session_link))
         body = build_comment_body("\n\n".join(sections), self.metadata)

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -135,6 +135,21 @@ class _BuilderTestBase(unittest.TestCase):
 class BuildReviewRequestTest(_BuilderTestBase):
     def setUp(self) -> None:
         super().setUp()
+        # ``ReviewWorkflow.build_dispatch`` lazily imports ``oz.ownership``
+        # to look up ``OWNERSHIP_REPO``. If not stubbed, the real
+        # ``oz/ownership.py`` is imported, which transitively imports
+        # ``oz/triage.py`` with ``from .helpers import get_field`` — that
+        # fails because ``oz.helpers`` is already stubbed as a bare module.
+        # Extend tracking so the stub is removed on tearDown.
+        self._module_keys.extend(["oz.ownership"])
+        self._original_modules["oz.ownership"] = sys.modules.get("oz.ownership")
+        oz_ownership = _ensure_module("oz.ownership")
+        oz_ownership.OWNERSHIP_REPO = "warpdotdev/warp-ownership"  # type: ignore[attr-defined]
+        oz_ownership.load_ownership_areas_from_repo = MagicMock(return_value=[])  # type: ignore[attr-defined]
+        oz_ownership.format_ownership_areas_for_prompt = MagicMock(  # type: ignore[attr-defined]
+            return_value=""
+        )
+        oz_ownership.ownership_area_lookup = MagicMock(return_value={})  # type: ignore[attr-defined]
         workflows = _ensure_module("workflows")
         review_module = _ensure_module("workflows.review_pr")
         workflows.review_pr = review_module  # type: ignore[attr-defined]
@@ -464,6 +479,119 @@ class BuildReviewRequestTest(_BuilderTestBase):
         review_module = sys.modules["workflows.review_pr"]
         review_module.enforce_pr_issue_state_for_review.assert_called_once()  # type: ignore[attr-defined]
         review_module.gather_review_context.assert_called_once()  # type: ignore[attr-defined]
+
+    def test_returns_none_and_posts_error_comment_when_gather_context_fails(self) -> None:
+        """When gather_review_context raises, dispatch is skipped with a user-facing comment.
+
+        The webhook handler would otherwise return a 500 with no user-visible
+        feedback. Catching here and posting a comment ensures the user knows
+        to retry with /oz-review.
+        """
+        from core.builders import build_review_request
+
+        github_client, repo, _pr = self._github_client_with_review_comments()
+        review_module = sys.modules["workflows.review_pr"]
+        review_module.gather_review_context.side_effect = RuntimeError(  # type: ignore[attr-defined]
+            "GitHub API error during diff fetch"
+        )
+
+        with self.assertLogs("core.workflows", level="ERROR"):
+            request = build_review_request(
+                self._payload(),
+                github_client=github_client,
+                workspace_path=Path("/tmp/ws"),
+            )
+
+        # Dispatch must be skipped.
+        self.assertIsNone(request)
+        # An error comment must be posted so the user knows to retry.
+        repo.get_issue.assert_called_with(42)
+        repo.get_issue.return_value.create_comment.assert_called_once()
+        comment_body: str = repo.get_issue.return_value.create_comment.call_args[0][0]
+        self.assertIn("/oz-review", comment_body)
+
+    def test_posts_rate_limit_message_when_gather_context_is_rate_limited(self) -> None:
+        """Rate-limit exceptions produce a specific rate-limit message in the error comment."""
+        from core.builders import build_review_request
+        from github.GithubException import RateLimitExceededException
+
+        github_client, repo, _pr = self._github_client_with_review_comments()
+        review_module = sys.modules["workflows.review_pr"]
+        review_module.gather_review_context.side_effect = RateLimitExceededException(  # type: ignore[attr-defined]
+            429, {"message": "API rate limit exceeded"}
+        )
+
+        with self.assertLogs("core.workflows", level="ERROR"):
+            request = build_review_request(
+                self._payload(),
+                github_client=github_client,
+                workspace_path=Path("/tmp/ws"),
+            )
+
+        self.assertIsNone(request)
+        repo.get_issue.assert_called_with(42)
+        comment_body: str = repo.get_issue.return_value.create_comment.call_args[0][0]
+        # The comment must mention rate limits and include the retrigger hint.
+        self.assertIn("rate limit", comment_body.lower())
+        self.assertIn("/oz-review", comment_body)
+
+    def test_requester_mention_included_in_context_error_comment(self) -> None:
+        """The requester login is @-mentioned in context-gathering error comments."""
+        from core.builders import build_review_request
+
+        payload = self._payload()
+        payload["sender"] = {"login": "alice"}
+        github_client, repo, _pr = self._github_client_with_review_comments()
+        review_module = sys.modules["workflows.review_pr"]
+        review_module.gather_review_context.side_effect = RuntimeError("API error")  # type: ignore[attr-defined]
+
+        with self.assertLogs("core.workflows", level="ERROR"):
+            request = build_review_request(
+                payload,
+                github_client=github_client,
+                workspace_path=Path("/tmp/ws"),
+            )
+
+        self.assertIsNone(request)
+        comment_body: str = repo.get_issue.return_value.create_comment.call_args[0][0]
+        self.assertIn("@alice", comment_body)
+
+
+class GithubRateLimitErrorDetectionTest(unittest.TestCase):
+    """Unit tests for the _is_github_rate_limit_error helper."""
+
+    def _detect(self, exc: Exception) -> bool:
+        from core.workflows import _is_github_rate_limit_error  # type: ignore[attr-defined]
+        return _is_github_rate_limit_error(exc)
+
+    def test_rate_limit_exception_detected(self) -> None:
+        from github.GithubException import RateLimitExceededException
+        exc = RateLimitExceededException(429, {"message": "rate limit exceeded"})
+        self.assertTrue(self._detect(exc))
+
+    def test_github_exception_with_429_detected(self) -> None:
+        from github.GithubException import GithubException
+        exc = GithubException(429, {"message": "rate limit exceeded"})
+        self.assertTrue(self._detect(exc))
+
+    def test_github_exception_403_with_rate_limit_message_detected(self) -> None:
+        from github.GithubException import GithubException
+        exc = GithubException(403, {"message": "You have exceeded a secondary rate limit"})
+        self.assertTrue(self._detect(exc))
+
+    def test_github_exception_403_without_rate_limit_message_not_detected(self) -> None:
+        from github.GithubException import GithubException
+        exc = GithubException(403, {"message": "Forbidden"})
+        self.assertFalse(self._detect(exc))
+
+    def test_generic_github_exception_500_not_detected(self) -> None:
+        from github.GithubException import GithubException
+        exc = GithubException(500, {"message": "Internal server error"})
+        self.assertFalse(self._detect(exc))
+
+    def test_non_github_exception_not_detected(self) -> None:
+        exc = RuntimeError("rate limit")
+        self.assertFalse(self._detect(exc))
 
 
 class BuildRespondRequestTest(_BuilderTestBase):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -112,6 +112,10 @@ class _HandlerTestBase(unittest.TestCase):
             self.progress_instances.append(instance)
             return instance
 
+        # ``core/workflows/__init__.py`` imports ENFORCEMENT_COMMENT_RUN_ID at
+        # module level; the stub must carry it so the first import of
+        # ``core.workflows`` in this test session succeeds.
+        helpers.ENFORCEMENT_COMMENT_RUN_ID = "pr-issue-state-enforcement"  # type: ignore[attr-defined]
         helpers.WorkflowProgressComment = MagicMock(  # type: ignore[attr-defined]
             side_effect=_progress_factory
         )
@@ -220,6 +224,21 @@ class ReviewHandlersTest(_HandlerTestBase):
         # uses it to surface the error message in-place.
         self.assertEqual(len(self.progress_instances), 1)
         self.progress_instances[0].report_error.assert_called_once()
+
+    def test_failure_handler_passes_review_retrigger_hint(self) -> None:
+        """The review failure handler passes a /oz-review retrigger hint to report_error."""
+        from core.handlers import build_review_handlers
+
+        github_client = MagicMock()
+        github_client.get_repo.return_value = MagicMock(name="repo")
+        handlers = build_review_handlers(_factory(github_client))
+
+        state = _state("review-pull-request")
+        handlers.failure_handler(state=state, run=MagicMock(state="FAILED"))
+
+        call_kwargs = self.progress_instances[0].report_error.call_args.kwargs
+        self.assertIn("retrigger_hint", call_kwargs)
+        self.assertIn("/oz-review", call_kwargs["retrigger_hint"])
 
     def test_non_terminal_handler_records_session_link(self) -> None:
         from core.handlers import build_review_handlers
@@ -405,6 +424,19 @@ class TriageHandlersTest(_HandlerTestBase):
         handlers.failure_handler(state=self._state(), run=MagicMock(state="FAILED"))
         self.assertEqual(len(self.progress_instances), 1)
         self.progress_instances[0].report_error.assert_called_once()
+
+    def test_failure_handler_passes_no_retrigger_hint_for_triage(self) -> None:
+        """Non-review workflows do not pass a retrigger hint to report_error."""
+        from core.handlers import build_triage_handlers
+
+        github_client = MagicMock()
+        github_client.get_repo.return_value = MagicMock(name="repo")
+        handlers = build_triage_handlers(_factory(github_client))
+        handlers.failure_handler(state=self._state(), run=MagicMock(state="FAILED"))
+
+        call_kwargs = self.progress_instances[0].report_error.call_args.kwargs
+        self.assertIn("retrigger_hint", call_kwargs)
+        self.assertEqual(call_kwargs["retrigger_hint"], "")
 
     def test_non_terminal_handler_records_session_link(self) -> None:
         from core.handlers import build_triage_handlers


### PR DESCRIPTION
## Summary

Fixes two issues related to GitHub rate-limiting in the Oz PR review flow (REMOTE-2012):

### Issue 1: Silent webhook failure when rate-limited during context gathering

When `gather_review_context` raises (e.g. due to GitHub API rate-limiting while fetching the PR diff or the local companion skill), the exception previously propagated through `evaluate_route` and the webhook handler returned a 500 with no user-visible feedback. The `/oz-review` retry appeared to "do nothing" because no new bot comment was ever created.

**Fix:** Wrap `gather_review_context` in `ReviewWorkflow.build_dispatch` with try/except. When any exception occurs, post a user-visible comment on the PR and return `None` to skip dispatch gracefully. Rate-limit errors (HTTP 429 / `RateLimitExceededException` / 403 with rate-limit body) get a specific message; other GitHub API errors get a generic message. Both mention `/oz-review` to retry.

### Issue 2: Generic "unexpected error" message with no recovery guidance

When a review run fails in the cloud agent (e.g. because GitHub rate-limits the Oz platform while loading the review skill), the error comment said "I ran into an unexpected error while working on this." with no hint on how to recover.

**Fix:** 
- Add `error_retrigger_hint` property to `ReviewWorkflow`. The failure handler in `handlers_for_workflow` reads this attribute and passes it to `report_error()`, which appends "Comment `/oz-review` on this pull request to try again." to the error message.
- Add `retrigger_hint: str = ""` parameter to `WorkflowProgressComment.report_error()` so any workflow can include a recovery hint.
- Non-review workflows pass an empty hint — no behavior change for triage, verify, etc.

### Bonus: Fix incorrect RETRIGGER_HINT count

The `RETRIGGER_HINT` constant said "up to 3 times on the same pull request" but the actual per-PR daily limit (`MAX_DAILY_REVIEW_INVOCATIONS`) is 5. Updated the hint text to not hardcode a count.

### Also: Fix pre-existing test environment issues

The handler and builder tests were broken in our test environment because:
- `oz.helpers` was stubbed in `_HandlerTestBase` without `ENFORCEMENT_COMMENT_RUN_ID` (imported at module level by `core/workflows/__init__.py`).
- `oz.ownership` was not stubbed in `BuildReviewRequestTest`, causing cascading real imports that hit the stubbed `oz.helpers`.

Both fixed by extending the stub setup.

_Conversation: https://staging.warp.dev/conversation/6eb5dc33-37b4-4466-b73d-50e841722115_
_Run: https://oz.staging.warp.dev/runs/019efb06-4d0e-7cf9-9dbb-cf88feac7c8f_

_This PR was generated with [Oz](https://warp.dev/oz)._
