### PR TITLE
Use linked issue assignee as deterministic PR reviewer

### DIFF
--- a/core/workflows/review_pr.py
+++ b/core/workflows/review_pr.py
@@ -554,6 +554,59 @@ def _reviewer_from_pr_assignee(
     return []
 
 
+def _resolve_linked_issue_assignee_logins(
+    github: Repository,
+    issue_number: int | None,
+    *,
+    pr_author_login: str,
+) -> list[str]:
+    """Return non-automation assignee logins from the linked issue.
+
+    These are the triagers assigned to the backing issue. Used as a
+    deterministic reviewer source before falling back to ownership-area
+    random selection.
+    """
+    if not issue_number:
+        return []
+    try:
+        issue = github.get_issue(issue_number)
+    except Exception:
+        logger.exception(
+            "review-pr: failed to fetch linked issue #%s to resolve assignee reviewer",
+            issue_number,
+        )
+        return []
+    logins: list[str] = []
+    for assignee in get_field(issue, "assignees", []) or []:
+        if is_automation_user(assignee):
+            continue
+        login = _normalize_reviewer_login(
+            get_login(assignee),
+            pr_author_login=pr_author_login,
+        )
+        if login:
+            logins.append(login)
+    if logins:
+        logger.info(
+            "review-pr: resolved linked issue #%s assignees as candidate reviewers: %s",
+            issue_number,
+            logins,
+        )
+    return logins
+
+
+def _reviewer_from_linked_issue_assignees(logins: list[str]) -> list[str]:
+    """Return the first linked-issue assignee login as the reviewer."""
+    for login in logins or []:
+        if login:
+            logger.info(
+                "review-pr: using linked issue assignee %s as reviewer",
+                login,
+            )
+            return [login]
+    return []
+
+
 def _reviewer_from_existing_review_request(
     pr: Any,
     *,
@@ -1037,6 +1090,7 @@ class ReviewContext(TypedDict):
     # the agent's ``recommended_area`` back to an owner deterministically.
     ownership_areas: list[dict[str, Any]]
     ownership_areas_loaded: bool
+    linked_issue_reviewer_logins: list[str]
     progress_comment_id: int
 
 
@@ -1154,6 +1208,7 @@ def gather_review_context(
     non_member_review_section = ""
     stakeholders_entries: list[dict[str, Any]] = []
     pr_assignee_reviewers: list[str] = []
+    linked_issue_reviewer_logins: list[str] = []
     ownership_areas_serialized: list[dict[str, Any]] = []
     ownership_areas_loaded = False
     if requires_human_reviewer:
@@ -1162,6 +1217,11 @@ def gather_review_context(
             pr_author_login=pr_author_login,
         )
         if not pr_assignee_reviewers:
+            linked_issue_reviewer_logins = _resolve_linked_issue_assignee_logins(
+                github,
+                issue_number,
+                pr_author_login=pr_author_login,
+            )
             # Load ``.github/STAKEHOLDERS`` directly from the repository
             # that triggered the webhook. This is shown to the agent even
             # when ownership areas are available so the fallback path is
@@ -1257,6 +1317,7 @@ def gather_review_context(
         stakeholder_logins=sorted(_stakeholder_logins(stakeholders_entries)),
         stakeholder_entries=stakeholders_entries,
         pr_assignee_reviewers=pr_assignee_reviewers,
+        linked_issue_reviewer_logins=linked_issue_reviewer_logins,
         ownership_areas=ownership_areas_serialized,
         ownership_areas_loaded=bool(ownership_areas_loaded),
         progress_comment_id=int(progress_comment_id or 0),
@@ -1467,6 +1528,11 @@ def apply_review_result(
             for entry in (context.get("ownership_areas") or [])
             if isinstance(entry, dict) and entry.get("name")
         ]
+        linked_issue_reviewer_logins = [
+            str(login)
+            for login in (context.get("linked_issue_reviewer_logins") or [])
+            if isinstance(login, str) and login.strip()
+        ]
         recommended_reviewers = (
             _reviewer_from_existing_review_request(
                 pr,
@@ -1477,6 +1543,7 @@ def apply_review_result(
                 pr,
                 pr_author_login=pr_author_login,
             )
+            or _reviewer_from_linked_issue_assignees(linked_issue_reviewer_logins)
             or _resolve_recommended_reviewers(
                 result,
                 ownership_areas=ownership_areas,

--- a/tests/test_review_pr_reviewer_sampling.py
+++ b/tests/test_review_pr_reviewer_sampling.py
@@ -19,6 +19,7 @@ from workflows.review_pr import (  # type: ignore[import-not-found]
     _is_team_slug,
     _parse_verdict,
     _resolve_recommended_reviewers,
+    _reviewer_from_linked_issue_assignees,
     _reviewer_from_pr_assignee,
     _split_reviewers,
     _stakeholder_pattern_matches,
@@ -112,6 +113,104 @@ class DeterministicReviewerFallbackTest(unittest.TestCase):
             pr_author_login="contributor",
         )
         self.assertEqual(reviewers, [])
+
+
+class LinkedIssueAssigneeReviewerTest(unittest.TestCase):
+    def test_returns_first_login(self) -> None:
+        self.assertEqual(
+            _reviewer_from_linked_issue_assignees(["triager", "other"]),
+            ["triager"],
+        )
+
+    def test_returns_empty_when_no_logins(self) -> None:
+        self.assertEqual(_reviewer_from_linked_issue_assignees([]), [])
+
+    def test_approve_non_member_pr_prefers_linked_issue_assignee_over_ownership_area(self) -> None:
+        pr = MagicMock()
+        github = MagicMock()
+        github.get_pull.return_value = pr
+        progress = MagicMock()
+        context = {
+            "owner": "acme",
+            "repo": "widgets",
+            "pr_number": 7,
+            "requester": "alice",
+            "is_non_member": True,
+            "requires_human_reviewer": True,
+            "pr_author_login": "contributor",
+            "stakeholder_entries": STAKEHOLDERS,
+            "stakeholder_logins": ["api-owner", "docs-owner", "fallback"],
+            "linked_issue_reviewer_logins": ["triager"],
+            "ownership_areas": [
+                {
+                    "name": "Docs API",
+                    "owners": ["api-owner"],
+                    "matches": "API reference docs",
+                }
+            ],
+            "ownership_areas_loaded": True,
+            "diff_line_map": {},
+            "diff_content_map": {},
+        }
+        with patch("workflows.review_pr._resolve_recommended_reviewers") as resolve:
+            apply_review_result(
+                github,
+                context=context,
+                run=MagicMock(),
+                result={
+                    "verdict": "APPROVE",
+                    "summary": "Looks good",
+                    "comments": [],
+                    "recommended_area": "Docs API",
+                },
+                progress=progress,
+            )
+        resolve.assert_not_called()
+        pr.create_review_request.assert_called_once_with(reviewers=["triager"])
+
+    def test_gather_context_stores_linked_issue_assignees(self) -> None:
+        pr = MagicMock()
+        pr.get_files.return_value = [
+            SimpleNamespace(
+                filename="src/app.py",
+                patch="+print('hi')",
+                status="modified",
+            )
+        ]
+        pr.user.login = "contributor"
+        pr.user.type = "User"
+        pr.author_association = "CONTRIBUTOR"
+        pr.assignees = []
+        pr.title = "feat: add app"
+        pr.body = ""
+        pr.base.ref = "main"
+        pr.head.ref = "feature"
+        issue = MagicMock()
+        issue.assignees = [SimpleNamespace(login="triager")]
+        github = MagicMock()
+        github.get_pull.return_value = pr
+        github.get_issue.return_value = issue
+
+        with (
+            patch("workflows.review_pr.resolve_issue_number_for_pr", return_value=42),
+            patch("workflows.review_pr.repo_local_skill_path_for_dispatch", return_value=None),
+            patch("workflows.review_pr.resolve_spec_context_for_pr_via_api", return_value={}),
+            patch("workflows.review_pr._build_diff_maps", return_value=({}, {})),
+            patch("workflows.review_pr.load_stakeholders_from_repo", return_value=STAKEHOLDERS),
+            patch("workflows.review_pr.load_ownership_areas_from_repo") as load_ownership,
+        ):
+            context = gather_review_context(
+                github,
+                owner="acme",
+                repo="widgets",
+                pr_number=7,
+                trigger_source="pull_request",
+                requester="alice",
+                workspace_path=MagicMock(),
+                ownership_repo_handle=MagicMock(),
+            )
+
+        self.assertEqual(context["linked_issue_reviewer_logins"], ["triager"])
 
 
 class OwnershipAreasResolveReviewerTest(unittest.TestCase):


### PR DESCRIPTION
## What

Makes PR reviewer assignment deterministic by using the linked issue's assignee (the triager) before falling back to random ownership-area selection.

## Why

The existing priority chain in `apply_review_result` could assign a different person to review a PR than who triaged the backing issue. The triager already has context on the issue, so they're the right person to review any PR implementing it. There's more discussion in this thread: https://warpdev.slack.com/archives/C0B0G11CT8W/p1784142614696039.

## How

New priority chain:
1. Existing review requests on the PR
2. PR assignees
3. **Linked issue assignee (the triager)** ← new
4. Random ownership-area / STAKEHOLDERS fallback

`_resolve_linked_issue_assignee_logins` fetches the backing issue's non-automation assignees at dispatch time (`gather_review_context`) and stores them in `ReviewContext.linked_issue_reviewer_logins`. `_reviewer_from_linked_issue_assignees` picks the first login at apply time.

## Verification

62 tests pass, including 4 new tests covering the new behavior.

Fixes: https://github.com/warpdotdev/oz-for-oss/issues/486
Linear: [APP-4865](https://linear.app/warpdotdev/issue/APP-4865)

_Conversation: https://staging.warp.dev/conversation/22f5b7df-a1ae-4949-887a-a30f746dc03a_
_Run: https://oz.staging.warp.dev/runs/019f673c-6a08-7a4e-b679-1c503ebb6419_

_This PR was generated with [Oz](https://warp.dev/oz)._
