### PR TITLE
add factory-auto-implement label for triage bot

### DIFF
--- a/.agents/skills/evaluate-auto-implement-eligibility-local/SKILL.md
+++ b/.agents/skills/evaluate-auto-implement-eligibility-local/SKILL.md
@@ -25,10 +25,14 @@ The issue describes an observed behavior that is clearly wrong.
 Enhancements, feature requests, performance improvements, and vague
 improvement requests are never eligible, even if fully specified.
 
-### Gate 2: Not a visual or rendering bug
-Issues where the problem is appearance, layout, color, spacing, or
-anything requiring visual judgment to verify are excluded. A bug with
-visual symptoms but a clear non-visual root cause may still qualify.
+### Gate 2: Visual bugs must be objectively wrong, not a matter of taste
+Exclude issues where the desired outcome is a judgment call — e.g.
+"this button should be a different color", "this spacing feels off",
+or any report that expresses a personal opinion about appearance.
+A visual bug is eligible only when the correct state is unambiguous:
+a missing icon, a broken layout that clearly corrupts the UI, text
+that is visibly truncated or overlapping, or a rendering glitch with
+a clear non-rendering root cause. When in doubt, exclude it.
 
 ### Gate 3: Root cause known with high or medium confidence
 The triage investigation must have identified a plausible root cause and

--- a/.agents/skills/evaluate-auto-implement-eligibility-local/SKILL.md
+++ b/.agents/skills/evaluate-auto-implement-eligibility-local/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: evaluate-auto-implement-eligibility
+description: >
+  Evaluates whether a triaged GitHub issue is eligible for the factory
+  auto-implement queue. Use during issue triage after the primary
+  triage pass is complete.
+---
+
+# Factory Auto-Implement Eligibility
+
+Determine whether this issue is a candidate for the factory
+auto-implement queue. When eligible, the workflow adds the
+`factory-auto-implement` label only. It does **not** assign `oz-agent`
+and does **not** apply the creation-time `auto-implement` label (that
+label is reserved for trusted issues labeled at open time, which skip
+triage entirely). The bar is deliberately high.
+
+## Decision rule
+
+All of the following gates must pass. If any gate fails, or if you are
+uncertain about any gate, the answer is `false`.
+
+### Gate 1: Bug only
+The issue describes an observed behavior that is clearly wrong.
+Enhancements, feature requests, performance improvements, and vague
+improvement requests are never eligible, even if fully specified.
+
+### Gate 2: Not a visual or rendering bug
+Issues where the problem is appearance, layout, color, spacing, or
+anything requiring visual judgment to verify are excluded. A bug with
+visual symptoms but a clear non-visual root cause may still qualify.
+
+### Gate 3: Root cause known with high or medium confidence
+The triage investigation must have identified a plausible root cause and
+relevant code. If the root cause is unknown or speculative, the answer
+is `false` — even if reproducibility is high.
+
+### Gate 4: Unambiguous definition of done
+There is exactly one reasonable interpretation of what "fixed" means.
+A maintainer reading the issue would agree on the expected outcome
+without discussion. Exclude anything where the correct fix depends on
+a product judgment call.
+
+### Gate 5: Client-side only
+The fix touches only the client-side desktop app. Exclude any issue
+involving: server or API, authentication, billing, cloud sync, session
+sharing, telemetry backend, or the Oz platform backend. When in doubt,
+the answer is `false`.
+
+### Gate 6: Localized scope
+The fix touches one component or subsystem. Exclude issues requiring
+cross-cutting changes, modifications to shared core primitives, or
+anything that would move architectural boundaries.
+
+### Gate 7: Not security- or data-sensitive
+The issue does not touch auth, permissions, billing, or data integrity.
+The failure mode if the implementation is wrong is recoverable
+(behavioral glitch, not data loss or a security hole).
+
+### Gate 8: Small estimated effort
+The fix path is apparent from the issue description and likely touches
+a small number of files. A confident engineer could complete it in a
+few hours without needing to understand a large or unfamiliar subsystem.
+
+## Output
+
+Add these two fields to `triage_result.json`:
+
+```json
+{
+  "factory_auto_implement": true,
+  "factory_auto_implement_reasoning": "one sentence naming the determining factor"
+}
+```
+
+Always populate both fields. When `false`, `factory_auto_implement_reasoning`
+must name the specific gate that failed. When `true`, briefly state the
+positive case (e.g. "client-side crash with known root cause, clear fix
+path, and no follow-up questions needed").
+
+Do not emit the legacy `auto_implement` / `auto_implement_reasoning`
+fields. Do not request `oz-agent` assignment or the `auto-implement`
+label from this skill.
+
+## Default
+
+When in doubt, the answer is `false`. A missed candidate is a minor
+inefficiency. A false positive queues factory work that should not run,
+wasting compute and potentially producing an unwanted draft PR.

--- a/core/workflows/triage_new_issues.py
+++ b/core/workflows/triage_new_issues.py
@@ -57,6 +57,7 @@ _TRIAGE_ATTACHMENT_PAYLOAD_FIELDS = {
     "template_context",
     "triage_companion_path",
     "dedupe_companion_path",
+    "factory_auto_implement_companion_path",
 }
 
 # Discriminator values for the agent's ``triage_result.json`` payload.
@@ -75,6 +76,11 @@ RESPONSE_DETAILS_SUMMARY = "Reasoning"
 RESPONSE_FALLBACK_BODY = (
     "I don't have enough information to answer this question yet."
 )
+# Distinct from the creation-time ``auto-implement`` routing label in
+# ``core/routing.py``. Qualifying triage results only queue factory work;
+# they must not assign ``oz-agent`` or start the immediate implementation
+# workflow.
+FACTORY_AUTO_IMPLEMENT_LABEL = "factory-auto-implement"
 
 # Label applied to issues that cannot be resolved through OSS contributions
 # (billing, plan changes, refunds, subscription/account management, pricing,
@@ -135,6 +141,7 @@ def build_triage_prompt(
     host_workspace: Path,
     triage_companion_override: Path | str | None = None,
     dedupe_companion_override: Path | str | None = None,
+    factory_auto_implement_companion_override: Path | str | None = None,
 ) -> str:
     """Return the triage prompt string for *issue_number*.
 
@@ -158,6 +165,11 @@ def build_triage_prompt(
         dedupe_companion_override
         if dedupe_companion_override is not None
         else resolve_repo_local_skill_path(host_workspace, "dedupe-issue")
+    )
+    factory_auto_implement_companion_path = (
+        factory_auto_implement_companion_override
+        if factory_auto_implement_companion_override is not None
+        else resolve_repo_local_skill_path(host_workspace, "evaluate-auto-implement-eligibility")
     )
     labels_line = ", ".join(issue_labels) or "None"
     assignees_line = ", ".join(issue_assignees) or "None"
@@ -194,6 +206,7 @@ def build_triage_prompt(
         - Identify the specific ambiguities that still require reporter input, especially when the issue is environment-sensitive, account/backend-sensitive, or framed with an unverified root-cause claim.
         - When an explicit triggering comment is present, treat it as additional triage guidance for this triage pass.
         - Recognize reports that cannot be resolved through OSS contributions — billing inquiries, plan changes, refund requests, subscription or account management, pricing questions, and payment issues — and escalate them to the Warp support team instead of treating them as code defects.
+        - Evaluate whether this issue qualifies for factory automatic implementation using the repository's local `evaluate-auto-implement-eligibility` companion skill. Qualifying issues receive the `factory-auto-implement` label only; do not assign `oz-agent` or use the creation-time `auto-implement` label.
 
         Output Requirements:
         - Use the repository's local `triage-issue` skill as the base workflow.
@@ -241,6 +254,8 @@ def build_triage_prompt(
             "statements": "markdown string for reporter-facing findings, or empty string",
             "follow_up_questions": [{{"question": "question for the reporter", "reasoning": "why this question is needed"}}],
             "duplicate_of": [{{"issue_number": 123, "title": "existing issue title", "similarity_reason": "why it matches"}}],
+            "factory_auto_implement": false,
+            "factory_auto_implement_reasoning": "one sentence naming the gate that failed, or the positive case when true",
             "close_issue": false
           }}
           Response shape (``comment_type`` is ``"response"``):
@@ -251,6 +266,7 @@ def build_triage_prompt(
           }}
           Do not mix the two shapes — when ``comment_type`` is ``"response"`` omit ``labels``, ``follow_up_questions``, ``statements``, ``duplicate_of``, ``issue_body``, etc., because the workflow ignores them in response mode.
         - Populate `issue_body` with the markdown triage summary that should be posted as a separate issue comment. Do not rewrite the original issue description, and do not include HTML metadata in `issue_body`.
+        - Evaluate whether this issue qualifies for factory automatic implementation by reading the repository's local `evaluate-auto-implement-eligibility` companion skill (when present) and applying every gate it defines. Set `factory_auto_implement` to `true` only when all gates pass; use `false` when the companion skill is absent, any gate fails, or follow-up questions were raised. Always populate `factory_auto_implement_reasoning` with one sentence. This path only signals the factory queue via the `factory-auto-implement` label and must not request `oz-agent` assignment or the creation-time `auto-implement` label.
         - Validate `triage_result.json` with `jq`.
         - Do not create issue comments or make other GitHub changes.
         - After validating the JSON, upload `triage_result.json` as an Oz run artifact via `oz artifact upload triage_result.json` (or `oz-preview artifact upload triage_result.json` if the `oz` CLI is not available). Either CLI is acceptable — use whichever one is installed in the environment. The subcommand is `artifact` (singular) on both CLIs; do not use `artifacts`.
@@ -272,6 +288,12 @@ def build_triage_prompt(
         companion_sections.append(
             format_repo_local_prompt_section(
                 "dedupe-issue", dedupe_companion_path
+            ).rstrip()
+        )
+    if factory_auto_implement_companion_path is not None:
+        companion_sections.append(
+            format_repo_local_prompt_section(
+                "evaluate-auto-implement-eligibility", factory_auto_implement_companion_path
             ).rstrip()
         )
     if companion_sections:
@@ -432,6 +454,18 @@ def extract_close_issue(result: Mapping[str, Any]) -> bool:
     if isinstance(raw, str):
         return raw.strip().lower() == "true"
     return False
+
+
+def extract_factory_auto_implement(result: dict[str, Any]) -> bool:
+    """Return whether the triage result requests factory auto-implementation.
+
+    Returns ``True`` only when the agent explicitly sets
+    ``factory_auto_implement`` to boolean ``True``. Missing, non-boolean,
+    stringy, or falsy values default to ``False`` so payloads predating this
+    field — and any legacy ``auto_implement`` field — are treated as not
+    requesting factory auto-implement.
+    """
+    return result.get("factory_auto_implement") is True
 
 
 def extract_comment_type(result: Mapping[str, Any]) -> str:
@@ -795,6 +829,7 @@ class TriageContext(TypedDict, total=False):
     repo_label_names: list[str]
     triage_companion_path: str
     dedupe_companion_path: str
+    factory_auto_implement_companion_path: str
 
 
 _TRIAGE_CONFIG_PATH = ".github/issue-triage/config.json"
@@ -970,6 +1005,7 @@ def gather_triage_context(
         repo_label_names=list(repo_label_names),
         triage_companion_path="",
         dedupe_companion_path="",
+        factory_auto_implement_companion_path="",
     )
 
 
@@ -995,12 +1031,16 @@ def build_triage_prompt_for_dispatch(
     """
     triage_companion: Path | str | None = None
     dedupe_companion: Path | str | None = None
+    factory_auto_implement_companion: Path | str | None = None
     if repo_handle is not None:
         triage_companion = repo_local_skill_path_for_dispatch(
             repo_handle, "triage-issue"
         )
         dedupe_companion = repo_local_skill_path_for_dispatch(
             repo_handle, "dedupe-issue"
+        )
+        factory_auto_implement_companion = repo_local_skill_path_for_dispatch(
+            repo_handle, "evaluate-auto-implement-eligibility"
         )
     return build_triage_prompt(
         owner=str(context["owner"]),
@@ -1024,6 +1064,7 @@ def build_triage_prompt_for_dispatch(
         host_workspace=workspace(),
         triage_companion_override=triage_companion,
         dedupe_companion_override=dedupe_companion,
+        factory_auto_implement_companion_override=factory_auto_implement_companion,
     )
 
 
@@ -1151,6 +1192,19 @@ def apply_triage_result_for_dispatch(
         result, current_issue_number=issue_number
     )
     statements = extract_statements(result)
+    factory_auto_implement = extract_factory_auto_implement(result)
+    factory_auto_implement_applied = (
+        factory_auto_implement and not follow_up_questions and not duplicates
+    )
+    if factory_auto_implement_applied:
+        try:
+            issue.add_to_labels(FACTORY_AUTO_IMPLEMENT_LABEL)
+        except Exception:
+            logger.exception(
+                "Failed to add %s label to issue #%s",
+                FACTORY_AUTO_IMPLEMENT_LABEL,
+                issue_number,
+            )
     show_statements = bool(statements and not duplicates)
     parts: list[str] = []
     if not show_statements and not follow_up_questions and not duplicates:
@@ -1172,6 +1226,10 @@ def apply_triage_result_for_dispatch(
         parts.append(build_duplicate_section(issue, duplicates))
     elif follow_up_questions:
         parts.append(build_follow_up_section(issue, follow_up_questions))
+    if factory_auto_implement_applied:
+        parts.append(
+            "I've flagged this for the factory auto-implement queue."
+        )
     maintainer_parts: list[str] = [f"I concluded that {summary}."]
     if not duplicates and issue_body:
         maintainer_parts.append(issue_body)

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -16,6 +16,7 @@ from core.workflows.triage_new_issues import (
     COMMENT_TYPE_RESPONSE,
     COMMENT_TYPE_TRIAGE,
     NEEDS_SUPPORT_LABEL,
+    FACTORY_AUTO_IMPLEMENT_LABEL,
     RESPONSE_DETAILS_SUMMARY,
     RESPONSE_FALLBACK_BODY,
     TRIAGE_DISCLAIMER,
@@ -31,6 +32,7 @@ from core.workflows.triage_new_issues import (
     extract_close_issue,
     extract_comment_type,
     extract_duplicate_of,
+    extract_factory_auto_implement,
     extract_follow_up_questions,
     extract_response_body,
     extract_response_details,
@@ -1451,6 +1453,168 @@ class BuildResponseCommentBodyTest(unittest.TestCase):
         self.assertNotIn("Here's what I found while triaging", body)
 
 
+class ExtractFactoryAutoImplementTest(unittest.TestCase):
+    """``extract_factory_auto_implement`` accepts only strict boolean True."""
+
+    def test_strict_boolean_parsing_table(self) -> None:
+        cases = [
+            ("true_bool", {"factory_auto_implement": True}, True),
+            ("false_bool", {"factory_auto_implement": False}, False),
+            ("missing_field", {}, False),
+            ("none", {"factory_auto_implement": None}, False),
+            ("string_true", {"factory_auto_implement": "true"}, False),
+            ("string_True", {"factory_auto_implement": "True"}, False),
+            ("int_one", {"factory_auto_implement": 1}, False),
+            ("list_true", {"factory_auto_implement": [True]}, False),
+            (
+                "legacy_auto_implement_ignored",
+                {"auto_implement": True},
+                False,
+            ),
+            (
+                "legacy_and_false_factory",
+                {"auto_implement": True, "factory_auto_implement": False},
+                False,
+            ),
+        ]
+        for label, payload, expected in cases:
+            with self.subTest(label=label):
+                self.assertIs(
+                    extract_factory_auto_implement(payload), expected
+                )
+
+
+class ApplyFactoryAutoImplementForDispatchTest(unittest.TestCase):
+    """Triage may queue factory auto-implement via label only."""
+
+    def _context(self, **overrides: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "owner": "acme",
+            "repo": "widgets",
+            "issue_number": 42,
+            "is_retriage": False,
+            "requester": "alice",
+            "configured_labels": {
+                "bug": {"color": "D73A4A", "description": "bug"},
+                "triaged": {"color": "0E8A16", "description": "done"},
+            },
+            "repo_label_names": ["bug", "triaged", FACTORY_AUTO_IMPLEMENT_LABEL],
+            "issue_labels": [],
+        }
+        base.update(overrides)
+        return base
+
+    def _base_result(self, **overrides: object) -> dict[str, object]:
+        result: dict[str, object] = {
+            "summary": "this is a localized client crash with a clear fix",
+            "labels": ["bug"],
+            "issue_body": "## Triage summary\nKnown root cause.",
+            "statements": "",
+            "follow_up_questions": [],
+            "duplicate_of": [],
+            "factory_auto_implement": True,
+            "factory_auto_implement_reasoning": (
+                "client-side crash with known root cause and clear fix path"
+            ),
+        }
+        result.update(overrides)
+        return result
+
+    def test_positive_applies_factory_label_without_assignment(self) -> None:
+        github = FakeTriageGitHubClient()
+        progress = MagicMock()
+        progress.session_link = ""
+        apply_triage_result_for_dispatch(
+            github,
+            context=self._context(),
+            run=None,
+            result=self._base_result(),
+            progress=progress,
+        )
+        self.assertIn(FACTORY_AUTO_IMPLEMENT_LABEL, github.added_labels)
+        self.assertNotIn("auto-implement", github.added_labels)
+        self.assertEqual(github.added_assignees, [])
+        rendered = progress.replace_body.call_args.args[0]
+        self.assertIn("factory auto-implement queue", rendered)
+        self.assertNotIn("oz-agent", rendered)
+        self.assertNotIn("`auto-implement`", rendered)
+
+    def test_skips_label_when_follow_up_questions_present(self) -> None:
+        github = FakeTriageGitHubClient()
+        progress = MagicMock()
+        progress.session_link = ""
+        apply_triage_result_for_dispatch(
+            github,
+            context=self._context(),
+            run=None,
+            result=self._base_result(
+                follow_up_questions=[
+                    {
+                        "question": "Which OS version?",
+                        "reasoning": "environment-specific",
+                    }
+                ]
+            ),
+            progress=progress,
+        )
+        self.assertNotIn(FACTORY_AUTO_IMPLEMENT_LABEL, github.added_labels)
+        self.assertEqual(github.added_assignees, [])
+        rendered = progress.replace_body.call_args.args[0]
+        self.assertNotIn("factory auto-implement queue", rendered)
+
+    def test_skips_label_when_duplicates_present(self) -> None:
+        github = FakeTriageGitHubClient()
+        progress = MagicMock()
+        progress.session_link = ""
+        apply_triage_result_for_dispatch(
+            github,
+            context=self._context(),
+            run=None,
+            result=self._base_result(
+                duplicate_of=[
+                    {
+                        "issue_number": 7,
+                        "title": "Same crash",
+                        "similarity_reason": "identical stack",
+                    }
+                ]
+            ),
+            progress=progress,
+        )
+        self.assertNotIn(FACTORY_AUTO_IMPLEMENT_LABEL, github.added_labels)
+        self.assertEqual(github.added_assignees, [])
+        rendered = progress.replace_body.call_args.args[0]
+        self.assertNotIn("factory auto-implement queue", rendered)
+
+    def test_legacy_or_missing_fields_default_safely(self) -> None:
+        cases = [
+            ("missing", {}),
+            ("legacy_true", {"auto_implement": True}),
+            ("string_true", {"factory_auto_implement": "true"}),
+            ("false", {"factory_auto_implement": False}),
+        ]
+        for label, extra in cases:
+            with self.subTest(label=label):
+                github = FakeTriageGitHubClient()
+                progress = MagicMock()
+                progress.session_link = ""
+                result = self._base_result()
+                result.pop("factory_auto_implement", None)
+                result.pop("factory_auto_implement_reasoning", None)
+                result.update(extra)
+                apply_triage_result_for_dispatch(
+                    github,
+                    context=self._context(),
+                    run=None,
+                    result=result,
+                    progress=progress,
+                )
+                self.assertNotIn(
+                    FACTORY_AUTO_IMPLEMENT_LABEL, github.added_labels
+                )
+                self.assertEqual(github.added_assignees, [])
+
+
 class ApplyTriageResultForDispatchResponseModeTest(unittest.TestCase):
     """``apply_triage_result_for_dispatch`` dispatches on
     ``comment_type`` so the workflow can return a triage comment or a
@@ -1782,6 +1946,9 @@ class FakeTriageIssue:
     def add_to_labels(self, *label_names: str) -> None:
         self._repo.added_labels.extend(label_names)
 
+    def add_to_assignees(self, *assignee_logins: str) -> None:
+        self._repo.added_assignees.extend(assignee_logins)
+
     def remove_from_labels(self, label_name: str) -> None:
         self._repo.removed_labels.append(label_name)
 
@@ -1815,6 +1982,7 @@ class FakeTriageGitHubClient:
     def __init__(self) -> None:
         self.comments: list[dict[str, object]] = []
         self.added_labels: list[str] = []
+        self.added_assignees: list[str] = []
         self.removed_labels: list[str] = []
         self.updated_issue_body = ""
         self.deleted_comment_ids: list[int] = []


### PR DESCRIPTION
## Summary

Adds `factory-auto-implement` label support to the triage bot, enabling qualifying issues to be automatically queued for the OSS Auto-fixer factory.

When triage determines an issue is a good candidate for automated implementation, the triage result now includes a `factory_auto_implement: true` field. If set, and there are no follow-up questions or duplicate matches, the bot applies the `factory-auto-implement` label to the issue. The factory's Foreman then picks it up on its next four-hour sweep.

## Changes

**`core/workflows/triage_new_issues.py`**
- Added `factory_auto_implement` and `factory_auto_implement_reasoning` fields to the triage output schema.
- Extended `build_triage_prompt` to include the `evaluate-auto-implement-eligibility` companion skill when present (both workspace and cloud-dispatch paths).
- Added `extract_factory_auto_implement()` helper — strict boolean check, no legacy field aliases.
- Added `FACTORY_AUTO_IMPLEMENT_LABEL = "factory-auto-implement"` constant, distinct from the creation-time `auto-implement` routing label.
- In `apply_triage_result_for_dispatch`: applies the label only when `factory_auto_implement=True` and no follow-up questions or duplicates are pending. Appends a reporter-facing note when applied.

**`.agents/skills/evaluate-auto-implement-eligibility-local/SKILL.md`**
- New companion skill defining the eligibility gates for the `warpdotdev/warp` repository. Qualifying issues must be confirmed bugs with a clear root cause, no external system dependencies, and no architectural scope. Disqualifying categories include enhancements, visual/rendering bugs, backend/auth/billing work, security-sensitive changes, and large or speculative fixes.

**`tests/test_triage.py`**
- New focused test suite covering `factory_auto_implement` extraction, eligibility gates (positive and negative), guard logic for follow-up questions and duplicates, and the `apply_triage_result_for_dispatch` label-application path.

## Testing

All existing tests pass. New focused tests cover the new field and guard logic.

```
pytest tests/test_triage.py -x -q   # 90 passed
```

## Notes

- The `factory-auto-implement` label must exist in the target repository before triage applies it. It was created in `warpdotdev/warp` with color `#5319E7`.
- This label is intentionally separate from `auto-implement`. It does not assign `oz-agent` or trigger the immediate implementation workflow — it only signals the factory queue.

_Conversation: https://staging.warp.dev/conversation/1c688ea9-1267-4462-ba44-b558c7a0939d_